### PR TITLE
refactor: disc identification pipeline + transcoder path fix

### DIFF
--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -3,7 +3,6 @@ import logging
 import os
 import psutil
 import pyudev
-import subprocess
 import time
 
 from datetime import datetime as dt
@@ -151,12 +150,6 @@ class Job(db.Model):
         self.manual_start = False
         self.manual_mode = False
         self.has_track_99 = False
-
-        if self.disctype == "dvd" and not self.label:
-            logging.info("No disk label Available. Trying lsdvd")
-            command = f"lsdvd {devpath} | grep 'Disc Title' | cut -d ' ' -f 3-"
-            lsdvdlbl = str(subprocess.check_output(command, shell=True).strip(), 'utf-8')
-            self.label = lsdvdlbl
 
     def __str__(self):
         """Returns a string of the object"""

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -105,6 +105,9 @@ def bash_notify(cfg, title, body, job=None):
                 env['ARM_PATH'] = str(job.path or '')
                 env['ARM_RAW_PATH'] = str(job.raw_path or '')
                 env['ARM_TRANSCODE_PATH'] = str(job.transcode_path or '')
+                if job.config:
+                    env['ARM_RAW_PATH_BASE'] = str(getattr(job.config, 'RAW_PATH', '') or '')
+                    env['ARM_COMPLETED_PATH_BASE'] = str(getattr(job.config, 'COMPLETED_PATH', '') or '')
             subprocess.run(["/usr/bin/env", "bash", cfg['BASH_SCRIPT'], title, body], env=env)
             logging.debug("Sent bash notification successful")
         except Exception as error:  # noqa: E722

--- a/dev-data/config/notify_transcoder.sh
+++ b/dev-data/config/notify_transcoder.sh
@@ -6,28 +6,34 @@
 #   $2 = body  (e.g. "Movie Title (2024) rip complete. Starting transcode.")
 #
 # ARM (neu) also sets environment variables:
-#   ARM_RAW_PATH     - Actual raw MKV output directory (e.g. /home/arm/media/raw/SERIAL_MOM)
-#   ARM_JOB_ID       - ARM database job ID
-#   ARM_TITLE        - User-corrected title (or auto-detected if not corrected)
-#   ARM_TITLE_AUTO   - Auto-detected title from disc label
+#   ARM_PATH                - Final media directory (e.g. /home/arm/media/raw/movies/Title (Year))
+#   ARM_RAW_PATH            - Raw MKV output directory (e.g. /home/arm/media/raw/SERIAL_MOM)
+#   ARM_COMPLETED_PATH_BASE - Config COMPLETED_PATH base (e.g. /home/arm/media/raw/)
+#   ARM_RAW_PATH_BASE       - Config RAW_PATH base (e.g. /home/arm/media/raw/)
+#   ARM_JOB_ID              - ARM database job ID
+#   ARM_TITLE               - User-corrected title (or auto-detected if not corrected)
+#   ARM_TITLE_AUTO          - Auto-detected title from disc label
+#   ARM_VIDEO_TYPE          - movie / series
+#   ARM_YEAR                - Release year
+#   ARM_DISCTYPE            - dvd / bluray / bluray4k
+#   ARM_STATUS              - Job status (e.g. success)
+#
+# This script only sends a webhook to the transcoder for COMPLETION notifications
+# (NOTIFY_TRANSCODE), which fire after ARM has moved files to their final location.
+# Earlier "rip complete" notifications (NOTIFY_RIP) are ignored since the raw
+# directory may already be empty by the time the transcoder processes it.
+#
+# Requires arm.yaml:  NOTIFY_TRANSCODE: True
 #
 # Install:
-#   1. Copy this script to /home/arm/scripts/ on the ARM machine
-#   2. chmod +x /home/arm/scripts/notify_transcoder.sh
+#   1. Copy this script to /etc/arm/config/ (or /home/arm/scripts/)
+#   2. chmod +x notify_transcoder.sh
 #   3. Set BASH_SCRIPT in arm.yaml:
-#        BASH_SCRIPT: "/home/arm/scripts/notify_transcoder.sh"
-#   4. Clear JSON_URL in arm.yaml (to avoid duplicate notifications):
-#        JSON_URL: ""
+#        BASH_SCRIPT: "/etc/arm/config/notify_transcoder.sh"
 #
 # Configuration: Set these to match your arm-transcoder setup
 TRANSCODER_URL="http://arm-transcoder:5000/webhook/arm"
 WEBHOOK_SECRET=""  # Set this to match WEBHOOK_SECRET in arm-transcoder's .env
-
-# Local scratch storage: when both are set, ripped files are moved from
-# local disk to shared storage before notifying the transcoder.
-# Leave empty to skip (ARM writes directly to shared storage).
-LOCAL_RAW_PATH=""   # Local disk where ARM rips to (e.g. /home/arm/media/raw)
-SHARED_RAW_PATH=""  # Shared storage handoff location (e.g. /mnt/media/raw)
 
 TITLE="${1:-}"
 BODY="${2:-}"
@@ -37,37 +43,31 @@ if [ -z "$BODY" ]; then
     exit 1
 fi
 
-# ARM (neu) passes the actual raw path via environment variable.
-# This is more reliable than extracting the title directory from body text.
-RAW_PATH="${ARM_RAW_PATH:-}"
+# Only notify the transcoder on completion (after files are moved to final location).
+# "rip complete" notifications fire before the move — skip them.
+if [[ "$BODY" != *"processing complete"* ]] && [[ "${ARM_STATUS:-}" != "success" ]]; then
+    echo "Skipping non-completion notification: $BODY"
+    exit 0
+fi
 
-# Move ripped files from local scratch → shared storage (if configured)
-if [ -n "$LOCAL_RAW_PATH" ] && [ -n "$SHARED_RAW_PATH" ]; then
-    if [ -n "$RAW_PATH" ]; then
-        # Use the directory basename from ARM_RAW_PATH
-        TITLE_DIR="$(basename "$RAW_PATH")"
-    else
-        # Fallback: extract title directory from body text
-        TITLE_DIR=""
-        if [[ "$BODY" =~ ^(.+)[[:space:]]rip\ complete ]]; then
-            TITLE_DIR="${BASH_REMATCH[1]}"
-        elif [[ "$BODY" =~ ^(.+)[[:space:]]processing\ complete ]]; then
-            TITLE_DIR="${BASH_REMATCH[1]}"
-        fi
-    fi
+# Compute the relative path under the shared raw/completed mount.
+# ARM_PATH is the final location (e.g. /home/arm/media/raw/movies/Title (Year)).
+# ARM_COMPLETED_PATH_BASE is the config base (e.g. /home/arm/media/raw/).
+# The relative path (e.g. movies/Title (Year)) maps directly to the transcoder's RAW_PATH.
+SOURCE_PATH=""
+if [ -n "${ARM_PATH:-}" ] && [ -n "${ARM_COMPLETED_PATH_BASE:-}" ]; then
+    SOURCE_PATH="${ARM_PATH#"$ARM_COMPLETED_PATH_BASE"}"
+    SOURCE_PATH="${SOURCE_PATH#/}"
+elif [ -n "${ARM_PATH:-}" ] && [ -n "${ARM_RAW_PATH_BASE:-}" ]; then
+    SOURCE_PATH="${ARM_PATH#"$ARM_RAW_PATH_BASE"}"
+    SOURCE_PATH="${SOURCE_PATH#/}"
+fi
 
-    if [ -n "$TITLE_DIR" ]; then
-        SRC="$LOCAL_RAW_PATH/$TITLE_DIR"
-        DST="$SHARED_RAW_PATH/$TITLE_DIR"
-        if [ -d "$SRC" ]; then
-            mkdir -p "$SHARED_RAW_PATH"
-            mv "$SRC" "$DST"
-            echo "Moved $SRC → $DST"
-            # Update RAW_PATH to reflect the new location
-            RAW_PATH="$DST"
-        else
-            echo "WARNING: Local source not found: $SRC" >&2
-        fi
+if [ -z "$SOURCE_PATH" ]; then
+    echo "WARNING: Could not determine source path from ARM_PATH=$ARM_PATH" >&2
+    # Fallback: try raw path basename
+    if [ -n "${ARM_RAW_PATH:-}" ]; then
+        SOURCE_PATH="$(basename "$ARM_RAW_PATH")"
     fi
 fi
 
@@ -76,14 +76,17 @@ json_escape() {
     printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()), end="")'
 }
 
-# Build JSON payload — include path basename if available from ARM_RAW_PATH.
-# The transcoder expects a directory name only (no slashes) and prepends its own RAW_PATH.
-if [ -n "$RAW_PATH" ]; then
-    PATH_BASENAME="$(basename "$RAW_PATH")"
-    JSON_PAYLOAD="{\"title\": $(json_escape "$TITLE"), \"body\": $(json_escape "$BODY"), \"path\": $(json_escape "$PATH_BASENAME"), \"type\": \"info\"}"
-else
-    JSON_PAYLOAD="{\"title\": $(json_escape "$TITLE"), \"body\": $(json_escape "$BODY"), \"type\": \"info\"}"
-fi
+# Build JSON payload with all available metadata
+JSON_PAYLOAD="{\"title\": $(json_escape "$TITLE"), \"body\": $(json_escape "$BODY"), \"type\": \"info\""
+
+[ -n "$SOURCE_PATH" ]    && JSON_PAYLOAD="$JSON_PAYLOAD, \"path\": $(json_escape "$SOURCE_PATH")"
+[ -n "$ARM_JOB_ID" ]     && JSON_PAYLOAD="$JSON_PAYLOAD, \"job_id\": $(json_escape "$ARM_JOB_ID")"
+[ -n "$ARM_VIDEO_TYPE" ] && JSON_PAYLOAD="$JSON_PAYLOAD, \"video_type\": $(json_escape "$ARM_VIDEO_TYPE")"
+[ -n "$ARM_YEAR" ]       && JSON_PAYLOAD="$JSON_PAYLOAD, \"year\": $(json_escape "$ARM_YEAR")"
+[ -n "$ARM_DISCTYPE" ]   && JSON_PAYLOAD="$JSON_PAYLOAD, \"disctype\": $(json_escape "$ARM_DISCTYPE")"
+[ -n "$ARM_STATUS" ]     && JSON_PAYLOAD="$JSON_PAYLOAD, \"status\": $(json_escape "$ARM_STATUS")"
+
+JSON_PAYLOAD="$JSON_PAYLOAD}"
 
 # Build curl command
 CURL_ARGS=(
@@ -104,7 +107,7 @@ HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 RESP_BODY=$(echo "$RESPONSE" | head -n -1)
 
 if [ "$HTTP_CODE" -ge 200 ] 2>/dev/null && [ "$HTTP_CODE" -lt 300 ] 2>/dev/null; then
-    echo "Notification sent to arm-transcoder (HTTP ${HTTP_CODE})"
+    echo "Notification sent to arm-transcoder (HTTP ${HTTP_CODE}): path=$SOURCE_PATH"
 else
     echo "Failed to notify arm-transcoder (HTTP ${HTTP_CODE}): ${RESP_BODY}" >&2
     exit 1


### PR DESCRIPTION
## Summary
- **Disc identification refactor:** Restructured `identify()` into 5 clear phases — mount, resolve label, disc-specific ID, metadata search, last-resort fallback. Fixes label poisoning bug where `identify_dvd()` set `job.label = "not identified"`, causing complete identification failure when pyudev missed `ID_FS_LABEL` due to container udev timing.
- **Label recovery:** New `resolve_disc_label()` with blkid → lsdvd → XML fallback chain. Removed fragile lsdvd call from `Job.__init__()`.
- **Transcoder notification fix:** Added `ARM_COMPLETED_PATH_BASE` / `ARM_RAW_PATH_BASE` env vars to `bash_notify()` so the notify script can compute correct relative paths for the transcoder webhook.
- **Updated notify script:** Only fires on completion notifications (after file move), sends relative path under shared mount.

## Test plan
- [x] 490 pytest tests passing (30 new tests for identify pipeline)
- [x] Deployed to hifi-server, ripped "The Babysitter" DVD
- [x] blkid recovered label when pyudev missed it
- [x] CRC64 + OMDB identified the disc correctly
- [x] MakeMKV rip completed, files moved to final location
- [x] Transcoder received correct path and transcoded with audio preserved