### PR TITLE
fix: suppress spurious transcoder webhooks and accept transcoding callback

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -216,6 +216,11 @@ cython_debug/
 .dockerignore
 .gitignore
 .gitmodules
+dev-data/
+components/
+test/
+.venv/
+.claude/
 
 *.yml
 *.md

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -367,7 +367,7 @@ async def update_transcode_config(job_id: int, request: Request):
 async def transcode_callback(job_id: int, request: Request):
     """Receive status update from the external transcoder.
 
-    Expected payload: {"status": "completed"|"failed", "error": "..."}
+    Expected payload: {"status": "transcoding"|"completed"|"failed", "error": "..."}
     """
     job = Job.query.get(job_id)
     if not job:
@@ -376,7 +376,9 @@ async def transcode_callback(job_id: int, request: Request):
     body = await request.json()
     status = body.get("status")
 
-    if status == "completed":
+    if status == "transcoding":
+        job.status = JobState.TRANSCODE_ACTIVE.value
+    elif status == "completed":
         job.status = JobState.SUCCESS.value
         notification = Notifications(
             f"Job: {job.job_id} transcode complete",

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -363,6 +363,45 @@ async def update_transcode_config(job_id: int, request: Request):
     return {"success": True, "overrides": overrides}
 
 
+@router.post('/jobs/{job_id}/transcode-callback')
+async def transcode_callback(job_id: int, request: Request):
+    """Receive status update from the external transcoder.
+
+    Expected payload: {"status": "completed"|"failed", "error": "..."}
+    """
+    job = Job.query.get(job_id)
+    if not job:
+        return JSONResponse({"success": False, "error": "Job not found"}, status_code=404)
+
+    body = await request.json()
+    status = body.get("status")
+
+    if status == "completed":
+        job.status = JobState.SUCCESS.value
+        notification = Notifications(
+            f"Job: {job.job_id} transcode complete",
+            f"'{job.title}' transcoding finished successfully"
+        )
+        db.session.add(notification)
+    elif status == "failed":
+        job.status = JobState.FAILURE.value
+        error_msg = body.get("error", "Transcode failed")
+        job.errors = error_msg
+        notification = Notifications(
+            f"Job: {job.job_id} transcode failed",
+            f"'{job.title}' transcoding failed: {error_msg}"
+        )
+        db.session.add(notification)
+    else:
+        return JSONResponse(
+            {"success": False, "error": f"Unknown status: {status}"},
+            status_code=400,
+        )
+
+    db.session.commit()
+    return {"success": True, "job_id": job.job_id, "status": job.status}
+
+
 def _clean_for_filename(string):
     """Clean a string for use in filenames."""
     string = re.sub(r'\s+', ' ', string)

--- a/arm/api/v1/metadata.py
+++ b/arm/api/v1/metadata.py
@@ -1,0 +1,117 @@
+"""API v1 — Metadata endpoints.
+
+Provides OMDb/TMDb search & details, MusicBrainz search & details,
+CRC64 lookup, and API key testing. ARM is the single source of truth
+for all external metadata calls.
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Query
+
+from arm.services.metadata import (
+    MetadataConfigError,
+    get_details,
+    get_music_details,
+    has_api_key,
+    lookup_crc,
+    search,
+    search_music,
+    test_configured_key,
+)
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/metadata", tags=["metadata"])
+
+
+# --- Music routes MUST come before the {imdb_id} catch-all ---
+
+
+@router.get("/music/search")
+async def search_music_metadata(
+    q: str = Query(..., min_length=1),
+    artist: str | None = None,
+    release_type: str | None = None,
+    format: str | None = None,
+    country: str | None = None,
+    status: str | None = None,
+    tracks: int | None = None,
+    offset: int = Query(0, ge=0),
+):
+    """Search MusicBrainz for releases matching the query with optional filters."""
+    log.debug("GET /metadata/music/search q=%r artist=%s", q, artist)
+    return await search_music(
+        q, artist, release_type=release_type, format=format,
+        country=country, status=status, tracks=tracks, offset=offset,
+    )
+
+
+@router.get("/music/{release_id}")
+async def get_music_detail(release_id: str):
+    """Fetch full release details from MusicBrainz by release MBID."""
+    log.debug("GET /metadata/music/%s", release_id)
+    result = await get_music_details(release_id)
+    if not result:
+        log.debug("MusicBrainz release %s not found", release_id)
+        raise HTTPException(status_code=404, detail="Release not found")
+    return result
+
+
+# --- Test key route before {imdb_id} catch-all ---
+
+
+@router.get("/test-key")
+async def test_metadata_key():
+    """Test the currently configured metadata API key by making a real API call."""
+    log.debug("GET /metadata/test-key")
+    result = await test_configured_key()
+    log.info("Metadata key test: provider=%s success=%s", result.get("provider"), result.get("success"))
+    return result
+
+
+# --- CRC route before {imdb_id} catch-all ---
+
+
+@router.get("/crc/{crc64}")
+async def crc_lookup_endpoint(crc64: str):
+    """Look up a CRC64 hash in the community database."""
+    log.debug("GET /metadata/crc/%s", crc64)
+    result = await lookup_crc(crc64)
+    result["has_api_key"] = has_api_key()
+    return result
+
+
+# --- Search (no path param conflict) ---
+
+
+@router.get("/search")
+async def search_metadata(
+    q: str = Query(..., min_length=1),
+    year: str | None = None,
+):
+    """Search OMDb/TMDb for titles matching the query."""
+    log.debug("GET /metadata/search q=%r year=%s", q, year)
+    try:
+        return await search(q, year)
+    except MetadataConfigError as exc:
+        log.warning("Metadata search failed (config): %s", exc)
+        raise HTTPException(status_code=503, detail=str(exc))
+
+
+# --- IMDb detail catch-all (LAST) ---
+
+
+@router.get("/{imdb_id}")
+async def get_media_detail(imdb_id: str):
+    """Fetch full details for a title by IMDb ID."""
+    log.debug("GET /metadata/%s", imdb_id)
+    try:
+        result = await get_details(imdb_id)
+    except MetadataConfigError as exc:
+        log.warning("Metadata detail failed (config): %s", exc)
+        raise HTTPException(status_code=503, detail=str(exc))
+    if not result:
+        log.debug("No metadata found for %s", imdb_id)
+        raise HTTPException(status_code=404, detail="Title not found")
+    return result

--- a/arm/api/v1/metadata.py
+++ b/arm/api/v1/metadata.py
@@ -64,9 +64,7 @@ async def get_music_detail(release_id: str):
 @router.get("/test-key")
 async def test_metadata_key():
     """Test the currently configured metadata API key by making a real API call."""
-    result = await test_configured_key()
-    log.debug("Metadata key test completed: success=%s", result.get("success"))
-    return result
+    return await test_configured_key()
 
 
 # --- CRC route before {imdb_id} catch-all ---

--- a/arm/api/v1/metadata.py
+++ b/arm/api/v1/metadata.py
@@ -64,9 +64,8 @@ async def get_music_detail(release_id: str):
 @router.get("/test-key")
 async def test_metadata_key():
     """Test the currently configured metadata API key by making a real API call."""
-    log.debug("GET /metadata/test-key")
     result = await test_configured_key()
-    log.info("Metadata key test: provider=%s success=%s", result.get("provider"), result.get("success"))
+    log.debug("Metadata key test completed: success=%s", result.get("success"))
     return result
 
 

--- a/arm/app.py
+++ b/arm/app.py
@@ -29,10 +29,11 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-from arm.api.v1 import jobs, logs, notifications, settings, system, drives  # noqa: E402
+from arm.api.v1 import jobs, logs, metadata, notifications, settings, system, drives  # noqa: E402
 
 app.include_router(jobs.router)
 app.include_router(logs.router)
+app.include_router(metadata.router)
 app.include_router(notifications.router)
 app.include_router(settings.router)
 app.include_router(system.router)

--- a/arm/database/__init__.py
+++ b/arm/database/__init__.py
@@ -97,7 +97,20 @@ class _DB:
             log.debug("Database engine already initialised — skipping.")
             return
         engine_kw.setdefault('pool_pre_ping', True)
+        # SQLite: enable WAL mode (readers never block writers) and set a
+        # 30-second busy_timeout so concurrent writes wait instead of
+        # immediately raising SQLITE_BUSY.
+        if db_uri.startswith('sqlite'):
+            connect_args = engine_kw.pop('connect_args', {})
+            connect_args.setdefault('timeout', 30)
+            engine_kw['connect_args'] = connect_args
         self._engine = create_engine(db_uri, **engine_kw)
+        if db_uri.startswith('sqlite'):
+            @event.listens_for(self._engine, "connect")
+            def _set_sqlite_pragma(dbapi_conn, connection_record):
+                cursor = dbapi_conn.cursor()
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.close()
         factory = sessionmaker(bind=self._engine)
         self._session_factory = scoped_session(factory)
         log.info("Database engine initialised: %s", db_uri)

--- a/arm/migrations/versions/f3a4b5c6d7e8_job_add_transcode_overrides.py
+++ b/arm/migrations/versions/f3a4b5c6d7e8_job_add_transcode_overrides.py
@@ -16,9 +16,12 @@ depends_on = None
 
 def upgrade():
     """Add transcode_overrides JSON text column to job table."""
-    op.add_column('job',
-                  sa.Column('transcode_overrides', sa.Text(), nullable=True)
-                  )
+    conn = op.get_bind()
+    cols = [r[1] for r in conn.execute(sa.text("PRAGMA table_info('job')")).fetchall()]
+    if 'transcode_overrides' not in cols:
+        op.add_column('job',
+                      sa.Column('transcode_overrides', sa.Text(), nullable=True)
+                      )
 
 
 def downgrade():

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -15,7 +15,6 @@ import os
 import logging
 import subprocess
 import time
-import urllib
 import re
 import datetime
 import unicodedata
@@ -372,26 +371,26 @@ def identify_dvd(job):
         crc64 = pydvdid.compute(str(job.mountpoint))
         logging.info(f"DVD CRC64 hash is: {crc64}")
         job.crc_id = str(crc64)
-        urlstring = f"https://1337server.pythonanywhere.com/api/v1/?mode=s&crc64={crc64}"
-        logging.debug(urlstring)
-        dvd_info_xml = urllib.request.urlopen(urlstring).read()
-        arm_api_json = json.loads(dvd_info_xml)
-        logging.debug(f"dvd xml - {arm_api_json}")
-        logging.debug(f"results = {arm_api_json['results']}")
-        if arm_api_json['success']:
+        from arm.services.metadata_sync import lookup_crc_sync
+        crc_result = lookup_crc_sync(str(crc64))
+        logging.debug(f"CRC lookup result: {crc_result}")
+        if crc_result.get("error"):
+            logging.warning(f"CRC lookup error for {crc64}: {crc_result['error']}")
+        if crc_result.get("found") and crc_result.get("results"):
+            hit = crc_result["results"][0]
             logging.info("Found crc64 id from online API")
-            logging.info(f"title is {arm_api_json['results']['0']['title']}")
+            logging.info(f"title is {hit['title']}")
             args = {
-                'title': arm_api_json['results']['0']['title'],
-                'title_auto': arm_api_json['results']['0']['title'],
-                'year': utils.extract_year(arm_api_json['results']['0']['year']),
-                'year_auto': utils.extract_year(arm_api_json['results']['0']['year']),
-                'imdb_id': arm_api_json['results']['0']['imdb_id'],
-                'imdb_id_auto': arm_api_json['results']['0']['imdb_id'],
-                'video_type': arm_api_json['results']['0']['video_type'],
-                'video_type_auto': arm_api_json['results']['0']['video_type'],
-                'poster_url': arm_api_json['results']['0']['poster_img'],
-                'poster_url_auto': arm_api_json['results']['0']['poster_img'],
+                'title': hit['title'],
+                'title_auto': hit['title'],
+                'year': utils.extract_year(hit['year']),
+                'year_auto': utils.extract_year(hit['year']),
+                'imdb_id': hit['imdb_id'],
+                'imdb_id_auto': hit['imdb_id'],
+                'video_type': hit['video_type'],
+                'video_type_auto': hit['video_type'],
+                'poster_url': hit['poster_url'],
+                'poster_url_auto': hit['poster_url'],
                 'hasnicetitle': True
             }
             utils.database_updater(args, job)
@@ -487,6 +486,21 @@ def update_job(job, search_results):
     return utils.database_updater(args, job)
 
 
+def _to_matcher_format(normalized: list[dict]) -> list[dict]:
+    """Convert normalized search results to OMDb-style dicts for arm_matcher."""
+    results = []
+    for item in normalized:
+        media_type = item.get("media_type", "movie")
+        results.append({
+            "Title": item.get("title", ""),
+            "Year": item.get("year", ""),
+            "Type": media_type,
+            "imdbID": item.get("imdb_id", ""),
+            "Poster": item.get("poster_url") or "N/A",
+        })
+    return results
+
+
 def metadata_selector(job, title=None, year=None):
     """
     Used to switch between OMDB or TMDB as the metadata provider\n
@@ -505,24 +519,32 @@ def metadata_selector(job, title=None, year=None):
 
     :return: json/dict object or None
     """
-    from arm.services import metadata as svc_meta
+    from arm.services.metadata_sync import search_sync
+    from arm.services.metadata import MetadataConfigError
 
-    search_results = None
-    if cfg.arm_config['METADATA_PROVIDER'].lower() == "tmdb":
-        logging.debug("provider tmdb")
-        search_results = svc_meta.tmdb_search(title, year)
-    elif cfg.arm_config['METADATA_PROVIDER'].lower() == "omdb":
-        logging.debug("provider omdb")
-        search_results = svc_meta.call_omdb_api(str(title), str(year))
-    else:
-        logging.debug(cfg.arm_config['METADATA_PROVIDER'])
-        logging.debug("unknown provider - doing nothing, saying nothing. Getting Kryten")
+    logging.debug("metadata_selector: title=%r year=%s", title, year)
+    try:
+        normalized = search_sync(str(title), str(year) if year else None)
+    except MetadataConfigError as e:
+        logging.error("Metadata provider not configured: %s", e)
+        return None
+    except Exception as e:
+        logging.warning("Metadata search failed for title=%r year=%s: %s", title, year, e)
+        normalized = []
 
-    if search_results is not None:
-        if update_job(job, search_results) is None:
-            # Matcher wasn't confident — treat as no results so the
-            # retry loop continues with simplified queries
-            return None
+    if not normalized:
+        logging.debug("Metadata search returned no results for title=%r year=%s", title, year)
+        return None
+
+    # Convert normalized results to OMDb-style format for arm_matcher
+    search_results = {"Search": _to_matcher_format(normalized)}
+    logging.info("Metadata search returned %d results for title=%r", len(normalized), title)
+
+    if update_job(job, search_results) is None:
+        # Matcher wasn't confident — treat as no results so the
+        # retry loop continues with simplified queries
+        logging.debug("Matcher rejected all %d results for title=%r — will retry", len(normalized), title)
+        return None
 
     return search_results
 

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -294,7 +294,14 @@ if __name__ == "__main__":
         # Possibly add cleanup section here for failed job files
     else:
         if job:
-            job.status = JobState.SUCCESS.value
+            # If external transcoder is configured and this was a video disc,
+            # mark as waiting_transcode — the transcoder callback will set
+            # the final status (success/fail) when it finishes.
+            if (job.disctype in ("dvd", "bluray", "bluray4k")
+                    and cfg.arm_config.get("TRANSCODER_URL")):
+                job.status = JobState.TRANSCODE_WAITING.value
+            else:
+                job.status = JobState.SUCCESS.value
     finally:
         if job:
             job.eject()  # each job stores its eject status, so it is safe to call.

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -131,6 +131,11 @@ def transcoder_notify(cfg, title, body, job=None):
     """Send a webhook notification to the arm-transcoder service.
     If LOCAL_RAW_PATH and SHARED_RAW_PATH are both set, moves the job's
     raw directory from local to shared storage before notifying."""
+    # Skip webhook for setup failures (no job) or uncommitted jobs
+    # (job created but not yet persisted to DB — e.g. duplicate_run_check).
+    if job is None or getattr(job, 'job_id', None) is None:
+        return
+
     transcoder_url = cfg.get('TRANSCODER_URL', '')
     if not transcoder_url:
         return

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -1,315 +1,619 @@
-"""
-Metadata services — extracted from arm/ui/metadata.py and arm/ui/utils.py.
+"""Metadata services — async OMDb/TMDb/MusicBrainz/CRC64.
 
-All app.logger calls replaced with standard logging.
+Ported from the UI's clean httpx implementations. ARM is the single source
+of truth for all external metadata API calls. Reads keys from the in-memory
+``cfg.arm_config`` dict (loaded at startup).
 """
-import urllib
-import json
-import re
+
+from __future__ import annotations
+
 import logging
+import re
+from typing import Any
 
-import requests
+import httpx
 
 import arm.config.config as cfg
-from arm.models.job import Job
-from arm.database import db
 
 log = logging.getLogger(__name__)
 
-TMDB_YEAR_REGEX = r"-\d{0,2}-\d{0,2}"
+TMDB_POSTER_BASE = "https://image.tmdb.org/t/p/original"
+MUSICBRAINZ_BASE = "https://musicbrainz.org/ws/2"
+COVERART_BASE = "https://coverartarchive.org/release"
+CRC_DB_URL = "https://1337server.pythonanywhere.com/api/v1/"
+USER_AGENT = "ARM/1.0 (https://github.com/uprightbass360/automatic-ripping-machine-neu)"
 
 
-def call_omdb_api(title=None, year=None, imdb_id=None, plot="short"):
-    """
-    Queries OMDbapi.org for title information and parses if it's a movie
-        or a tv series
-    """
-    omdb_api_key = cfg.arm_config['OMDB_API_KEY']
-    title_info = None
-    str_url = f"https://www.omdbapi.com/?s={title}&plot={plot}&r=json&apikey={omdb_api_key}"
-    if imdb_id:
-        str_url = f"https://www.omdbapi.com/?i={imdb_id}&plot={plot}&r=json&apikey={omdb_api_key}"
-    elif title:
-        title = urllib.parse.quote(title)
-        if year and year is not None:
-            year = urllib.parse.quote(year)
-            str_url = f"https://www.omdbapi.com/?s={title}&y={year}&plot={plot}&r=json&apikey={omdb_api_key}"
+class MetadataConfigError(Exception):
+    """Raised when metadata provider is not configured or returns an auth error."""
+
+
+def _extract_year(raw: str) -> str:
+    """Extract a 4-digit year from a date/range string."""
+    m = re.search(r"\d{4}", str(raw))
+    return m.group(0) if m else raw
+
+
+def _get_keys() -> dict[str, str | None]:
+    """Read provider and API keys from live ARM config."""
+    provider = str(cfg.arm_config.get("METADATA_PROVIDER", "omdb")).lower()
+    return {
+        "provider": provider,
+        "omdb_key": cfg.arm_config.get("OMDB_API_KEY"),
+        "tmdb_key": cfg.arm_config.get("TMDB_API_KEY"),
+    }
+
+
+def has_api_key() -> bool:
+    """Check whether ARM_API_KEY is configured."""
+    return bool(cfg.arm_config.get("ARM_API_KEY"))
+
+
+def _http_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(timeout=15.0)
+
+
+def _mb_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        timeout=15.0,
+        headers={"User-Agent": USER_AGENT, "Accept": "application/json"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API — Video metadata (OMDb / TMDb)
+# ---------------------------------------------------------------------------
+
+
+async def test_configured_key() -> dict[str, Any]:
+    """Test the currently configured metadata API key. Returns {success, message, provider}."""
+    keys = _get_keys()
+    provider = keys["provider"]
+    log.info("Testing %s API key", provider.upper())
+    key = keys["tmdb_key"] if provider == "tmdb" else keys["omdb_key"]
+    if not key or not key.strip():
+        return {"success": False, "message": f"No API key configured for {provider.upper()}", "provider": provider}
+    key = key.strip()
+    try:
+        if provider == "tmdb":
+            async with _http_client() as client:
+                resp = await client.get(
+                    "https://api.themoviedb.org/3/configuration",
+                    params={"api_key": key},
+                )
+                if resp.status_code in (401, 403):
+                    return {"success": False, "message": "Invalid TMDb API key", "provider": provider}
+                if resp.status_code == 200:
+                    return {"success": True, "message": "TMDb API key is valid", "provider": provider}
+                return {"success": False, "message": f"Unexpected response ({resp.status_code})", "provider": provider}
         else:
-            str_url = f"https://www.omdbapi.com/?s={title}&plot={plot}&r=json&apikey={omdb_api_key}"
-    else:
-        log.debug("no params")
-    try:
-        title_info_json = urllib.request.urlopen(str_url).read()
-        title_info = json.loads(title_info_json.decode())
-        title_info['background_url'] = None
-        log.debug(f"omdb - {title_info}")
-        if 'Error' in title_info or title_info['Response'] == "False":
-            if title and not imdb_id:
+            async with _http_client() as client:
+                resp = await client.get(
+                    "https://www.omdbapi.com/",
+                    params={"apikey": key, "t": "The Matrix", "r": "json"},
+                )
+                if resp.status_code in (401, 403):
+                    return {"success": False, "message": "Invalid OMDb API key", "provider": provider}
                 try:
-                    log.debug("omdb search failed, trying exact title match (?t=)")
-                    t_url = f"https://www.omdbapi.com/?t={title}&plot={plot}&r=json&apikey={omdb_api_key}"
-                    if year:
-                        t_url = f"https://www.omdbapi.com/?t={title}&y={year}&plot={plot}&r=json&apikey={omdb_api_key}"
-                    fallback_json = urllib.request.urlopen(t_url, timeout=30).read()
-                    fallback_info = json.loads(fallback_json.decode())
-                    if 'Error' not in fallback_info and fallback_info.get('Response') == "True":
-                        fallback_info['background_url'] = None
-                        title_info = {"Search": [fallback_info], "Response": "True", "background_url": None}
-                    else:
-                        title_info = None
-                except Exception as error:
-                    log.error(f"omdb ?t= fallback failed with error - {error}")
-                    title_info = None
-            else:
-                title_info = None
-    except urllib.error.HTTPError as error:
-        log.error(f"omdb call failed with error - {error}")
-    else:
-        log.debug("omdb - call was successful")
-    return title_info
+                    data = resp.json()
+                except (ValueError, UnicodeDecodeError):
+                    text = resp.text[:200] if resp.text else "(empty)"
+                    log.warning("OMDb returned non-JSON (%s): %s", resp.status_code, text)
+                    if resp.status_code == 200:
+                        return {"success": False, "message": "OMDb returned an invalid response", "provider": provider}
+                    return {"success": False, "message": f"OMDb returned HTTP {resp.status_code}", "provider": provider}
+                if data.get("Response") == "True":
+                    found = data.get("Title", "")
+                    return {
+                        "success": True,
+                        "message": f"OMDb key valid \u2014 found \"{found}\"",
+                        "provider": provider,
+                    }
+                error_msg = data.get("Error", "")
+                if "Invalid API key" in error_msg:
+                    return {"success": False, "message": "Invalid OMDb API key", "provider": provider}
+                if error_msg:
+                    return {"success": False, "message": f"OMDb: {error_msg}", "provider": provider}
+                return {"success": True, "message": "OMDb API key accepted", "provider": provider}
+    except httpx.TimeoutException:
+        return {"success": False, "message": "Request timed out \u2014 check network connectivity", "provider": provider}
+    except httpx.ConnectError:
+        return {"success": False, "message": "Cannot connect to API \u2014 check network/DNS", "provider": provider}
+    except Exception as exc:
+        log.warning("Metadata key test failed: %s", exc)
+        return {"success": False, "message": f"Test failed: {type(exc).__name__}", "provider": provider}
 
 
-def get_omdb_poster(title=None, year=None, imdb_id=None, plot="short"):
-    """
-    Queries OMDbapi.org for the poster for movie/show
-    """
-    omdb_api_key = cfg.arm_config['OMDB_API_KEY']
-    if imdb_id:
-        str_url = f"https://www.omdbapi.com/?i={imdb_id}&plot={plot}&r=json&apikey={omdb_api_key}"
-        str_url_2 = ""
-    elif title:
-        str_url = f"https://www.omdbapi.com/?s={title}&y={year}&plot={plot}&r=json&apikey={omdb_api_key}"
-        str_url_2 = f"https://www.omdbapi.com/?t={title}&y={year}&plot={plot}&r=json&apikey={omdb_api_key}"
+async def search(query: str, year: str | None = None) -> list[dict[str, Any]]:
+    """Search for titles. Returns normalized list of SearchResult dicts."""
+    log.debug("Metadata search: query=%r year=%s", query, year)
+    keys = _get_keys()
+    if keys["provider"] == "tmdb" and keys["tmdb_key"]:
+        return await _tmdb_search(query, year, keys["tmdb_key"])
+    if keys["provider"] == "tmdb" and not keys["tmdb_key"]:
+        if keys["omdb_key"]:
+            log.warning("METADATA_PROVIDER is 'tmdb' but TMDB_API_KEY is empty; falling back to OMDb")
+        else:
+            raise MetadataConfigError(
+                "METADATA_PROVIDER is 'tmdb' but TMDB_API_KEY is not set and no OMDB_API_KEY fallback."
+            )
+    if keys["omdb_key"]:
+        return await _omdb_search(query, year, keys["omdb_key"])
+    raise MetadataConfigError(
+        f"No API key configured for metadata provider '{keys['provider']}'. "
+        "Set OMDB_API_KEY or TMDB_API_KEY in arm.yaml."
+    )
+
+
+async def get_details(imdb_id: str) -> dict[str, Any] | None:
+    """Fetch full details for a single title by IMDb ID."""
+    log.debug("Metadata detail lookup: imdb_id=%s", imdb_id)
+    keys = _get_keys()
+    if keys["provider"] == "tmdb" and keys["tmdb_key"]:
+        return await _tmdb_find(imdb_id, keys["tmdb_key"])
+    if keys["provider"] == "tmdb" and not keys["tmdb_key"]:
+        if keys["omdb_key"]:
+            log.warning("METADATA_PROVIDER is 'tmdb' but TMDB_API_KEY is empty; falling back to OMDb")
+        else:
+            raise MetadataConfigError(
+                "METADATA_PROVIDER is 'tmdb' but TMDB_API_KEY is not set and no OMDB_API_KEY fallback."
+            )
+    if keys["omdb_key"]:
+        return await _omdb_details(imdb_id, keys["omdb_key"])
+    raise MetadataConfigError(
+        f"No API key configured for metadata provider '{keys['provider']}'. "
+        "Set OMDB_API_KEY or TMDB_API_KEY in arm.yaml."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API — MusicBrainz
+# ---------------------------------------------------------------------------
+
+
+# Lucene special characters that must be escaped in user-provided search terms.
+_LUCENE_SPECIAL = re.compile(r'([+\-&|!(){}\[\]^"~*?:\\/<>])')
+
+
+def _escape_lucene(text: str) -> str:
+    """Escape Lucene special characters in user input."""
+    return _LUCENE_SPECIAL.sub(r"\\\1", text)
+
+
+async def search_music(
+    query: str,
+    artist: str | None = None,
+    release_type: str | None = None,
+    format: str | None = None,
+    country: str | None = None,
+    status: str | None = None,
+    tracks: int | None = None,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Search MusicBrainz for releases matching query text and optional filters."""
+    log.debug("MusicBrainz search: query=%r artist=%s", query, artist)
+    safe_query = _escape_lucene(query)
+    parts: list[str] = []
+    if artist:
+        safe_artist = _escape_lucene(artist)
+        parts.append(f'release:"{safe_query}" AND artist:"{safe_artist}"')
     else:
-        log.debug("no params")
-        return None, None
+        parts.append(safe_query)
+    if release_type:
+        parts.append(f"AND type:{release_type}")
+    if format:
+        parts.append(f'AND format:"{format}"')
+    if country:
+        parts.append(f"AND country:{country}")
+    if status:
+        parts.append(f"AND status:{status}")
+    if tracks is not None:
+        parts.append(f"AND tracks:{tracks}")
+    lucene_query = " ".join(parts)
+
+    params: dict[str, str] = {"query": lucene_query, "fmt": "json", "limit": "15"}
+    if offset > 0:
+        params["offset"] = str(offset)
+
     try:
-        title_info_json = urllib.request.urlopen(requests.utils.requote_uri(str_url)).read()
-    except Exception as error:
-        log.debug(f"Failed to reach OMdb - {error}")
-    else:
-        title_info = json.loads(title_info_json.decode())
-        if 'Error' not in title_info:
-            return title_info['Search'][0]['Poster'], title_info['Search'][0]['imdbID']
+        async with _mb_client() as client:
+            resp = await client.get(f"{MUSICBRAINZ_BASE}/release", params=params)
+            resp.raise_for_status()
+            data = resp.json()
+    except (httpx.ConnectError, httpx.HTTPError) as exc:
+        log.warning("MusicBrainz search failed: %s", exc)
+        return {"results": [], "total": 0}
 
-        try:
-            title_info_json2 = urllib.request.urlopen(requests.utils.requote_uri(str_url_2)).read()
-            title_info2 = json.loads(title_info_json2.decode())
-            if 'Error' not in title_info2:
-                return title_info2['Poster'], title_info2['imdbID']
-        except Exception as error:
-            log.error(f"Failed to reach OMdb - {error}")
+    total = data.get("count", 0)
+    log.info("MusicBrainz search for %r returned %d total results", query, total)
+    results: list[dict[str, Any]] = []
+    for release in data.get("releases", []):
+        mbid = release.get("id", "")
+        artist_credit = release.get("artist-credit", [])
+        artist_name = _build_artist_credit(artist_credit)
+        date = release.get("date", "")
+        year = date[:4] if date else ""
+        track_count = release.get("track-count")
+        media = release.get("media", [])
+        label_info = release.get("label-info", [])
+        release_group = release.get("release-group", {})
 
-    return None, None
+        results.append({
+            "title": release.get("title", ""),
+            "artist": artist_name,
+            "year": year,
+            "release_id": mbid,
+            "media_type": "music",
+            "poster_url": f"{COVERART_BASE}/{mbid}/front-250" if mbid else None,
+            "track_count": track_count,
+            "country": release.get("country"),
+            "release_type": release_group.get("primary-type"),
+            "format": _extract_format(media),
+            "label": _extract_label(label_info),
+        })
+    return {"results": results, "total": total}
 
 
-def get_tmdb_poster(search_query=None, year=None):
-    """
-    Queries api.themoviedb.org for the poster and backdrop for movie
-    """
-    tmdb_api_key = cfg.arm_config['TMDB_API_KEY']
-    search_results, poster_base, response = tmdb_fetch_results(search_query, year, tmdb_api_key)
+async def get_music_details(release_id: str) -> dict[str, Any] | None:
+    """Fetch full release details from MusicBrainz by release MBID."""
+    log.debug("MusicBrainz detail lookup: release_id=%s", release_id)
+    params = {
+        "inc": "artist-credits+recordings+release-groups+labels",
+        "fmt": "json",
+    }
 
-    if 'status_code' in search_results:
-        log.debug("get_tmdb_poster failed with status_code %s", int(search_results.get('status_code', 0)))
+    try:
+        async with _mb_client() as client:
+            resp = await client.get(
+                f"{MUSICBRAINZ_BASE}/release/{release_id}", params=params
+            )
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            data = resp.json()
+    except (httpx.ConnectError, httpx.HTTPError) as exc:
+        log.warning("MusicBrainz detail fetch failed for %s: %s", release_id, exc)
         return None
 
-    if search_results['total_results'] > 0:
-        log.debug("TMDB movie results: %d", int(search_results['total_results']))
-        return tmdb_process_poster(search_results, poster_base)
+    mbid = data.get("id", release_id)
+    artist_credit = data.get("artist-credit", [])
+    artist_name = _build_artist_credit(artist_credit)
+    date = data.get("date", "")
+    year = date[:4] if date else ""
+    label_info = data.get("label-info", [])
+    media = data.get("media", [])
+    release_group = data.get("release-group", {})
 
-    url = f"https://api.themoviedb.org/3/search/tv?api_key={tmdb_api_key}&query={search_query}"
-    response = requests.get(url)
-    search_results = json.loads(response.text)
-    if search_results['total_results'] > 0:
-        log.debug("TMDB tv results: %d", int(search_results['total_results']))
-        return tmdb_process_poster(search_results, poster_base)
-    log.debug("No results found")
+    tracks_list: list[dict[str, Any]] = []
+    track_count = 0
+    for medium in media:
+        for track in medium.get("tracks", []):
+            recording = track.get("recording", {})
+            length_ms = track.get("length") or recording.get("length")
+            tracks_list.append({
+                "number": track.get("number", ""),
+                "title": recording.get("title", track.get("title", "")),
+                "length_ms": length_ms,
+            })
+        track_count += medium.get("track-count", 0)
+
+    return {
+        "title": data.get("title", ""),
+        "artist": artist_name,
+        "year": year,
+        "release_id": mbid,
+        "media_type": "music",
+        "poster_url": f"{COVERART_BASE}/{mbid}/front-250",
+        "track_count": track_count or len(tracks_list),
+        "country": data.get("country"),
+        "release_type": release_group.get("primary-type"),
+        "format": _extract_format(media),
+        "label": _extract_label(label_info),
+        "catalog_number": _extract_catalog_number(label_info),
+        "barcode": data.get("barcode") or None,
+        "status": data.get("status"),
+        "tracks": tracks_list,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API — CRC64 lookup
+# ---------------------------------------------------------------------------
+
+
+async def lookup_crc(crc64: str) -> dict[str, Any]:
+    """Search the CRC64 database for a disc hash.
+
+    Returns {"found": bool, "results": [...]} on success,
+    or {"found": false, "results": [], "error": "..."} on failure.
+    """
+    log.debug("CRC64 lookup: %s", crc64)
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(CRC_DB_URL, params={"mode": "s", "crc64": crc64})
+            resp.raise_for_status()
+            data = resp.json()
+    except (httpx.HTTPError, httpx.ConnectError) as exc:
+        log.warning("CRC database unreachable for %s: %s", crc64, exc)
+        return {"found": False, "results": [], "error": "CRC database unreachable"}
+
+    if not data.get("success"):
+        log.debug("CRC64 %s not found in database", crc64)
+        return {"found": False, "results": []}
+
+    raw = data.get("results", {})
+    results = []
+    for entry in raw.values():
+        results.append({
+            "title": entry.get("title", ""),
+            "year": entry.get("year", ""),
+            "imdb_id": entry.get("imdb_id", ""),
+            "tmdb_id": entry.get("tmdb_id", ""),
+            "video_type": entry.get("video_type", ""),
+            "disctype": entry.get("disctype", ""),
+            "label": entry.get("label", ""),
+            "poster_url": entry.get("poster_img", ""),
+            "hasnicetitle": entry.get("hasnicetitle", ""),
+            "validated": entry.get("validated", ""),
+            "date_added": entry.get("date_added", ""),
+        })
+
+    found = len(results) > 0
+    if found:
+        log.info("CRC64 %s matched %d result(s): %s", crc64, len(results), results[0].get("title", "?"))
+    return {"found": found, "results": results}
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_artist_credit(credits: list[dict]) -> str:
+    """Join all artist-credit entries with their joinphrases."""
+    parts: list[str] = []
+    for entry in credits:
+        parts.append(entry.get("name", ""))
+        jp = entry.get("joinphrase", "")
+        if jp:
+            parts.append(jp)
+    return "".join(parts)
+
+
+def _extract_label(label_info: list[dict]) -> str | None:
+    if label_info and label_info[0].get("label"):
+        return label_info[0]["label"].get("name")
     return None
 
 
-def tmdb_process_poster(search_results, poster_base):
-    """
-    Process the results from tmdb and fix results with poster
-    """
-    for media in search_results['results']:
-        if media['poster_path'] is not None and 'release_date' in media:
-            released_date = re.sub(TMDB_YEAR_REGEX, "", media['release_date'])
-            log.debug("TMDB poster match: %s (%s)", str(media['title']), str(released_date))
-            media['poster_url'] = f"{poster_base}{media['poster_path']}"
-            media["Plot"] = media['overview']
-            media['background_url'] = f"{poster_base}{media['backdrop_path']}"
-            media['Type'] = "movie"
-            log.debug("TMDB backdrop found for %s", str(media['title']))
-            return media
+def _extract_catalog_number(label_info: list[dict]) -> str | None:
+    if label_info:
+        return label_info[0].get("catalog-number")
     return None
 
 
-def tmdb_search(search_query=None, year=None):
-    """
-    Queries api.themoviedb.org for movies close to the query
-    """
-    tmdb_api_key = cfg.arm_config['TMDB_API_KEY']
-    search_results, poster_base, response = tmdb_fetch_results(search_query, year, tmdb_api_key)
-    log.debug("TMDB search results - movie - %d results", int(search_results.get('total_results', 0)))
-    if 'status_code' in search_results:
-        log.error("tmdb_fetch_results failed with status_code %s", int(search_results.get('status_code', 0)))
-        return None
-    return_results = {}
-    if search_results['total_results'] > 0:
-        log.debug("tmdb_search - found %d movies", int(search_results['total_results']))
-        return tmdb_process_results(poster_base, return_results, search_results, "movie")
-    log.debug("tmdb_search - movie not found, trying tv series ")
-    url = f"https://api.themoviedb.org/3/search/tv?api_key={tmdb_api_key}&query={search_query}"
-    response = requests.get(url)
-    search_results = json.loads(response.text)
-    if search_results['total_results'] > 0:
-        log.debug("TMDB tv results: %d", int(search_results['total_results']))
-        return tmdb_process_results(poster_base, return_results, search_results, "series")
-
-    log.debug("tmdb_search - no results found")
+def _extract_format(media: list[dict]) -> str | None:
+    if media:
+        return media[0].get("format")
     return None
 
 
-def tmdb_process_results(poster_base, return_results, search_results, media_type="movie"):
-    """
-    Process search result so that it follows omdb style of output
-    """
-    for result in search_results['results']:
-        log.debug("Processing TMDB result: %s", str(result.get('title', result.get('name', 'unknown'))))
-        result['poster_path'] = result['poster_path'] if result['poster_path'] is not None else None
-        result['release_date'] = '0000-00-00' if 'release_date' not in result else result['release_date']
-        result['imdbID'] = tmdb_get_imdb(result['id'])
-        result['Year'] = re.sub(TMDB_YEAR_REGEX, "", result['first_air_date']) if 'first_air_date' in result else \
-            re.sub(TMDB_YEAR_REGEX, "", result['release_date'])
-        result['Title'] = result['title'] if 'title' in result else result['name']
-        result['Type'] = media_type
-        result['Poster'] = f"{poster_base}{result['poster_path']}"
-        result['background_url'] = f"{poster_base}{result['backdrop_path']}"
-        result["Plot"] = result['overview']
-    return_results['Search'] = search_results['results']
-    return return_results
+# ---------------------------------------------------------------------------
+# OMDb helpers
+# ---------------------------------------------------------------------------
 
 
-def tmdb_get_imdb(tmdb_id):
-    """
-    Queries api.themoviedb.org for imdb_id by TMDB id
-    """
-    tmdb_api_key = cfg.arm_config['TMDB_API_KEY']
-    url = f"https://api.themoviedb.org/3/movie/{tmdb_id}?api_key={tmdb_api_key}&" \
-          f"append_to_response=alternative_titles,credits,images,keywords,releases,reviews,similar,videos,external_ids"
-    url_tv = f"https://api.themoviedb.org/3/tv/{tmdb_id}/external_ids?api_key={tmdb_api_key}"
-    response = requests.get(url)
-    search_results = json.loads(response.text)
-    if 'status_code' in search_results:
-        response = requests.get(url_tv)
-        tv_json = json.loads(response.text)
-        log.debug("TMDB TV external IDs response keys: %s", [str(k) for k in tv_json.keys()])
-        if 'status_code' not in tv_json:
-            return tv_json['imdb_id']
-        return None
-    return search_results['external_ids']['imdb_id']
-
-
-def tmdb_find(imdb_id):
-    """
-    basic function to return an object from TMDB from only the IMDB id
-    """
-    tmdb_api_key = cfg.arm_config['TMDB_API_KEY']
-    url = f"https://api.themoviedb.org/3/find/{imdb_id}?api_key={tmdb_api_key}&external_source=imdb_id"
-    poster_size = "original"
-    poster_base = f"https://image.tmdb.org/t/p/{poster_size}"
-    response = requests.get(url)
-    search_results = json.loads(response.text)
-    if len(search_results['movie_results']) > 0:
-        return_results = {'results': search_results['movie_results']}
-        return_results['poster_url'] = f"{poster_base}{return_results['results'][0]['poster_path']}"
-        return_results["Plot"] = return_results['results'][0]['overview']
-        return_results['background_url'] = f"{poster_base}{return_results['results'][0]['backdrop_path']}"
-        return_results['Type'] = "movie"
-        return_results['imdbID'] = imdb_id
-        return_results['Poster'] = return_results['poster_url']
-        return_results['Year'] = re.sub(TMDB_YEAR_REGEX, "", return_results['results'][0]['release_date'])
-        return_results['Title'] = return_results['results'][0]['title']
-    else:
-        return_results = {'results': search_results['tv_results']}
-        return_results['poster_url'] = f"{poster_base}{return_results['results'][0]['poster_path']}"
-        return_results["Plot"] = return_results['results'][0]['overview']
-        return_results['background_url'] = f"{poster_base}{return_results['results'][0]['backdrop_path']}"
-        return_results['imdbID'] = imdb_id
-        return_results['Type'] = "series"
-        return_results['Poster'] = return_results['poster_url']
-        return_results['Year'] = re.sub(TMDB_YEAR_REGEX, "", return_results['results'][0]['first_air_date'])
-        return_results['Title'] = return_results['results'][0]['name']
-    return return_results
-
-
-def tmdb_fetch_results(search_query, year, tmdb_api_key):
-    """
-    Main function for fetching movie results from TMDB
-    """
+async def _omdb_search(query: str, year: str | None, api_key: str) -> list[dict[str, Any]]:
+    params: dict[str, str] = {"s": query, "r": "json", "apikey": api_key}
     if year:
-        url = f"https://api.themoviedb.org/3/search/movie?api_key={tmdb_api_key}&query={search_query}&year={year}"
-    else:
-        url = f"https://api.themoviedb.org/3/search/movie?api_key={tmdb_api_key}&query={search_query}"
-    poster_size = "original"
-    poster_base = f"https://image.tmdb.org/t/p/{poster_size}"
-    response = requests.get(url)
-    return_json = json.loads(response.text)
-    return return_json, poster_base, response
+        params["y"] = year
+    async with _http_client() as client:
+        resp = await client.get("https://www.omdbapi.com/", params=params)
+        if resp.status_code in (401, 403):
+            raise MetadataConfigError("OMDb API key is invalid or expired. Check OMDB_API_KEY in arm.yaml.")
+        data = resp.json()
+
+    results = []
+    if data.get("Response") == "True" and "Search" in data:
+        for item in data["Search"]:
+            results.append(_normalize_omdb(item))
+        log.info("OMDb search for %r returned %d results", query, len(results))
+        return results
+
+    # Fallback: ?t= exact match for short/numeric titles
+    log.debug("OMDb ?s= search for %r returned no results, trying ?t= exact match", query)
+    params_t: dict[str, str] = {"t": query, "r": "json", "apikey": api_key}
+    if year:
+        params_t["y"] = year
+    async with _http_client() as client:
+        resp = await client.get("https://www.omdbapi.com/", params=params_t)
+        if resp.status_code in (401, 403):
+            raise MetadataConfigError("OMDb API key is invalid or expired. Check OMDB_API_KEY in arm.yaml.")
+        data = resp.json()
+    if data.get("Response") == "True":
+        results.append(_normalize_omdb(data))
+    log.info("OMDb search for %r returned %d results (via ?t= fallback)", query, len(results))
+    return results
 
 
-def metadata_selector(func, query="", year="", imdb_id=""):
-    """
-    Used to switch between OMDB or TMDB as the metadata provider
-    - TMDB returned queries are converted into the OMDB format
-    """
-    return_function = None
-    if cfg.arm_config['METADATA_PROVIDER'].lower() == "tmdb":
-        log.debug(f"provider tmdb - function: {func}")
-        if func == "search":
-            return_function = tmdb_search(str(query), str(year))
-        elif func == "get_details":
-            if query:
-                log.debug("provider tmdb - using: get_tmdb_poster")
-                return_function = get_tmdb_poster(str(query), str(year))
-            elif imdb_id:
-                log.debug("provider tmdb - using: tmdb_find")
-                return_function = tmdb_find(imdb_id)
-            log.debug("No title or imdb provided")
-
-    elif cfg.arm_config['METADATA_PROVIDER'].lower() == "omdb":
-        log.debug(f"provider omdb - function: {func}")
-        if func == "search":
-            return_function = call_omdb_api(str(query), str(year))
-        elif func == "get_details":
-            return_function = call_omdb_api(title=str(query), year=str(year), imdb_id=str(imdb_id), plot="full")
-    else:
-        log.debug("Unknown metadata selected")
-    return return_function
+def _normalize_omdb(item: dict) -> dict[str, Any]:
+    media_type = (item.get("Type") or "movie").lower()
+    if media_type != "series":
+        media_type = "movie"
+    poster = item.get("Poster")
+    if poster == "N/A":
+        poster = None
+    year_raw = item.get("Year", "")
+    return {
+        "title": item.get("Title", ""),
+        "year": _extract_year(year_raw) if year_raw else "",
+        "imdb_id": item.get("imdbID"),
+        "media_type": media_type,
+        "poster_url": poster,
+    }
 
 
-def job_dupe_check(crc_id):
-    """
-    function for checking the database to look for jobs that have completed
-    successfully with the same crc
-    """
-    if crc_id is None:
-        return False, None
-    jobs = Job.query.filter_by(crc_id=crc_id, status="success", hasnicetitle=True)
-    return_results = {}
-    i = 0
-    for j in jobs:
-        log.debug("job obj= " + str(j.get_d()))
-        return_results[i] = {}
-        for key, value in iter(j.get_d().items()):
-            return_results[i][str(key)] = str(value)
-        i += 1
+async def _omdb_details(imdb_id: str, api_key: str) -> dict[str, Any] | None:
+    params = {"i": imdb_id, "plot": "short", "r": "json", "apikey": api_key}
+    async with _http_client() as client:
+        resp = await client.get("https://www.omdbapi.com/", params=params)
+        if resp.status_code in (401, 403):
+            raise MetadataConfigError("OMDb API key is invalid or expired. Check OMDB_API_KEY in arm.yaml.")
+        data = resp.json()
+    if data.get("Response") != "True":
+        log.debug("OMDb detail lookup for %s returned no result: %s", imdb_id, data.get("Error", "unknown"))
+        return None
+    result = _normalize_omdb(data)
+    plot = data.get("Plot")
+    result["plot"] = plot if plot != "N/A" else None
+    result["background_url"] = None  # OMDb has no background images
+    return result
 
-    log.debug(return_results)
-    log.debug("r len=" + str(len(return_results)))
-    if jobs is not None and len(return_results) > 0:
-        log.debug("jobs is none or len(r) - we have jobs")
-        return True, return_results
-    log.debug("jobs is none or len(r) is 0 - we have no jobs")
-    return False, None
+
+# ---------------------------------------------------------------------------
+# TMDb helpers
+# ---------------------------------------------------------------------------
+
+
+async def _tmdb_search(query: str, year: str | None, api_key: str) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+
+    # Try movies first
+    params: dict[str, str] = {"api_key": api_key, "query": query}
+    if year:
+        params["year"] = year
+    async with _http_client() as client:
+        resp = await client.get(
+            "https://api.themoviedb.org/3/search/movie", params=params
+        )
+        if resp.status_code in (401, 403):
+            raise MetadataConfigError("TMDb API key is invalid or expired. Check TMDB_API_KEY in arm.yaml.")
+        data = resp.json()
+
+    movie_count = data.get("total_results", 0)
+    if movie_count > 0:
+        for item in data["results"]:
+            results.append(await _normalize_tmdb(item, "movie", api_key))
+        log.info("TMDb movie search for %r returned %d results", query, len(results))
+        return results
+
+    # Fallback to TV
+    log.debug("TMDb movie search for %r returned 0 results, trying TV", query)
+    params_tv: dict[str, str] = {"api_key": api_key, "query": query}
+    if year:
+        params_tv["first_air_date_year"] = year
+    async with _http_client() as client:
+        resp = await client.get(
+            "https://api.themoviedb.org/3/search/tv", params=params_tv
+        )
+        if resp.status_code in (401, 403):
+            raise MetadataConfigError("TMDb API key is invalid or expired. Check TMDB_API_KEY in arm.yaml.")
+        data = resp.json()
+
+    if data.get("total_results", 0) > 0:
+        for item in data["results"]:
+            results.append(await _normalize_tmdb(item, "series", api_key))
+    log.info("TMDb TV search for %r returned %d results", query, len(results))
+    return results
+
+
+async def _normalize_tmdb(
+    item: dict, media_type: str, api_key: str
+) -> dict[str, Any]:
+    title = item.get("title") or item.get("name", "")
+    release = item.get("release_date") or item.get("first_air_date") or ""
+    year = _extract_year(release) if release else ""
+    poster_path = item.get("poster_path")
+    poster_url = f"{TMDB_POSTER_BASE}{poster_path}" if poster_path else None
+    imdb_id = await _tmdb_get_imdb(item["id"], media_type, api_key)
+    return {
+        "title": title,
+        "year": year,
+        "imdb_id": imdb_id,
+        "media_type": media_type,
+        "poster_url": poster_url,
+    }
+
+
+async def _tmdb_get_imdb(
+    tmdb_id: int, media_type: str, api_key: str
+) -> str | None:
+    """Get the IMDb ID for a TMDb entry."""
+    try:
+        async with _http_client() as client:
+            if media_type == "series":
+                resp = await client.get(
+                    f"https://api.themoviedb.org/3/tv/{tmdb_id}/external_ids",
+                    params={"api_key": api_key},
+                )
+                data = resp.json()
+                if "status_code" not in data:
+                    return data.get("imdb_id")
+                log.debug("TMDb TV external_ids failed for %s, trying movie endpoint", tmdb_id)
+                resp = await client.get(
+                    f"https://api.themoviedb.org/3/movie/{tmdb_id}",
+                    params={"api_key": api_key, "append_to_response": "external_ids"},
+                )
+                data = resp.json()
+                if "status_code" not in data:
+                    return data.get("external_ids", {}).get("imdb_id")
+            else:
+                resp = await client.get(
+                    f"https://api.themoviedb.org/3/movie/{tmdb_id}",
+                    params={"api_key": api_key, "append_to_response": "external_ids"},
+                )
+                data = resp.json()
+                if "status_code" not in data:
+                    return data.get("external_ids", {}).get("imdb_id")
+                log.debug("TMDb movie endpoint failed for %s, trying TV external_ids", tmdb_id)
+                resp = await client.get(
+                    f"https://api.themoviedb.org/3/tv/{tmdb_id}/external_ids",
+                    params={"api_key": api_key},
+                )
+                data = resp.json()
+                if "status_code" not in data:
+                    return data.get("imdb_id")
+    except Exception as e:
+        log.warning("Failed to resolve IMDb ID for TMDb %s %s: %s", media_type, tmdb_id, e)
+    return None
+
+
+async def _tmdb_find(imdb_id: str, api_key: str) -> dict[str, Any] | None:
+    """Lookup full details by IMDb ID via TMDb /find endpoint."""
+    async with _http_client() as client:
+        resp = await client.get(
+            f"https://api.themoviedb.org/3/find/{imdb_id}",
+            params={"api_key": api_key, "external_source": "imdb_id"},
+        )
+        if resp.status_code in (401, 403):
+            raise MetadataConfigError("TMDb API key is invalid or expired. Check TMDB_API_KEY in arm.yaml.")
+        data = resp.json()
+
+    item = None
+    media_type = "movie"
+    if data.get("movie_results"):
+        item = data["movie_results"][0]
+    elif data.get("tv_results"):
+        item = data["tv_results"][0]
+        media_type = "series"
+
+    if not item:
+        log.debug("TMDb /find returned no results for %s", imdb_id)
+        return None
+
+    title = item.get("title") or item.get("name", "")
+    release = item.get("release_date") or item.get("first_air_date") or ""
+    year = _extract_year(release) if release else ""
+    poster_path = item.get("poster_path")
+    backdrop_path = item.get("backdrop_path")
+
+    log.info("TMDb detail for %s: %s (%s) [%s]", imdb_id, title, year, media_type)
+    return {
+        "title": title,
+        "year": year,
+        "imdb_id": imdb_id,
+        "media_type": media_type,
+        "poster_url": f"{TMDB_POSTER_BASE}{poster_path}" if poster_path else None,
+        "plot": item.get("overview") or None,
+        "background_url": f"{TMDB_POSTER_BASE}{backdrop_path}" if backdrop_path else None,
+    }

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -69,7 +69,6 @@ async def test_configured_key() -> dict[str, Any]:
     """Test the currently configured metadata API key. Returns {success, message, provider}."""
     keys = _get_keys()
     provider = keys["provider"]
-    log.debug("Testing metadata provider: %s", provider)
     key = keys["tmdb_key"] if provider == "tmdb" else keys["omdb_key"]
     if not key or not key.strip():
         return {"success": False, "message": f"No API key configured for {provider.upper()}", "provider": provider}

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -69,7 +69,7 @@ async def test_configured_key() -> dict[str, Any]:
     """Test the currently configured metadata API key. Returns {success, message, provider}."""
     keys = _get_keys()
     provider = keys["provider"]
-    log.info("Testing %s API key", provider.upper())
+    log.debug("Testing metadata provider: %s", provider)
     key = keys["tmdb_key"] if provider == "tmdb" else keys["omdb_key"]
     if not key or not key.strip():
         return {"success": False, "message": f"No API key configured for {provider.upper()}", "provider": provider}

--- a/arm/services/metadata_sync.py
+++ b/arm/services/metadata_sync.py
@@ -1,0 +1,62 @@
+"""Synchronous metadata wrappers for the ripper process.
+
+The ripper is spawned by udev and has no running event loop, so
+``asyncio.run()`` is safe here.
+
+MetadataConfigError is intentionally NOT caught — callers should
+handle it (or let it propagate to fail the identification phase).
+Network errors from httpx are caught and logged to prevent a
+transient API outage from crashing the ripper.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+from arm.services import metadata
+from arm.services.metadata import MetadataConfigError  # noqa: F401 — re-export for callers
+
+log = logging.getLogger(__name__)
+
+
+def search_sync(query: str, year: str | None = None) -> list[dict[str, Any]]:
+    """Sync wrapper for metadata.search().
+
+    Raises MetadataConfigError if no API key is configured.
+    Returns empty list on network/timeout errors.
+    """
+    try:
+        return asyncio.run(metadata.search(query, year))
+    except MetadataConfigError:
+        raise
+    except (httpx.HTTPError, httpx.ConnectError, httpx.TimeoutException) as exc:
+        log.error("Metadata search network error for %r: %s", query, exc)
+        return []
+
+
+def get_details_sync(imdb_id: str) -> dict[str, Any] | None:
+    """Sync wrapper for metadata.get_details().
+
+    Raises MetadataConfigError if no API key is configured.
+    Returns None on network/timeout errors.
+    """
+    try:
+        return asyncio.run(metadata.get_details(imdb_id))
+    except MetadataConfigError:
+        raise
+    except (httpx.HTTPError, httpx.ConnectError, httpx.TimeoutException) as exc:
+        log.error("Metadata detail network error for %s: %s", imdb_id, exc)
+        return None
+
+
+def lookup_crc_sync(crc64: str) -> dict[str, Any]:
+    """Sync wrapper for metadata.lookup_crc().
+
+    Always returns a dict (never raises). Network errors are caught
+    internally by lookup_crc() and returned as {"found": False, "error": ...}.
+    """
+    return asyncio.run(metadata.lookup_crc(crc64))

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,7 +16,8 @@ services:
     volumes:
       - ./dev-data/music:/home/arm/music
       - ./dev-data/logs:/home/arm/logs
-      - ./dev-data/media:/home/arm/media
+      # NB: media is NOT overridden here — it uses ${ARM_MEDIA_PATH} from .env
+      # (NFS share) so the transcoder can find ripped files.
       - ./dev-data/config:/etc/arm/config
       - ./dev-data/makemkv:/home/arm/.MakeMKV
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ testpaths = test
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
+markers =
+    integration: tests that require running containers (deselect with -m "not integration")
 
 [coverage:run]
 source = arm

--- a/test/test_identify.py
+++ b/test/test_identify.py
@@ -310,85 +310,290 @@ class TestMetadataSelector:
         job.label = 'TEST'
         return job
 
-    def test_omdb_provider(self):
-        """When METADATA_PROVIDER=omdb, calls call_omdb_api."""
+    def test_search_sync_called(self):
+        """metadata_selector calls search_sync and processes results."""
         from arm.ripper.identify import metadata_selector
-        import arm.config.config as cfg
 
         job = self._make_job()
-        original = cfg.arm_config.get('METADATA_PROVIDER')
-        cfg.arm_config['METADATA_PROVIDER'] = 'omdb'
-        try:
-            # Return None to avoid update_job being called
-            with unittest.mock.patch('arm.services.metadata.call_omdb_api',
-                                     return_value=None) as mock_omdb:
-                metadata_selector(job, 'Serial Mom', '1994')
-                mock_omdb.assert_called_once()
-        finally:
-            if original is not None:
-                cfg.arm_config['METADATA_PROVIDER'] = original
-
-    def test_tmdb_provider(self):
-        """When METADATA_PROVIDER=tmdb, calls tmdb_search."""
-        from arm.ripper.identify import metadata_selector
-        import arm.config.config as cfg
-
-        job = self._make_job()
-        original = cfg.arm_config.get('METADATA_PROVIDER')
-        cfg.arm_config['METADATA_PROVIDER'] = 'tmdb'
-        try:
-            with unittest.mock.patch('arm.services.metadata.tmdb_search',
-                                     return_value=None) as mock_tmdb:
-                metadata_selector(job, 'Serial Mom', '1994')
-                mock_tmdb.assert_called_once()
-        finally:
-            if original is not None:
-                cfg.arm_config['METADATA_PROVIDER'] = original
-
-    def test_unknown_provider_returns_none(self):
-        """Unknown METADATA_PROVIDER returns None."""
-        from arm.ripper.identify import metadata_selector
-        import arm.config.config as cfg
-
-        job = self._make_job()
-        original = cfg.arm_config.get('METADATA_PROVIDER')
-        cfg.arm_config['METADATA_PROVIDER'] = 'invalid_provider'
-        try:
+        # Return empty list — no results
+        with unittest.mock.patch('arm.services.metadata_sync.search_sync',
+                                 return_value=[]) as mock_search:
             result = metadata_selector(job, 'Serial Mom', '1994')
-            assert result is None
-        finally:
-            if original is not None:
-                cfg.arm_config['METADATA_PROVIDER'] = original
+            mock_search.assert_called_once_with('Serial Mom', '1994')
+        assert result is None
+
+    def test_search_sync_with_results(self):
+        """metadata_selector converts results to matcher format."""
+        from arm.ripper.identify import metadata_selector
+
+        job = self._make_job()
+        normalized = [
+            {"title": "Serial Mom", "year": "1994", "imdb_id": "tt0111127",
+             "media_type": "movie", "poster_url": None},
+        ]
+        with unittest.mock.patch('arm.services.metadata_sync.search_sync',
+                                 return_value=normalized):
+            # Matcher will reject because label='TEST' doesn't match 'Serial Mom'
+            result = metadata_selector(job, 'Serial Mom', '1994')
+        assert result is None
 
     def test_returns_none_when_matcher_rejects(self):
         """When API returns results but matcher isn't confident, return None
         so identify_loop retries with simplified queries."""
         from arm.ripper.identify import metadata_selector
-        import arm.config.config as cfg
 
         job = self._make_job()
         # label = 'TEST' but API returns unrelated result
-        original = cfg.arm_config.get('METADATA_PROVIDER')
-        cfg.arm_config['METADATA_PROVIDER'] = 'omdb'
-        try:
-            bad_results = {
-                'Search': [{
-                    'Title': 'Completely Unrelated Movie',
-                    'Year': '2020',
-                    'Type': 'movie',
-                    'imdbID': 'tt9999999',
-                    'Poster': 'N/A',
-                }],
-                'Response': 'True',
-            }
-            with unittest.mock.patch('arm.services.metadata.call_omdb_api',
-                                     return_value=bad_results):
-                result = metadata_selector(job, 'TEST', '2020')
-            # Should return None because matcher rejected the results
-            assert result is None
-        finally:
-            if original is not None:
-                cfg.arm_config['METADATA_PROVIDER'] = original
+        bad_results = [
+            {"title": "Completely Unrelated Movie", "year": "2020",
+             "imdb_id": "tt9999999", "media_type": "movie", "poster_url": None},
+        ]
+        with unittest.mock.patch('arm.services.metadata_sync.search_sync',
+                                 return_value=bad_results):
+            result = metadata_selector(job, 'TEST', '2020')
+        # Should return None because matcher rejected the results
+        assert result is None
+
+
+class TestToMatcherFormat:
+    """Test _to_matcher_format() conversion from normalized to OMDb-style dicts."""
+
+    def test_converts_normalized_results(self):
+        from arm.ripper.identify import _to_matcher_format
+        normalized = [
+            {"title": "Matrix", "year": "1999", "imdb_id": "tt0133093",
+             "media_type": "movie", "poster_url": "http://img.com/p.jpg"},
+        ]
+        result = _to_matcher_format(normalized)
+        assert len(result) == 1
+        assert result[0]["Title"] == "Matrix"
+        assert result[0]["Year"] == "1999"
+        assert result[0]["imdbID"] == "tt0133093"
+        assert result[0]["Type"] == "movie"
+        assert result[0]["Poster"] == "http://img.com/p.jpg"
+
+    def test_missing_poster_becomes_na(self):
+        from arm.ripper.identify import _to_matcher_format
+        normalized = [{"title": "X", "year": "2020", "imdb_id": "tt0000001",
+                       "media_type": "movie", "poster_url": None}]
+        result = _to_matcher_format(normalized)
+        assert result[0]["Poster"] == "N/A"
+
+    def test_empty_list(self):
+        from arm.ripper.identify import _to_matcher_format
+        assert _to_matcher_format([]) == []
+
+    def test_missing_fields_default_to_empty(self):
+        from arm.ripper.identify import _to_matcher_format
+        result = _to_matcher_format([{}])
+        assert result[0]["Title"] == ""
+        assert result[0]["Year"] == ""
+        assert result[0]["imdbID"] == ""
+        assert result[0]["Type"] == "movie"
+        assert result[0]["Poster"] == "N/A"
+
+    def test_series_type_preserved(self):
+        from arm.ripper.identify import _to_matcher_format
+        normalized = [{"title": "Friends", "year": "1994", "imdb_id": "tt0108778",
+                       "media_type": "series", "poster_url": None}]
+        result = _to_matcher_format(normalized)
+        assert result[0]["Type"] == "series"
+
+
+class TestMetadataSelectorErrors:
+    """Test metadata_selector() error handling paths."""
+
+    def _make_job(self):
+        from arm.models.job import Job
+        with unittest.mock.patch.object(Job, 'parse_udev'), \
+             unittest.mock.patch.object(Job, 'get_pid'):
+            job = Job('/dev/sr0')
+        job.title = 'TEST'
+        job.label = 'TEST'
+        return job
+
+    def test_metadata_config_error_returns_none(self):
+        """MetadataConfigError (no API key) returns None without crashing."""
+        from arm.ripper.identify import metadata_selector
+        from arm.services.metadata import MetadataConfigError
+
+        job = self._make_job()
+        with unittest.mock.patch('arm.services.metadata_sync.search_sync',
+                                 side_effect=MetadataConfigError("no key")):
+            result = metadata_selector(job, 'Test', '2020')
+        assert result is None
+
+    def test_generic_exception_returns_none(self):
+        """Unexpected exceptions return None (logged, not raised)."""
+        from arm.ripper.identify import metadata_selector
+
+        job = self._make_job()
+        with unittest.mock.patch('arm.services.metadata_sync.search_sync',
+                                 side_effect=RuntimeError("unexpected")):
+            result = metadata_selector(job, 'Test', '2020')
+        assert result is None
+
+    def test_empty_results_returns_none(self):
+        """Empty results list returns None."""
+        from arm.ripper.identify import metadata_selector
+
+        job = self._make_job()
+        with unittest.mock.patch('arm.services.metadata_sync.search_sync',
+                                 return_value=[]):
+            result = metadata_selector(job, 'Test', '2020')
+        assert result is None
+
+    def test_year_none_passed_as_none(self):
+        """Year=None is passed through correctly."""
+        from arm.ripper.identify import metadata_selector
+
+        job = self._make_job()
+        with unittest.mock.patch('arm.services.metadata_sync.search_sync',
+                                 return_value=[]) as mock_search:
+            metadata_selector(job, 'Test')
+            mock_search.assert_called_once_with('Test', None)
+
+
+class TestMetadataSelectorSuccess:
+    """Test metadata_selector() success path where update_job accepts a match."""
+
+    def _make_job(self):
+        from arm.models.job import Job
+        with unittest.mock.patch.object(Job, 'parse_udev'), \
+             unittest.mock.patch.object(Job, 'get_pid'):
+            job = Job('/dev/sr0')
+        job.title = 'SERIAL_MOM'
+        job.label = 'SERIAL_MOM'
+        return job
+
+    def test_returns_search_results_on_match(self):
+        """When update_job accepts match, return the search_results dict."""
+        from arm.ripper.identify import metadata_selector
+
+        job = self._make_job()
+        normalized = [
+            {"title": "Serial Mom", "year": "1994", "imdb_id": "tt0111127",
+             "media_type": "movie", "poster_url": None},
+        ]
+        with unittest.mock.patch('arm.services.metadata_sync.search_sync',
+                                 return_value=normalized), \
+             unittest.mock.patch('arm.ripper.identify.update_job',
+                                 return_value=True):
+            result = metadata_selector(job, 'Serial Mom', '1994')
+        assert result is not None
+        assert "Search" in result
+        assert result["Search"][0]["Title"] == "Serial Mom"
+
+    def test_returns_none_when_update_job_returns_none(self):
+        """When update_job returns None (matcher rejects), return None."""
+        from arm.ripper.identify import metadata_selector
+
+        job = self._make_job()
+        normalized = [
+            {"title": "Serial Mom", "year": "1994", "imdb_id": "tt0111127",
+             "media_type": "movie", "poster_url": None},
+        ]
+        with unittest.mock.patch('arm.services.metadata_sync.search_sync',
+                                 return_value=normalized), \
+             unittest.mock.patch('arm.ripper.identify.update_job',
+                                 return_value=None):
+            result = metadata_selector(job, 'Serial Mom', '1994')
+        assert result is None
+
+
+class TestIdentifyDvdCrc:
+    """Test identify_dvd() CRC lookup paths."""
+
+    def _make_job(self):
+        from arm.models.job import Job
+        with unittest.mock.patch.object(Job, 'parse_udev'), \
+             unittest.mock.patch.object(Job, 'get_pid'):
+            job = Job('/dev/sr0')
+        job.mountpoint = '/mnt/dvd'
+        job.devpath = '/dev/sr0'
+        job.has_track_99 = False
+        return job
+
+    def test_crc_found_updates_job_and_returns_true(self):
+        """CRC lookup success path: updates job fields, returns True."""
+        from arm.ripper.identify import identify_dvd
+
+        job = self._make_job()
+        crc_result = {
+            "found": True,
+            "results": [{
+                "title": "The Matrix", "year": "1999",
+                "imdb_id": "tt0133093", "video_type": "movie",
+                "poster_url": "http://img/poster.jpg",
+            }]
+        }
+        with unittest.mock.patch('arm.ripper.identify.pydvdid') as mock_dvdid, \
+             unittest.mock.patch('arm.services.metadata_sync.lookup_crc_sync',
+                                 return_value=crc_result), \
+             unittest.mock.patch('arm.ripper.identify.utils') as mock_utils, \
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+            mock_dvdid.compute.return_value = "abc123"
+            mock_utils.extract_year.return_value = "1999"
+            result = identify_dvd(job)
+        assert result is True
+        # Verify database_updater was called with right args
+        call_args = mock_utils.database_updater.call_args[0]
+        assert call_args[0]["title"] == "The Matrix"
+        assert call_args[0]["hasnicetitle"] is True
+        assert call_args[1] is job
+
+    def test_crc_not_found_returns_false(self):
+        """CRC lookup returns not found — returns False."""
+        from arm.ripper.identify import identify_dvd
+
+        job = self._make_job()
+        crc_result = {"found": False, "results": []}
+        with unittest.mock.patch('arm.ripper.identify.pydvdid') as mock_dvdid, \
+             unittest.mock.patch('arm.services.metadata_sync.lookup_crc_sync',
+                                 return_value=crc_result), \
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+            mock_dvdid.compute.return_value = "abc123"
+            result = identify_dvd(job)
+        assert result is False
+
+    def test_crc_error_field_logged_still_checks_found(self):
+        """CRC lookup with error field but found=False returns False."""
+        from arm.ripper.identify import identify_dvd
+
+        job = self._make_job()
+        crc_result = {"found": False, "results": [], "error": "CRC database unreachable"}
+        with unittest.mock.patch('arm.ripper.identify.pydvdid') as mock_dvdid, \
+             unittest.mock.patch('arm.services.metadata_sync.lookup_crc_sync',
+                                 return_value=crc_result), \
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+            mock_dvdid.compute.return_value = "abc123"
+            result = identify_dvd(job)
+        assert result is False
+
+    def test_pydvdid_exception_returns_false(self):
+        """pydvdid.compute() exception is caught, returns False."""
+        from arm.ripper.identify import identify_dvd
+
+        job = self._make_job()
+        with unittest.mock.patch('arm.ripper.identify.pydvdid') as mock_dvdid, \
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+            mock_dvdid.compute.side_effect = RuntimeError("no disc structure")
+            result = identify_dvd(job)
+        assert result is False
+
+    def test_crc_id_set_on_job(self):
+        """CRC64 hash is stored on job.crc_id."""
+        from arm.ripper.identify import identify_dvd
+
+        job = self._make_job()
+        crc_result = {"found": False, "results": []}
+        with unittest.mock.patch('arm.ripper.identify.pydvdid') as mock_dvdid, \
+             unittest.mock.patch('arm.services.metadata_sync.lookup_crc_sync',
+                                 return_value=crc_result), \
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+            mock_dvdid.compute.return_value = "deadbeef12345678"
+            identify_dvd(job)
+        assert job.crc_id == "deadbeef12345678"
 
 
 class TestTryWithYear:
@@ -1346,120 +1551,140 @@ class TestMatcherIntegration:
     def test_metadata_selector_returns_none_on_reject(self, app_context):
         """metadata_selector returns None when matcher rejects — enables retry."""
         from arm.ripper.identify import metadata_selector
-        import arm.config.config as cfg
 
         job = self._make_job(app_context, label="SERIAL_MOM",
                              year_auto="1994", video_type_auto="movie")
 
-        bad_results = {'Search': [
-            {'Title': 'Completely Wrong Movie', 'Year': '2020',
-             'imdbID': 'tt9999999', 'Type': 'movie', 'Poster': 'N/A'},
-        ], 'Response': 'True'}
+        bad_results = [
+            {"title": "Completely Wrong Movie", "year": "2020",
+             "imdb_id": "tt9999999", "media_type": "movie", "poster_url": None},
+        ]
 
-        original = cfg.arm_config.get('METADATA_PROVIDER')
-        cfg.arm_config['METADATA_PROVIDER'] = 'omdb'
-        try:
-            with unittest.mock.patch('arm.services.metadata.call_omdb_api',
-                                     return_value=bad_results):
-                result = metadata_selector(job, 'Serial+Mom', '1994')
-            assert result is None
-        finally:
-            if original is not None:
-                cfg.arm_config['METADATA_PROVIDER'] = original
+        with unittest.mock.patch('arm.services.metadata_sync.search_sync',
+                                 return_value=bad_results):
+            result = metadata_selector(job, 'Serial+Mom', '1994')
+        assert result is None
 
 
 class TestOmdbShortTitleFallback:
-    """Test call_omdb_api() fallback to ?t= for short/numeric titles (#1430)."""
+    """Test _omdb_search() fallback to ?t= for short/numeric titles (#1430)."""
 
-    def _mock_urlopen(self, responses):
-        """Create a mock urlopen that returns different responses per call."""
+    def _mock_httpx_get(self, responses):
+        """Create a mock httpx get that returns different responses per call."""
+        import httpx
         call_count = [0]
 
-        def side_effect(url, **kwargs):
+        async def side_effect(url, **kwargs):
             idx = min(call_count[0], len(responses) - 1)
             call_count[0] += 1
-            mock_resp = unittest.mock.MagicMock()
-            mock_resp.read.return_value = json.dumps(responses[idx]).encode()
-            return mock_resp
+            resp = unittest.mock.MagicMock(spec=httpx.Response)
+            resp.status_code = 200
+            resp.json.return_value = responses[idx]
+            return resp
 
         return side_effect
 
-    @unittest.mock.patch.dict('arm.config.config.arm_config', {'OMDB_API_KEY': 'test_key'})
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'OMDB_API_KEY': 'test_key', 'METADATA_PROVIDER': 'omdb',
+    })
     def test_search_failure_falls_back_to_exact_title(self):
         """When ?s= returns 'Too many results', ?t= is tried."""
-        from arm.services.metadata import call_omdb_api
+        import asyncio
+        from arm.services.metadata import _omdb_search
 
         search_error = {"Response": "False", "Error": "Too many results."}
         exact_match = {
-            "Response": "True",
-            "Title": "9",
-            "Year": "2009",
-            "Type": "movie",
-            "imdbID": "tt0472033",
+            "Response": "True", "Title": "9", "Year": "2009",
+            "Type": "movie", "imdbID": "tt0472033",
             "Poster": "https://example.com/9.jpg",
         }
-        mock_open = self._mock_urlopen([search_error, exact_match])
-        with unittest.mock.patch('arm.services.metadata.urllib.request.urlopen', side_effect=mock_open):
-            result = call_omdb_api(title="9", year="2009")
+        mock_get = self._mock_httpx_get([search_error, exact_match])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            ctx = unittest.mock.AsyncMock()
+            ctx.get = mock_get
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = asyncio.run(_omdb_search("9", "2009", "test_key"))
 
-        assert result is not None
-        assert result['Search'][0]['Title'] == '9'
-        assert result['Search'][0]['imdbID'] == 'tt0472033'
+        assert len(result) == 1
+        assert result[0]['title'] == '9'
+        assert result[0]['imdb_id'] == 'tt0472033'
 
-    @unittest.mock.patch.dict('arm.config.config.arm_config', {'OMDB_API_KEY': 'test_key'})
-    def test_both_search_and_exact_fail_returns_none(self):
-        """When both ?s= and ?t= fail, returns None."""
-        from arm.services.metadata import call_omdb_api
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'OMDB_API_KEY': 'test_key', 'METADATA_PROVIDER': 'omdb',
+    })
+    def test_both_search_and_exact_fail_returns_empty(self):
+        """When both ?s= and ?t= fail, returns empty list."""
+        import asyncio
+        from arm.services.metadata import _omdb_search
 
         error_resp = {"Response": "False", "Error": "Movie not found!"}
-        mock_open = self._mock_urlopen([error_resp, error_resp])
-        with unittest.mock.patch('arm.services.metadata.urllib.request.urlopen', side_effect=mock_open):
-            result = call_omdb_api(title="xyznonexistent", year="2020")
+        mock_get = self._mock_httpx_get([error_resp, error_resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            ctx = unittest.mock.AsyncMock()
+            ctx.get = mock_get
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = asyncio.run(_omdb_search("xyznonexistent", "2020", "test_key"))
 
-        assert result is None
+        assert result == []
 
-    @unittest.mock.patch.dict('arm.config.config.arm_config', {'OMDB_API_KEY': 'test_key'})
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'OMDB_API_KEY': 'test_key', 'METADATA_PROVIDER': 'omdb',
+    })
     def test_search_succeeds_no_fallback_needed(self):
         """When ?s= succeeds, no fallback is triggered."""
-        from arm.services.metadata import call_omdb_api
+        import asyncio
+        from arm.services.metadata import _omdb_search
 
         search_success = {
             "Response": "True",
             "Search": [{"Title": "The Matrix", "Year": "1999", "imdbID": "tt0133093",
                         "Type": "movie", "Poster": "https://example.com/matrix.jpg"}]
         }
-        mock_open = self._mock_urlopen([search_success])
-        with unittest.mock.patch('arm.services.metadata.urllib.request.urlopen', side_effect=mock_open):
-            result = call_omdb_api(title="The Matrix", year="1999")
+        mock_get = self._mock_httpx_get([search_success])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            ctx = unittest.mock.AsyncMock()
+            ctx.get = mock_get
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = asyncio.run(_omdb_search("The Matrix", "1999", "test_key"))
 
-        assert result is not None
-        assert result['Search'][0]['Title'] == 'The Matrix'
+        assert len(result) == 1
+        assert result[0]['title'] == 'The Matrix'
 
-    @unittest.mock.patch.dict('arm.config.config.arm_config', {'OMDB_API_KEY': 'test_key'})
-    def test_fallback_network_error_returns_none(self):
-        """When ?s= fails and ?t= raises a network error, returns None gracefully (#1430)."""
-        from arm.services.metadata import call_omdb_api
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'OMDB_API_KEY': 'test_key', 'METADATA_PROVIDER': 'omdb',
+    })
+    def test_fallback_network_error_raises(self):
+        """When ?s= fails and ?t= raises a network error, raises MetadataConfigError
+        for auth errors or propagates other httpx errors."""
+        import asyncio
+        import httpx
+        from arm.services.metadata import _omdb_search
 
         call_count = [0]
 
-        def mock_urlopen(url, **kwargs):
+        async def mock_get(url, **kwargs):
             call_count[0] += 1
             if call_count[0] == 1:
-                # First call (?s=) returns error response
-                mock_resp = unittest.mock.MagicMock()
-                mock_resp.read.return_value = json.dumps(
-                    {"Response": "False", "Error": "Too many results."}
-                ).encode()
-                return mock_resp
-            # Second call (?t=) raises network error
-            raise urllib.error.URLError("DNS lookup failed")
+                resp = unittest.mock.MagicMock(spec=httpx.Response)
+                resp.status_code = 200
+                resp.json.return_value = {"Response": "False", "Error": "Too many results."}
+                return resp
+            resp = unittest.mock.MagicMock(spec=httpx.Response)
+            resp.status_code = 401
+            resp.json.return_value = {}
+            return resp
 
-        import urllib.error
-        with unittest.mock.patch('arm.services.metadata.urllib.request.urlopen',
-                                 side_effect=mock_urlopen):
-            result = call_omdb_api(title="9", year="2009")
-
-        assert result is None
+        from arm.services.metadata import MetadataConfigError
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            ctx = unittest.mock.AsyncMock()
+            ctx.get = mock_get
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            with pytest.raises(MetadataConfigError):
+                asyncio.run(_omdb_search("9", "2009", "test_key"))
 
 
 class TestResolveDiscLabel:

--- a/test/test_integration_metadata.py
+++ b/test/test_integration_metadata.py
@@ -1,0 +1,342 @@
+"""Integration tests for metadata API — runs against live containers.
+
+Requires:
+  - arm-rippers on localhost:8080
+  - arm-ui on localhost:8888
+
+Run with: pytest test/test_integration_metadata.py -v -m integration
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+ARM_BASE = "http://localhost:8080"
+UI_BASE = "http://localhost:8888"
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def arm():
+    """Shared httpx client for ARM direct endpoints."""
+    with httpx.Client(base_url=ARM_BASE, timeout=15.0) as client:
+        yield client
+
+
+@pytest.fixture(scope="module")
+def ui():
+    """Shared httpx client for UI proxy endpoints."""
+    with httpx.Client(base_url=UI_BASE, timeout=15.0) as client:
+        yield client
+
+
+def _require_reachable(client: httpx.Client, label: str):
+    try:
+        client.get("/")
+    except httpx.ConnectError:
+        pytest.skip(f"{label} not reachable")
+
+
+# ---------------------------------------------------------------------------
+# ARM direct — /api/v1/metadata/search
+# ---------------------------------------------------------------------------
+
+
+class TestArmMetadataSearch:
+    def test_search_returns_results(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/search", params={"q": "Matrix"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        first = data[0]
+        assert "title" in first
+        assert "imdb_id" in first
+        assert "media_type" in first
+
+    def test_search_with_year_narrows(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/search", params={"q": "Matrix", "year": "1999"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(r["year"] == "1999" for r in data)
+
+    def test_search_missing_q_returns_422(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/search")
+        assert resp.status_code == 422
+
+    def test_search_nonsense_returns_empty(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/search", params={"q": "zzxxyy99nonexistent"})
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# ARM direct — /api/v1/metadata/{imdb_id}
+# ---------------------------------------------------------------------------
+
+
+class TestArmMediaDetail:
+    def test_detail_returns_full_info(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/tt0133093")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["title"] == "The Matrix"
+        assert data["year"] == "1999"
+        assert data["imdb_id"] == "tt0133093"
+        assert "plot" in data
+
+    def test_detail_not_found(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/tt0000000")
+        # OMDb returns 200 with Response=False for non-existent IDs → our code returns 404
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# ARM direct — /api/v1/metadata/music/search
+# ---------------------------------------------------------------------------
+
+
+class TestArmMusicSearch:
+    def test_music_search_returns_results(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/music/search", params={"q": "Abbey Road"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "results" in data
+        assert "total" in data
+        # MusicBrainz rate-limits aggressively; treat empty as soft failure
+        if data["total"] == 0:
+            pytest.skip("MusicBrainz returned 0 results (likely rate-limited)")
+
+    def test_music_search_with_format_filter(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/music/search",
+                       params={"q": "Abbey Road", "format": "CD"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] > 0
+
+    def test_music_search_missing_q(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/music/search")
+        assert resp.status_code == 422
+
+    def test_music_search_result_schema(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/music/search", params={"q": "Abbey Road"})
+        data = resp.json()
+        if data["results"]:
+            entry = data["results"][0]
+            for key in ("title", "artist", "release_id", "media_type"):
+                assert key in entry, f"Missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# ARM direct — /api/v1/metadata/music/{release_id}
+# ---------------------------------------------------------------------------
+
+
+class TestArmMusicDetail:
+    def _get_release_id(self, arm):
+        """Get a real release_id from a search to use in detail lookup."""
+        resp = arm.get("/api/v1/metadata/music/search", params={"q": "Abbey Road"})
+        data = resp.json()
+        if not data.get("results"):
+            pytest.skip("No MusicBrainz results to test detail with")
+        return data["results"][0]["release_id"]
+
+    def test_music_detail_returns_tracks(self, arm):
+        _require_reachable(arm, "ARM")
+        release_id = self._get_release_id(arm)
+        resp = arm.get(f"/api/v1/metadata/music/{release_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["release_id"] == release_id
+        assert "tracks" in data
+        assert "title" in data
+
+    def test_music_detail_not_found(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/music/00000000-0000-0000-0000-000000000000")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# ARM direct — /api/v1/metadata/crc/{crc64}
+# ---------------------------------------------------------------------------
+
+
+class TestArmCrcLookup:
+    def test_crc_unknown_returns_not_found(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/crc/0000000000000000")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["found"] is False
+        assert "has_api_key" in data
+
+    def test_crc_response_schema(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/crc/abc123")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "found" in data
+        assert "results" in data
+        assert isinstance(data["results"], list)
+
+
+# ---------------------------------------------------------------------------
+# ARM direct — /api/v1/metadata/test-key
+# ---------------------------------------------------------------------------
+
+
+class TestArmTestKey:
+    def test_key_returns_status(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/test-key")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "success" in data
+        assert "message" in data
+        assert "provider" in data
+
+    def test_key_valid_omdb(self, arm):
+        _require_reachable(arm, "ARM")
+        resp = arm.get("/api/v1/metadata/test-key")
+        data = resp.json()
+        # If OMDB_API_KEY is configured, should be valid
+        if data["provider"] == "omdb" and data["success"]:
+            assert "valid" in data["message"].lower() or "found" in data["message"].lower()
+
+
+# ===========================================================================
+# UI Proxy — all metadata requests proxied through ARM
+# ===========================================================================
+
+
+class TestUiProxySearch:
+    def test_search_proxied(self, ui):
+        _require_reachable(ui, "UI")
+        resp = ui.get("/api/metadata/search", params={"q": "Matrix"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        assert data[0]["title"] == "The Matrix"
+
+    def test_search_with_year(self, ui):
+        _require_reachable(ui, "UI")
+        resp = ui.get("/api/metadata/search", params={"q": "Matrix", "year": "1999"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(r["year"] == "1999" for r in data)
+
+
+class TestUiProxyDetail:
+    def test_detail_proxied(self, ui):
+        _require_reachable(ui, "UI")
+        resp = ui.get("/api/metadata/tt0133093")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["title"] == "The Matrix"
+        assert "plot" in data
+
+    def test_detail_not_found(self, ui):
+        _require_reachable(ui, "UI")
+        resp = ui.get("/api/metadata/tt0000000")
+        assert resp.status_code == 404
+
+
+class TestUiProxyMusicSearch:
+    def test_music_search_proxied(self, ui):
+        _require_reachable(ui, "UI")
+        resp = ui.get("/api/metadata/music/search", params={"q": "Abbey Road"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] > 0
+
+    def test_music_search_with_filters(self, ui):
+        _require_reachable(ui, "UI")
+        resp = ui.get("/api/metadata/music/search",
+                       params={"q": "Abbey Road", "format": "CD", "country": "US"})
+        assert resp.status_code == 200
+        assert resp.json()["total"] > 0
+
+
+class TestUiProxyMusicDetail:
+    def test_music_detail_proxied(self, ui):
+        _require_reachable(ui, "UI")
+        # First get a release_id
+        search = ui.get("/api/metadata/music/search", params={"q": "Abbey Road"})
+        results = search.json().get("results", [])
+        if not results:
+            pytest.skip("No MusicBrainz results")
+        release_id = results[0]["release_id"]
+        resp = ui.get(f"/api/metadata/music/{release_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "tracks" in data
+        assert "title" in data
+
+    def test_music_detail_not_found(self, ui):
+        _require_reachable(ui, "UI")
+        resp = ui.get("/api/metadata/music/00000000-0000-0000-0000-000000000000")
+        assert resp.status_code == 404
+
+
+class TestUiProxyTestKey:
+    def test_test_metadata_proxied(self, ui):
+        _require_reachable(ui, "UI")
+        resp = ui.get("/api/settings/test-metadata")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "success" in data
+        assert "provider" in data
+
+
+# ---------------------------------------------------------------------------
+# Cross-validation: ARM and UI return same data
+# ---------------------------------------------------------------------------
+
+
+class TestCrossValidation:
+    def test_search_results_match(self, arm, ui):
+        _require_reachable(arm, "ARM")
+        _require_reachable(ui, "UI")
+        arm_resp = arm.get("/api/v1/metadata/search", params={"q": "Inception", "year": "2010"})
+        ui_resp = ui.get("/api/metadata/search", params={"q": "Inception", "year": "2010"})
+        assert arm_resp.status_code == 200
+        assert ui_resp.status_code == 200
+        arm_data = arm_resp.json()
+        ui_data = ui_resp.json()
+        assert len(arm_data) == len(ui_data)
+        if arm_data:
+            assert arm_data[0]["imdb_id"] == ui_data[0]["imdb_id"]
+
+    def test_detail_results_match(self, arm, ui):
+        _require_reachable(arm, "ARM")
+        _require_reachable(ui, "UI")
+        arm_resp = arm.get("/api/v1/metadata/tt0133093")
+        ui_resp = ui.get("/api/metadata/tt0133093")
+        assert arm_resp.json()["title"] == ui_resp.json()["title"]
+        assert arm_resp.json()["plot"] == ui_resp.json()["plot"]
+
+    def test_key_test_results_match(self, arm, ui):
+        _require_reachable(arm, "ARM")
+        _require_reachable(ui, "UI")
+        arm_resp = arm.get("/api/v1/metadata/test-key")
+        ui_resp = ui.get("/api/settings/test-metadata")
+        assert arm_resp.json()["success"] == ui_resp.json()["success"]
+        assert arm_resp.json()["provider"] == ui_resp.json()["provider"]

--- a/test/test_metadata_api.py
+++ b/test/test_metadata_api.py
@@ -1,0 +1,207 @@
+"""Tests for arm/api/v1/metadata.py — FastAPI router endpoints.
+
+Covers all 6 endpoints: /search, /{imdb_id}, /music/search,
+/music/{release_id}, /crc/{crc64}, /test-key.
+"""
+
+import unittest.mock
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def client():
+    """Create a test client for just the metadata router."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from arm.api.v1.metadata import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/metadata/search
+# ---------------------------------------------------------------------------
+
+
+class TestSearchEndpoint:
+    def test_success(self, client):
+        results = [{"title": "Matrix", "year": "1999", "imdb_id": "tt0133093",
+                     "media_type": "movie", "poster_url": None}]
+        with unittest.mock.patch('arm.api.v1.metadata.search', return_value=results):
+            resp = client.get("/api/v1/metadata/search?q=Matrix")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["title"] == "Matrix"
+
+    def test_with_year(self, client):
+        with unittest.mock.patch('arm.api.v1.metadata.search', return_value=[]) as mock_fn:
+            resp = client.get("/api/v1/metadata/search?q=Matrix&year=1999")
+        assert resp.status_code == 200
+        mock_fn.assert_called_once_with("Matrix", "1999")
+
+    def test_missing_query(self, client):
+        resp = client.get("/api/v1/metadata/search")
+        assert resp.status_code == 422  # FastAPI validation error
+
+    def test_config_error_returns_503(self, client):
+        from arm.services.metadata import MetadataConfigError
+        with unittest.mock.patch('arm.api.v1.metadata.search',
+                                 side_effect=MetadataConfigError("no key")):
+            resp = client.get("/api/v1/metadata/search?q=Matrix")
+        assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/metadata/{imdb_id}
+# ---------------------------------------------------------------------------
+
+
+class TestDetailEndpoint:
+    def test_success(self, client):
+        detail = {"title": "Matrix", "year": "1999", "imdb_id": "tt0133093",
+                  "media_type": "movie", "poster_url": None, "plot": "A hacker...",
+                  "background_url": None}
+        with unittest.mock.patch('arm.api.v1.metadata.get_details', return_value=detail):
+            resp = client.get("/api/v1/metadata/tt0133093")
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Matrix"
+
+    def test_not_found(self, client):
+        with unittest.mock.patch('arm.api.v1.metadata.get_details', return_value=None):
+            resp = client.get("/api/v1/metadata/tt9999999")
+        assert resp.status_code == 404
+
+    def test_config_error_returns_503(self, client):
+        from arm.services.metadata import MetadataConfigError
+        with unittest.mock.patch('arm.api.v1.metadata.get_details',
+                                 side_effect=MetadataConfigError("no key")):
+            resp = client.get("/api/v1/metadata/tt0133093")
+        assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/metadata/test-key
+# ---------------------------------------------------------------------------
+
+
+class TestKeyEndpoint:
+    def test_valid_key(self, client):
+        result = {"success": True, "message": "OMDb key valid", "provider": "omdb"}
+        with unittest.mock.patch('arm.api.v1.metadata.test_configured_key', return_value=result):
+            resp = client.get("/api/v1/metadata/test-key")
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_invalid_key(self, client):
+        result = {"success": False, "message": "Invalid key", "provider": "omdb"}
+        with unittest.mock.patch('arm.api.v1.metadata.test_configured_key', return_value=result):
+            resp = client.get("/api/v1/metadata/test-key")
+        assert resp.status_code == 200
+        assert resp.json()["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/metadata/crc/{crc64}
+# ---------------------------------------------------------------------------
+
+
+class TestCrcEndpoint:
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {'ARM_API_KEY': 'key123'})
+    def test_found(self, client):
+        crc_result = {"found": True, "results": [{"title": "Matrix"}]}
+        with unittest.mock.patch('arm.api.v1.metadata.lookup_crc', return_value=crc_result), \
+             unittest.mock.patch('arm.api.v1.metadata.has_api_key', return_value=True):
+            resp = client.get("/api/v1/metadata/crc/abc123")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["found"] is True
+        assert data["has_api_key"] is True
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {})
+    def test_not_found(self, client):
+        crc_result = {"found": False, "results": []}
+        with unittest.mock.patch('arm.api.v1.metadata.lookup_crc', return_value=crc_result), \
+             unittest.mock.patch('arm.api.v1.metadata.has_api_key', return_value=False):
+            resp = client.get("/api/v1/metadata/crc/unknown")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["found"] is False
+        assert data["has_api_key"] is False
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/metadata/music/search
+# ---------------------------------------------------------------------------
+
+
+class TestMusicSearchEndpoint:
+    def test_success(self, client):
+        result = {"results": [{"title": "Master of Puppets", "artist": "Metallica"}], "total": 1}
+        with unittest.mock.patch('arm.api.v1.metadata.search_music', return_value=result):
+            resp = client.get("/api/v1/metadata/music/search?q=Metallica")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+    def test_with_filters(self, client):
+        result = {"results": [], "total": 0}
+        with unittest.mock.patch('arm.api.v1.metadata.search_music',
+                                 return_value=result) as mock_fn:
+            resp = client.get(
+                "/api/v1/metadata/music/search?q=Metallica&artist=Metallica&format=CD&country=US"
+            )
+        assert resp.status_code == 200
+        # Verify filters were passed through
+        call_kwargs = mock_fn.call_args
+        assert call_kwargs[1]["format"] == "CD"
+        assert call_kwargs[1]["country"] == "US"
+
+    def test_missing_query(self, client):
+        resp = client.get("/api/v1/metadata/music/search")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/metadata/music/{release_id}
+# ---------------------------------------------------------------------------
+
+
+class TestMusicDetailEndpoint:
+    def test_success(self, client):
+        detail = {"title": "Master of Puppets", "artist": "Metallica", "tracks": []}
+        with unittest.mock.patch('arm.api.v1.metadata.get_music_details', return_value=detail):
+            resp = client.get("/api/v1/metadata/music/mbid-123")
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Master of Puppets"
+
+    def test_not_found(self, client):
+        with unittest.mock.patch('arm.api.v1.metadata.get_music_details', return_value=None):
+            resp = client.get("/api/v1/metadata/music/bad-mbid")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Route ordering: music/* must not be captured by {imdb_id} catch-all
+# ---------------------------------------------------------------------------
+
+
+class TestRouteOrdering:
+    def test_music_search_not_caught_by_imdb(self, client):
+        """GET /music/search should NOT match /{imdb_id} catch-all."""
+        result = {"results": [], "total": 0}
+        with unittest.mock.patch('arm.api.v1.metadata.search_music', return_value=result):
+            resp = client.get("/api/v1/metadata/music/search?q=test")
+        # Should be 200 from music search, not 503/404 from imdb handler
+        assert resp.status_code == 200
+
+    def test_test_key_not_caught_by_imdb(self, client):
+        """GET /test-key should NOT match /{imdb_id} catch-all."""
+        result = {"success": True, "message": "OK", "provider": "omdb"}
+        with unittest.mock.patch('arm.api.v1.metadata.test_configured_key', return_value=result):
+            resp = client.get("/api/v1/metadata/test-key")
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True

--- a/test/test_metadata_service.py
+++ b/test/test_metadata_service.py
@@ -1,0 +1,1391 @@
+"""Tests for arm/services/metadata.py — async metadata service.
+
+Covers: _get_keys, has_api_key, _extract_year, _escape_lucene,
+_normalize_omdb, _build_artist_credit, _extract_label, _extract_catalog_number,
+_extract_format, _omdb_search, _omdb_details, _tmdb_search, _tmdb_find,
+_tmdb_get_imdb, search, get_details, search_music, get_music_details,
+lookup_crc, test_configured_key.
+"""
+
+import asyncio
+import unittest.mock
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helper: run async functions from sync test methods
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Shared mock helpers
+# ---------------------------------------------------------------------------
+
+def _mock_httpx_responses(responses):
+    """Create a mock httpx client context manager that returns sequential responses."""
+    call_count = [0]
+
+    async def mock_get(url, **kwargs):
+        idx = min(call_count[0], len(responses) - 1)
+        call_count[0] += 1
+        resp = unittest.mock.MagicMock(spec=httpx.Response)
+        data = responses[idx]
+        resp.status_code = data.get("_status", 200)
+        resp.json.return_value = {k: v for k, v in data.items() if k != "_status"}
+        resp.text = str(resp.json.return_value)
+        resp.raise_for_status = unittest.mock.MagicMock()
+        if resp.status_code >= 400:
+            resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "error", request=unittest.mock.MagicMock(), response=resp
+            )
+        return resp
+
+    ctx = unittest.mock.AsyncMock()
+    ctx.get = mock_get
+    return ctx
+
+
+def _patch_http_client(responses):
+    """Patch _http_client to return a mock with sequential responses."""
+    ctx = _mock_httpx_responses(responses)
+    mock_client = unittest.mock.patch('arm.services.metadata._http_client')
+    return mock_client, ctx
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractYear:
+    def test_date_string(self):
+        from arm.services.metadata import _extract_year
+        assert _extract_year("1999-03-31") == "1999"
+
+    def test_year_only(self):
+        from arm.services.metadata import _extract_year
+        assert _extract_year("2001") == "2001"
+
+    def test_range_returns_first(self):
+        from arm.services.metadata import _extract_year
+        assert _extract_year("2011-2019") == "2011"
+
+    def test_dash_range(self):
+        from arm.services.metadata import _extract_year
+        assert _extract_year("2011–2019") == "2011"
+
+    def test_no_year_returns_raw(self):
+        from arm.services.metadata import _extract_year
+        assert _extract_year("unknown") == "unknown"
+
+    def test_empty_string(self):
+        from arm.services.metadata import _extract_year
+        assert _extract_year("") == ""
+
+
+class TestEscapeLucene:
+    def test_no_special_chars(self):
+        from arm.services.metadata import _escape_lucene
+        assert _escape_lucene("hello world") == "hello world"
+
+    def test_special_chars_escaped(self):
+        from arm.services.metadata import _escape_lucene
+        result = _escape_lucene("AC/DC (Live!)")
+        assert "\\/" in result
+        assert "\\(" in result
+        assert "\\)" in result
+        assert "\\!" in result
+
+    def test_empty_string(self):
+        from arm.services.metadata import _escape_lucene
+        assert _escape_lucene("") == ""
+
+    def test_plus_and_minus(self):
+        from arm.services.metadata import _escape_lucene
+        result = _escape_lucene("C++ and -flag")
+        assert "\\+" in result
+        assert "\\-" in result
+
+
+class TestNormalizeOmdb:
+    def test_movie_type(self):
+        from arm.services.metadata import _normalize_omdb
+        result = _normalize_omdb({"Title": "Matrix", "Year": "1999", "Type": "movie",
+                                   "imdbID": "tt0133093", "Poster": "http://img.com/p.jpg"})
+        assert result["title"] == "Matrix"
+        assert result["year"] == "1999"
+        assert result["media_type"] == "movie"
+        assert result["imdb_id"] == "tt0133093"
+        assert result["poster_url"] == "http://img.com/p.jpg"
+
+    def test_series_type(self):
+        from arm.services.metadata import _normalize_omdb
+        result = _normalize_omdb({"Title": "Friends", "Year": "1994–2004", "Type": "series",
+                                   "imdbID": "tt0108778", "Poster": "N/A"})
+        assert result["media_type"] == "series"
+        assert result["year"] == "1994"
+        assert result["poster_url"] is None
+
+    def test_unknown_type_defaults_to_movie(self):
+        from arm.services.metadata import _normalize_omdb
+        result = _normalize_omdb({"Title": "X", "Year": "2020", "Type": "game",
+                                   "imdbID": "tt0000001"})
+        assert result["media_type"] == "movie"
+
+    def test_missing_type_defaults_to_movie(self):
+        from arm.services.metadata import _normalize_omdb
+        result = _normalize_omdb({"Title": "X", "Year": "2020", "imdbID": "tt0000001"})
+        assert result["media_type"] == "movie"
+
+    def test_poster_na_normalized_to_none(self):
+        from arm.services.metadata import _normalize_omdb
+        result = _normalize_omdb({"Title": "X", "Year": "2020", "Poster": "N/A"})
+        assert result["poster_url"] is None
+
+    def test_missing_poster(self):
+        from arm.services.metadata import _normalize_omdb
+        result = _normalize_omdb({"Title": "X", "Year": "2020"})
+        assert result["poster_url"] is None
+
+
+class TestBuildArtistCredit:
+    def test_single_artist(self):
+        from arm.services.metadata import _build_artist_credit
+        result = _build_artist_credit([{"name": "Metallica"}])
+        assert result == "Metallica"
+
+    def test_multiple_artists_with_joinphrase(self):
+        from arm.services.metadata import _build_artist_credit
+        result = _build_artist_credit([
+            {"name": "Simon", "joinphrase": " & "},
+            {"name": "Garfunkel"},
+        ])
+        assert result == "Simon & Garfunkel"
+
+    def test_empty_list(self):
+        from arm.services.metadata import _build_artist_credit
+        assert _build_artist_credit([]) == ""
+
+
+class TestExtractLabel:
+    def test_valid_label(self):
+        from arm.services.metadata import _extract_label
+        result = _extract_label([{"label": {"name": "Virgin Records"}}])
+        assert result == "Virgin Records"
+
+    def test_empty_list(self):
+        from arm.services.metadata import _extract_label
+        assert _extract_label([]) is None
+
+    def test_missing_label_key(self):
+        from arm.services.metadata import _extract_label
+        assert _extract_label([{"catalog-number": "123"}]) is None
+
+
+class TestExtractCatalogNumber:
+    def test_valid_catalog(self):
+        from arm.services.metadata import _extract_catalog_number
+        assert _extract_catalog_number([{"catalog-number": "CDP 7464"}]) == "CDP 7464"
+
+    def test_empty_list(self):
+        from arm.services.metadata import _extract_catalog_number
+        assert _extract_catalog_number([]) is None
+
+
+class TestExtractFormat:
+    def test_valid_format(self):
+        from arm.services.metadata import _extract_format
+        assert _extract_format([{"format": "CD"}]) == "CD"
+
+    def test_empty_list(self):
+        from arm.services.metadata import _extract_format
+        assert _extract_format([]) is None
+
+    def test_missing_format(self):
+        from arm.services.metadata import _extract_format
+        assert _extract_format([{"tracks": []}]) is None
+
+
+# ---------------------------------------------------------------------------
+# _get_keys / has_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestGetKeys:
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'tmdb', 'OMDB_API_KEY': 'omdb123', 'TMDB_API_KEY': 'tmdb456',
+    })
+    def test_all_keys_present(self):
+        from arm.services.metadata import _get_keys
+        keys = _get_keys()
+        assert keys["provider"] == "tmdb"
+        assert keys["omdb_key"] == "omdb123"
+        assert keys["tmdb_key"] == "tmdb456"
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {}, clear=True)
+    def test_defaults_to_omdb(self):
+        from arm.services.metadata import _get_keys
+        keys = _get_keys()
+        assert keys["provider"] == "omdb"
+        assert not keys["omdb_key"]  # None or empty
+        assert not keys["tmdb_key"]  # None or empty
+
+
+class TestHasApiKey:
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {'ARM_API_KEY': 'secret'})
+    def test_key_configured(self):
+        from arm.services.metadata import has_api_key
+        assert has_api_key() is True
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {'ARM_API_KEY': ''})
+    def test_empty_key(self):
+        from arm.services.metadata import has_api_key
+        assert has_api_key() is False
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {})
+    def test_missing_key(self):
+        from arm.services.metadata import has_api_key
+        assert has_api_key() is False
+
+
+# ---------------------------------------------------------------------------
+# search() — provider routing
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key123',
+    })
+    def test_omdb_provider(self):
+        from arm.services.metadata import search
+        with unittest.mock.patch('arm.services.metadata._omdb_search',
+                                 return_value=[{"title": "Test"}]) as mock_omdb:
+            result = _run(search("Matrix", "1999"))
+            mock_omdb.assert_called_once_with("Matrix", "1999", "key123")
+        assert result == [{"title": "Test"}]
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'tmdb', 'TMDB_API_KEY': 'tmdb_key',
+    })
+    def test_tmdb_provider(self):
+        from arm.services.metadata import search
+        with unittest.mock.patch('arm.services.metadata._tmdb_search',
+                                 return_value=[{"title": "Test"}]) as mock_tmdb:
+            result = _run(search("Matrix"))
+            mock_tmdb.assert_called_once_with("Matrix", None, "tmdb_key")
+        assert result == [{"title": "Test"}]
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'tmdb', 'TMDB_API_KEY': '', 'OMDB_API_KEY': 'omdb_fallback',
+    })
+    def test_tmdb_falls_back_to_omdb(self):
+        from arm.services.metadata import search
+        with unittest.mock.patch('arm.services.metadata._omdb_search',
+                                 return_value=[]) as mock_omdb:
+            _run(search("Matrix"))
+            mock_omdb.assert_called_once_with("Matrix", None, "omdb_fallback")
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'tmdb', 'TMDB_API_KEY': '', 'OMDB_API_KEY': '',
+    })
+    def test_tmdb_no_fallback_raises(self):
+        from arm.services.metadata import search, MetadataConfigError
+        with pytest.raises(MetadataConfigError):
+            _run(search("Matrix"))
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': '',
+    })
+    def test_no_keys_raises(self):
+        from arm.services.metadata import search, MetadataConfigError
+        with pytest.raises(MetadataConfigError):
+            _run(search("Matrix"))
+
+
+# ---------------------------------------------------------------------------
+# get_details() — provider routing
+# ---------------------------------------------------------------------------
+
+
+class TestGetDetails:
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key123',
+    })
+    def test_omdb_provider(self):
+        from arm.services.metadata import get_details
+        with unittest.mock.patch('arm.services.metadata._omdb_details',
+                                 return_value={"title": "Matrix"}) as mock_fn:
+            result = _run(get_details("tt0133093"))
+            mock_fn.assert_called_once_with("tt0133093", "key123")
+        assert result["title"] == "Matrix"
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'tmdb', 'TMDB_API_KEY': 'tmdb_key',
+    })
+    def test_tmdb_provider(self):
+        from arm.services.metadata import get_details
+        with unittest.mock.patch('arm.services.metadata._tmdb_find',
+                                 return_value={"title": "Matrix"}) as mock_fn:
+            result = _run(get_details("tt0133093"))
+            mock_fn.assert_called_once_with("tt0133093", "tmdb_key")
+        assert result["title"] == "Matrix"
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key123',
+    })
+    def test_returns_none_when_not_found(self):
+        from arm.services.metadata import get_details
+        with unittest.mock.patch('arm.services.metadata._omdb_details', return_value=None):
+            result = _run(get_details("tt9999999"))
+        assert result is None
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': '',
+    })
+    def test_no_keys_raises(self):
+        from arm.services.metadata import get_details, MetadataConfigError
+        with pytest.raises(MetadataConfigError):
+            _run(get_details("tt0133093"))
+
+
+# ---------------------------------------------------------------------------
+# _omdb_search
+# ---------------------------------------------------------------------------
+
+
+class TestOmdbSearch:
+    def test_search_success(self):
+        from arm.services.metadata import _omdb_search
+        search_resp = {
+            "Response": "True",
+            "Search": [{"Title": "The Matrix", "Year": "1999", "imdbID": "tt0133093",
+                         "Type": "movie", "Poster": "http://img.com/matrix.jpg"}],
+        }
+        ctx = _mock_httpx_responses([search_resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_omdb_search("The Matrix", "1999", "test_key"))
+        assert len(result) == 1
+        assert result[0]["title"] == "The Matrix"
+
+    def test_search_fails_fallback_to_exact(self):
+        from arm.services.metadata import _omdb_search
+        search_fail = {"Response": "False", "Error": "Too many results."}
+        exact_match = {"Response": "True", "Title": "9", "Year": "2009",
+                       "Type": "movie", "imdbID": "tt0472033", "Poster": "N/A"}
+        ctx = _mock_httpx_responses([search_fail, exact_match])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_omdb_search("9", "2009", "test_key"))
+        assert len(result) == 1
+        assert result[0]["title"] == "9"
+
+    def test_both_fail_returns_empty(self):
+        from arm.services.metadata import _omdb_search
+        fail_resp = {"Response": "False", "Error": "Movie not found!"}
+        ctx = _mock_httpx_responses([fail_resp, fail_resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_omdb_search("xyznonexistent", None, "test_key"))
+        assert result == []
+
+    def test_auth_error_raises(self):
+        from arm.services.metadata import _omdb_search, MetadataConfigError
+        ctx = _mock_httpx_responses([{"_status": 401}])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            with pytest.raises(MetadataConfigError):
+                _run(_omdb_search("Matrix", None, "bad_key"))
+
+
+# ---------------------------------------------------------------------------
+# _omdb_details
+# ---------------------------------------------------------------------------
+
+
+class TestOmdbDetails:
+    def test_valid_result(self):
+        from arm.services.metadata import _omdb_details
+        resp = {"Response": "True", "Title": "Matrix", "Year": "1999", "Type": "movie",
+                "imdbID": "tt0133093", "Poster": "http://img.com/p.jpg",
+                "Plot": "A computer hacker learns..."}
+        ctx = _mock_httpx_responses([resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_omdb_details("tt0133093", "test_key"))
+        assert result["title"] == "Matrix"
+        assert result["plot"] == "A computer hacker learns..."
+        assert result["background_url"] is None
+
+    def test_plot_na_normalized(self):
+        from arm.services.metadata import _omdb_details
+        resp = {"Response": "True", "Title": "X", "Year": "2020", "Type": "movie",
+                "imdbID": "tt0000001", "Plot": "N/A"}
+        ctx = _mock_httpx_responses([resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_omdb_details("tt0000001", "test_key"))
+        assert result["plot"] is None
+
+    def test_not_found_returns_none(self):
+        from arm.services.metadata import _omdb_details
+        resp = {"Response": "False", "Error": "Incorrect IMDb ID."}
+        ctx = _mock_httpx_responses([resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_omdb_details("tt9999999", "test_key"))
+        assert result is None
+
+    def test_auth_error_raises(self):
+        from arm.services.metadata import _omdb_details, MetadataConfigError
+        ctx = _mock_httpx_responses([{"_status": 403}])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            with pytest.raises(MetadataConfigError):
+                _run(_omdb_details("tt0133093", "bad_key"))
+
+
+# ---------------------------------------------------------------------------
+# _tmdb_search
+# ---------------------------------------------------------------------------
+
+
+class TestTmdbSearch:
+    def test_movie_results(self):
+        from arm.services.metadata import _tmdb_search
+        movie_resp = {
+            "total_results": 1,
+            "results": [{"id": 603, "title": "The Matrix", "release_date": "1999-03-31",
+                         "poster_path": "/poster.jpg"}],
+        }
+        ctx = _mock_httpx_responses([movie_resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client, \
+             unittest.mock.patch('arm.services.metadata._tmdb_get_imdb', return_value="tt0133093"):
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_search("The Matrix", "1999", "tmdb_key"))
+        assert len(result) == 1
+        assert result[0]["title"] == "The Matrix"
+        assert result[0]["imdb_id"] == "tt0133093"
+
+    def test_no_movies_falls_back_to_tv(self):
+        from arm.services.metadata import _tmdb_search
+        empty_movies = {"total_results": 0, "results": []}
+        tv_resp = {
+            "total_results": 1,
+            "results": [{"id": 1396, "name": "Breaking Bad", "first_air_date": "2008-01-20",
+                         "poster_path": "/bb.jpg"}],
+        }
+        ctx = _mock_httpx_responses([empty_movies, tv_resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client, \
+             unittest.mock.patch('arm.services.metadata._tmdb_get_imdb', return_value="tt0903747"):
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_search("Breaking Bad", None, "tmdb_key"))
+        assert len(result) == 1
+        assert result[0]["title"] == "Breaking Bad"
+        assert result[0]["media_type"] == "series"
+
+    def test_auth_error_raises(self):
+        from arm.services.metadata import _tmdb_search, MetadataConfigError
+        ctx = _mock_httpx_responses([{"_status": 401}])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            with pytest.raises(MetadataConfigError):
+                _run(_tmdb_search("Matrix", None, "bad_key"))
+
+    def test_no_results_returns_empty(self):
+        from arm.services.metadata import _tmdb_search
+        empty = {"total_results": 0, "results": []}
+        ctx = _mock_httpx_responses([empty, empty])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_search("xyznonexistent", None, "tmdb_key"))
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _tmdb_find
+# ---------------------------------------------------------------------------
+
+
+class TestTmdbFind:
+    def test_movie_result(self):
+        from arm.services.metadata import _tmdb_find
+        resp = {
+            "movie_results": [{"title": "The Matrix", "release_date": "1999-03-31",
+                               "poster_path": "/matrix.jpg", "backdrop_path": "/matrix_bg.jpg",
+                               "overview": "A hacker discovers reality."}],
+            "tv_results": [],
+        }
+        ctx = _mock_httpx_responses([resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_find("tt0133093", "tmdb_key"))
+        assert result["title"] == "The Matrix"
+        assert result["media_type"] == "movie"
+        assert result["poster_url"] is not None
+        assert result["background_url"] is not None
+        assert result["plot"] == "A hacker discovers reality."
+
+    def test_tv_result(self):
+        from arm.services.metadata import _tmdb_find
+        resp = {
+            "movie_results": [],
+            "tv_results": [{"name": "Breaking Bad", "first_air_date": "2008-01-20",
+                            "poster_path": "/bb.jpg", "backdrop_path": None, "overview": ""}],
+        }
+        ctx = _mock_httpx_responses([resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_find("tt0903747", "tmdb_key"))
+        assert result["title"] == "Breaking Bad"
+        assert result["media_type"] == "series"
+        assert result["background_url"] is None
+        assert result["plot"] is None  # empty string → None
+
+    def test_not_found_returns_none(self):
+        from arm.services.metadata import _tmdb_find
+        resp = {"movie_results": [], "tv_results": []}
+        ctx = _mock_httpx_responses([resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_find("tt9999999", "tmdb_key"))
+        assert result is None
+
+    def test_auth_error_raises(self):
+        from arm.services.metadata import _tmdb_find, MetadataConfigError
+        ctx = _mock_httpx_responses([{"_status": 401}])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            with pytest.raises(MetadataConfigError):
+                _run(_tmdb_find("tt0133093", "bad_key"))
+
+
+# ---------------------------------------------------------------------------
+# _tmdb_get_imdb
+# ---------------------------------------------------------------------------
+
+
+class TestTmdbGetImdb:
+    def test_movie_direct(self):
+        from arm.services.metadata import _tmdb_get_imdb
+        movie_resp = {"external_ids": {"imdb_id": "tt0133093"}}
+        ctx = _mock_httpx_responses([movie_resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_get_imdb(603, "movie", "key"))
+        assert result == "tt0133093"
+
+    def test_series_direct(self):
+        from arm.services.metadata import _tmdb_get_imdb
+        tv_resp = {"imdb_id": "tt0903747"}
+        ctx = _mock_httpx_responses([tv_resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_get_imdb(1396, "series", "key"))
+        assert result == "tt0903747"
+
+    def test_series_fallback_to_movie(self):
+        from arm.services.metadata import _tmdb_get_imdb
+        tv_fail = {"status_code": 34, "status_message": "not found"}
+        movie_resp = {"external_ids": {"imdb_id": "tt0133093"}}
+        ctx = _mock_httpx_responses([tv_fail, movie_resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_get_imdb(603, "series", "key"))
+        assert result == "tt0133093"
+
+    def test_movie_fallback_to_tv(self):
+        """Movie endpoint fails (status_code in response) → falls back to TV external_ids."""
+        from arm.services.metadata import _tmdb_get_imdb
+        movie_fail = {"status_code": 34, "status_message": "not found"}
+        tv_resp = {"imdb_id": "tt0903747"}
+        ctx = _mock_httpx_responses([movie_fail, tv_resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_get_imdb(1396, "movie", "key"))
+        assert result == "tt0903747"
+
+    def test_movie_both_fail_returns_none(self):
+        """Both movie and TV endpoints fail → returns None."""
+        from arm.services.metadata import _tmdb_get_imdb
+        fail = {"status_code": 34, "status_message": "not found"}
+        ctx = _mock_httpx_responses([fail, fail])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_get_imdb(999, "movie", "key"))
+        assert result is None
+
+    def test_series_both_fail_returns_none(self):
+        """Series TV and movie fallback both fail → returns None."""
+        from arm.services.metadata import _tmdb_get_imdb
+        fail = {"status_code": 34, "status_message": "not found"}
+        ctx = _mock_httpx_responses([fail, fail])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_get_imdb(999, "series", "key"))
+        assert result is None
+
+    def test_exception_returns_none(self):
+        from arm.services.metadata import _tmdb_get_imdb
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(
+                side_effect=httpx.ConnectError("offline"))
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_get_imdb(603, "movie", "key"))
+        assert result is None
+
+    def test_value_error_returns_none(self):
+        """Non-httpx exceptions (ValueError, KeyError) also caught → returns None."""
+        from arm.services.metadata import _tmdb_get_imdb
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(
+                side_effect=ValueError("bad json"))
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(_tmdb_get_imdb(603, "movie", "key"))
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# search_music / get_music_details
+# ---------------------------------------------------------------------------
+
+
+class TestSearchMusic:
+    def test_basic_search(self):
+        from arm.services.metadata import search_music
+        mb_resp = {
+            "count": 1,
+            "releases": [{
+                "id": "mbid-123",
+                "title": "Master of Puppets",
+                "artist-credit": [{"name": "Metallica"}],
+                "date": "1986-03-03",
+                "track-count": 8,
+                "media": [{"format": "CD"}],
+                "label-info": [{"label": {"name": "Elektra"}}],
+                "release-group": {"primary-type": "Album"},
+                "country": "US",
+            }],
+        }
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mb_resp
+        mock_resp.raise_for_status = unittest.mock.MagicMock()
+
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+
+        with unittest.mock.patch('arm.services.metadata._mb_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(search_music("Metallica"))
+
+        assert result["total"] == 1
+        assert len(result["results"]) == 1
+        assert result["results"][0]["title"] == "Master of Puppets"
+        assert result["results"][0]["artist"] == "Metallica"
+        assert result["results"][0]["format"] == "CD"
+        assert result["results"][0]["label"] == "Elektra"
+
+    def test_with_artist_filter(self):
+        """Artist filter wraps query in release:"..." AND artist:"..." Lucene syntax."""
+        from arm.services.metadata import search_music
+        mb_resp = {"count": 0, "releases": []}
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mb_resp
+        mock_resp.raise_for_status = unittest.mock.MagicMock()
+
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+
+        with unittest.mock.patch('arm.services.metadata._mb_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            _run(search_music("Master of Puppets", artist="Metallica"))
+
+        call_params = ctx.get.call_args[1]["params"]
+        assert 'artist:"Metallica"' in call_params["query"]
+        assert 'release:"Master of Puppets"' in call_params["query"]
+
+    def test_with_all_filters(self):
+        """All optional filters are included in the Lucene query."""
+        from arm.services.metadata import search_music
+        mb_resp = {"count": 0, "releases": []}
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mb_resp
+        mock_resp.raise_for_status = unittest.mock.MagicMock()
+
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+
+        with unittest.mock.patch('arm.services.metadata._mb_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            _run(search_music("Test", release_type="Album", format="CD",
+                              country="US", status="Official", tracks=12))
+
+        call_params = ctx.get.call_args[1]["params"]
+        query = call_params["query"]
+        assert "type:Album" in query
+        assert 'format:"CD"' in query
+        assert "country:US" in query
+        assert "status:Official" in query
+        assert "tracks:12" in query
+
+    def test_offset_passed_when_nonzero(self):
+        """Offset > 0 is included in the HTTP params."""
+        from arm.services.metadata import search_music
+        mb_resp = {"count": 0, "releases": []}
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mb_resp
+        mock_resp.raise_for_status = unittest.mock.MagicMock()
+
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+
+        with unittest.mock.patch('arm.services.metadata._mb_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            _run(search_music("Test", offset=30))
+
+        call_params = ctx.get.call_args[1]["params"]
+        assert call_params["offset"] == "30"
+
+    def test_network_error_returns_empty(self):
+        from arm.services.metadata import search_music
+        with unittest.mock.patch('arm.services.metadata._mb_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(
+                side_effect=httpx.ConnectError("offline"))
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(search_music("Metallica"))
+        assert result == {"results": [], "total": 0}
+
+
+class TestGetMusicDetails:
+    def test_valid_release(self):
+        from arm.services.metadata import get_music_details
+        mb_resp = {
+            "id": "mbid-123",
+            "title": "Master of Puppets",
+            "artist-credit": [{"name": "Metallica"}],
+            "date": "1986-03-03",
+            "media": [{"format": "CD", "track-count": 2, "tracks": [
+                {"number": "1", "title": "Battery", "length": 312000,
+                 "recording": {"title": "Battery", "length": 312000}},
+                {"number": "2", "title": "Master", "length": 515000,
+                 "recording": {"title": "Master of Puppets", "length": 515000}},
+            ]}],
+            "label-info": [{"label": {"name": "Elektra"}, "catalog-number": "9 60439-2"}],
+            "release-group": {"primary-type": "Album"},
+            "country": "US",
+            "barcode": "075596043922",
+            "status": "Official",
+        }
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mb_resp
+        mock_resp.raise_for_status = unittest.mock.MagicMock()
+
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+
+        with unittest.mock.patch('arm.services.metadata._mb_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(get_music_details("mbid-123"))
+
+        assert result["title"] == "Master of Puppets"
+        assert result["artist"] == "Metallica"
+        assert len(result["tracks"]) == 2
+        assert result["tracks"][0]["title"] == "Battery"
+        assert result["barcode"] == "075596043922"
+        assert result["catalog_number"] == "9 60439-2"
+
+    def test_track_length_fallback_to_recording(self):
+        """When track.length is None, falls back to recording.length."""
+        from arm.services.metadata import get_music_details
+        mb_resp = {
+            "id": "mbid-456", "title": "Album",
+            "artist-credit": [{"name": "Artist"}], "date": "2020",
+            "media": [{"format": "CD", "track-count": 1, "tracks": [
+                {"number": "1", "title": "Song", "length": None,
+                 "recording": {"title": "Song", "length": 240000}},
+            ]}],
+            "label-info": [], "release-group": {},
+        }
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mb_resp
+        mock_resp.raise_for_status = unittest.mock.MagicMock()
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+
+        with unittest.mock.patch('arm.services.metadata._mb_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(get_music_details("mbid-456"))
+
+        assert result["tracks"][0]["length_ms"] == 240000
+
+    def test_multiple_media(self):
+        """Release with 2 discs (media) accumulates all tracks."""
+        from arm.services.metadata import get_music_details
+        mb_resp = {
+            "id": "mbid-789", "title": "Double Album",
+            "artist-credit": [{"name": "Artist"}], "date": "2020",
+            "media": [
+                {"format": "CD", "track-count": 1, "tracks": [
+                    {"number": "1", "length": 100, "recording": {"title": "Disc 1 Track"}},
+                ]},
+                {"format": "CD", "track-count": 1, "tracks": [
+                    {"number": "1", "length": 200, "recording": {"title": "Disc 2 Track"}},
+                ]},
+            ],
+            "label-info": [], "release-group": {},
+        }
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mb_resp
+        mock_resp.raise_for_status = unittest.mock.MagicMock()
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+
+        with unittest.mock.patch('arm.services.metadata._mb_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(get_music_details("mbid-789"))
+
+        assert len(result["tracks"]) == 2
+        assert result["track_count"] == 2
+
+    def test_empty_barcode_normalized_to_none(self):
+        """Empty barcode string becomes None."""
+        from arm.services.metadata import get_music_details
+        mb_resp = {
+            "id": "mbid-abc", "title": "Album",
+            "artist-credit": [{"name": "X"}], "date": "",
+            "media": [{"format": "CD", "track-count": 0, "tracks": []}],
+            "label-info": [], "release-group": {}, "barcode": "",
+        }
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mb_resp
+        mock_resp.raise_for_status = unittest.mock.MagicMock()
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+
+        with unittest.mock.patch('arm.services.metadata._mb_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(get_music_details("mbid-abc"))
+
+        assert result["barcode"] is None
+
+    def test_404_returns_none(self):
+        from arm.services.metadata import get_music_details
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 404
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+
+        with unittest.mock.patch('arm.services.metadata._mb_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(get_music_details("bad-mbid"))
+        assert result is None
+
+    def test_network_error_returns_none(self):
+        from arm.services.metadata import get_music_details
+        with unittest.mock.patch('arm.services.metadata._mb_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(
+                side_effect=httpx.ConnectError("offline"))
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(get_music_details("mbid-123"))
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# lookup_crc
+# ---------------------------------------------------------------------------
+
+
+class TestLookupCrc:
+    def test_found(self):
+        from arm.services.metadata import lookup_crc
+        crc_resp = {
+            "success": True,
+            "results": {"0": {
+                "title": "The Matrix", "year": "1999", "imdb_id": "tt0133093",
+                "tmdb_id": "603", "video_type": "movie", "disctype": "dvd",
+                "label": "MATRIX", "poster_img": "http://img.com/p.jpg",
+                "hasnicetitle": "True", "validated": "True", "date_added": "2023-01-01",
+            }},
+        }
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = crc_resp
+        mock_resp.raise_for_status = unittest.mock.MagicMock()
+
+        with unittest.mock.patch('httpx.AsyncClient') as mock_cls:
+            ctx = unittest.mock.AsyncMock()
+            ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+            mock_cls.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_cls.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(lookup_crc("abc123"))
+
+        assert result["found"] is True
+        assert len(result["results"]) == 1
+        assert result["results"][0]["title"] == "The Matrix"
+        assert result["results"][0]["poster_url"] == "http://img.com/p.jpg"
+
+    def test_not_found(self):
+        from arm.services.metadata import lookup_crc
+        crc_resp = {"success": False}
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = crc_resp
+        mock_resp.raise_for_status = unittest.mock.MagicMock()
+
+        with unittest.mock.patch('httpx.AsyncClient') as mock_cls:
+            ctx = unittest.mock.AsyncMock()
+            ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+            mock_cls.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_cls.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(lookup_crc("unknown_crc"))
+
+        assert result["found"] is False
+        assert result["results"] == []
+
+    def test_network_error(self):
+        from arm.services.metadata import lookup_crc
+        with unittest.mock.patch('httpx.AsyncClient') as mock_cls:
+            mock_cls.return_value.__aenter__ = unittest.mock.AsyncMock(
+                side_effect=httpx.ConnectError("offline"))
+            mock_cls.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(lookup_crc("abc123"))
+
+        assert result["found"] is False
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# test_configured_key
+# ---------------------------------------------------------------------------
+
+
+class TestConfiguredKey:
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': '',
+    })
+    def test_no_key_returns_failure(self):
+        from arm.services.metadata import test_configured_key
+        result = _run(test_configured_key())
+        assert result["success"] is False
+        assert "No API key" in result["message"]
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'valid_key',
+    })
+    def test_omdb_valid_key(self):
+        from arm.services.metadata import test_configured_key
+        resp = {"Response": "True", "Title": "The Matrix"}
+        ctx = _mock_httpx_responses([resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is True
+        assert result["provider"] == "omdb"
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'bad_key',
+    })
+    def test_omdb_auth_error(self):
+        from arm.services.metadata import test_configured_key
+        ctx = _mock_httpx_responses([{"_status": 401}])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is False
+        assert "Invalid" in result["message"]
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key',
+    })
+    def test_omdb_invalid_key_in_response(self):
+        from arm.services.metadata import test_configured_key
+        resp = {"Response": "False", "Error": "Invalid API key!"}
+        ctx = _mock_httpx_responses([resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is False
+        assert "Invalid" in result["message"]
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'tmdb', 'TMDB_API_KEY': 'tmdb_key',
+    })
+    def test_tmdb_valid_key(self):
+        from arm.services.metadata import test_configured_key
+        ctx = _mock_httpx_responses([{"images": {}}])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is True
+        assert result["provider"] == "tmdb"
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key',
+    })
+    def test_timeout(self):
+        from arm.services.metadata import test_configured_key
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(
+                side_effect=httpx.TimeoutException("timeout"))
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is False
+        assert "timed out" in result["message"]
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key',
+    })
+    def test_connect_error(self):
+        from arm.services.metadata import test_configured_key
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(
+                side_effect=httpx.ConnectError("dns failure"))
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is False
+        assert "network" in result["message"].lower() or "connect" in result["message"].lower()
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key',
+    })
+    def test_omdb_non_json_unicode_error(self):
+        """UnicodeDecodeError from resp.json() is handled like ValueError."""
+        from arm.services.metadata import test_configured_key
+
+        async def mock_get(url, **kwargs):
+            resp = unittest.mock.MagicMock(spec=httpx.Response)
+            resp.status_code = 200
+            resp.json.side_effect = UnicodeDecodeError("utf-8", b"", 0, 1, "bad")
+            resp.text = ""
+            return resp
+
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = mock_get
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is False
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key',
+    })
+    def test_omdb_non_json_non_200(self):
+        """Non-JSON response with non-200 status returns HTTP status in message."""
+        from arm.services.metadata import test_configured_key
+
+        async def mock_get(url, **kwargs):
+            resp = unittest.mock.MagicMock(spec=httpx.Response)
+            resp.status_code = 500
+            resp.json.side_effect = ValueError("not JSON")
+            resp.text = "Server Error"
+            return resp
+
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = mock_get
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is False
+        assert "500" in result["message"]
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key',
+    })
+    def test_omdb_error_message_not_invalid_key(self):
+        """OMDb error message that isn't 'Invalid API key' returns the actual error."""
+        from arm.services.metadata import test_configured_key
+        resp = {"Response": "False", "Error": "Request limit reached!"}
+        ctx = _mock_httpx_responses([resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is False
+        assert "Request limit reached" in result["message"]
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key',
+    })
+    def test_omdb_no_response_no_error_accepted(self):
+        """OMDb response without Response=True and no Error → key accepted."""
+        from arm.services.metadata import test_configured_key
+        resp = {"some": "data"}  # no Response, no Error
+        ctx = _mock_httpx_responses([resp])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is True
+        assert "accepted" in result["message"].lower()
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'tmdb', 'TMDB_API_KEY': 'key',
+    })
+    def test_tmdb_unexpected_status(self):
+        """TMDb returns unexpected status code (not 200, 401, 403)."""
+        from arm.services.metadata import test_configured_key
+        ctx = _mock_httpx_responses([{"_status": 500}])
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is False
+        assert "500" in result["message"]
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key',
+    })
+    def test_generic_exception(self):
+        """Generic Exception is caught and returns failure with type name."""
+        from arm.services.metadata import test_configured_key
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(
+                side_effect=RuntimeError("unexpected"))
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is False
+        assert "RuntimeError" in result["message"]
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'OMDB_API_KEY': 'key',
+    })
+    def test_omdb_non_json_response(self):
+        from arm.services.metadata import test_configured_key
+
+        async def mock_get(url, **kwargs):
+            resp = unittest.mock.MagicMock(spec=httpx.Response)
+            resp.status_code = 200
+            resp.json.side_effect = ValueError("not JSON")
+            resp.text = "<html>error</html>"
+            return resp
+
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = mock_get
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(test_configured_key())
+        assert result["success"] is False
+        assert "invalid response" in result["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# _omdb_search — fallback ?t= auth error
+# ---------------------------------------------------------------------------
+
+
+class TestOmdbSearchFallback:
+    """Test _omdb_search fallback ?t= exact match path."""
+
+    def test_fallback_auth_error_raises(self):
+        """Auth error (401/403) on fallback ?t= raises MetadataConfigError."""
+        from arm.services.metadata import _omdb_search, MetadataConfigError
+
+        call_count = [0]
+
+        async def mock_get(url, **kwargs):
+            call_count[0] += 1
+            resp = unittest.mock.MagicMock(spec=httpx.Response)
+            if call_count[0] == 1:
+                # First ?s= call returns no results
+                resp.status_code = 200
+                resp.json.return_value = {"Response": "False"}
+            else:
+                # Second ?t= call returns 401
+                resp.status_code = 401
+            return resp
+
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = mock_get
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            with pytest.raises(MetadataConfigError):
+                _run(_omdb_search("test", None, "badkey"))
+
+    def test_fallback_returns_single_result(self):
+        """Fallback ?t= returns a single result when ?s= finds nothing."""
+        from arm.services.metadata import _omdb_search
+
+        call_count = [0]
+
+        async def mock_get(url, **kwargs):
+            call_count[0] += 1
+            resp = unittest.mock.MagicMock(spec=httpx.Response)
+            resp.status_code = 200
+            if call_count[0] == 1:
+                resp.json.return_value = {"Response": "False"}
+            else:
+                resp.json.return_value = {
+                    "Response": "True", "Title": "42", "Year": "2013",
+                    "imdbID": "tt0453562", "Type": "movie", "Poster": "N/A"
+                }
+            return resp
+
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = mock_get
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            results = _run(_omdb_search("42", None, "key"))
+        assert len(results) == 1
+        assert results[0]["title"] == "42"
+
+    def test_fallback_no_results(self):
+        """Fallback ?t= also returns nothing — empty list."""
+        from arm.services.metadata import _omdb_search
+
+        call_count = [0]
+
+        async def mock_get(url, **kwargs):
+            call_count[0] += 1
+            resp = unittest.mock.MagicMock(spec=httpx.Response)
+            resp.status_code = 200
+            resp.json.return_value = {"Response": "False"}
+            return resp
+
+        ctx = unittest.mock.AsyncMock()
+        ctx.get = mock_get
+        with unittest.mock.patch('arm.services.metadata._http_client') as mock_client:
+            mock_client.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_client.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            results = _run(_omdb_search("nonexistent", None, "key"))
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# lookup_crc — entries with missing optional keys
+# ---------------------------------------------------------------------------
+
+
+class TestLookupCrcEdgeCases:
+    """Test lookup_crc with missing fields in CRC database results."""
+
+    def test_missing_optional_fields_default_to_empty(self):
+        """CRC result entries with missing keys get empty string defaults."""
+        from arm.services.metadata import lookup_crc
+
+        raw_response = {
+            "success": True,
+            "results": {
+                "1": {"title": "Matrix"}  # all other fields missing
+            }
+        }
+        with unittest.mock.patch('arm.services.metadata.httpx') as mock_httpx:
+            mock_client = unittest.mock.AsyncMock()
+            mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = raw_response
+            mock_resp.raise_for_status = unittest.mock.MagicMock()
+            mock_client.get.return_value = mock_resp
+            mock_httpx.AsyncClient.return_value.__aenter__ = unittest.mock.AsyncMock(
+                return_value=mock_client)
+            mock_httpx.AsyncClient.return_value.__aexit__ = unittest.mock.AsyncMock(
+                return_value=False)
+            result = _run(lookup_crc("abc123"))
+        assert result["found"] is True
+        assert len(result["results"]) == 1
+        entry = result["results"][0]
+        assert entry["title"] == "Matrix"
+        assert entry["year"] == ""
+        assert entry["imdb_id"] == ""
+        assert entry["video_type"] == ""
+
+    def test_empty_results_dict(self):
+        """Success=True but empty results dict returns found=False."""
+        from arm.services.metadata import lookup_crc
+
+        raw_response = {"success": True, "results": {}}
+        with unittest.mock.patch('arm.services.metadata.httpx') as mock_httpx:
+            mock_client = unittest.mock.AsyncMock()
+            mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = raw_response
+            mock_resp.raise_for_status = unittest.mock.MagicMock()
+            mock_client.get.return_value = mock_resp
+            mock_httpx.AsyncClient.return_value.__aenter__ = unittest.mock.AsyncMock(
+                return_value=mock_client)
+            mock_httpx.AsyncClient.return_value.__aexit__ = unittest.mock.AsyncMock(
+                return_value=False)
+            result = _run(lookup_crc("abc123"))
+        assert result["found"] is False
+        assert result["results"] == []
+
+    def test_multiple_crc_results(self):
+        """Multiple results in the CRC database response are all returned."""
+        from arm.services.metadata import lookup_crc
+
+        raw_response = {
+            "success": True,
+            "results": {
+                "1": {"title": "Matrix", "year": "1999", "imdb_id": "tt0133093",
+                       "video_type": "movie", "poster_img": "http://img/1.jpg"},
+                "2": {"title": "Matrix Reloaded", "year": "2003",
+                       "imdb_id": "tt0234215", "video_type": "movie"},
+            }
+        }
+        with unittest.mock.patch('arm.services.metadata.httpx') as mock_httpx:
+            mock_client = unittest.mock.AsyncMock()
+            mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = raw_response
+            mock_resp.raise_for_status = unittest.mock.MagicMock()
+            mock_client.get.return_value = mock_resp
+            mock_httpx.AsyncClient.return_value.__aenter__ = unittest.mock.AsyncMock(
+                return_value=mock_client)
+            mock_httpx.AsyncClient.return_value.__aexit__ = unittest.mock.AsyncMock(
+                return_value=False)
+            result = _run(lookup_crc("abc123"))
+        assert result["found"] is True
+        assert len(result["results"]) == 2

--- a/test/test_metadata_sync.py
+++ b/test/test_metadata_sync.py
@@ -1,0 +1,100 @@
+"""Tests for arm/services/metadata_sync.py — sync wrappers for the ripper.
+
+Covers: search_sync, get_details_sync, lookup_crc_sync — including
+MetadataConfigError propagation and network error handling.
+"""
+
+import unittest.mock
+
+import httpx
+import pytest
+
+
+class TestSearchSync:
+    def test_returns_results(self):
+        from arm.services.metadata_sync import search_sync
+        results = [{"title": "Matrix", "year": "1999"}]
+        with unittest.mock.patch('arm.services.metadata.search',
+                                 return_value=results) as mock_search:
+            result = search_sync("Matrix", "1999")
+            # asyncio.run calls the coroutine
+        assert result == results
+
+    def test_propagates_metadata_config_error(self):
+        from arm.services.metadata import MetadataConfigError
+        from arm.services.metadata_sync import search_sync
+        with unittest.mock.patch('arm.services.metadata.search',
+                                 side_effect=MetadataConfigError("no key")):
+            with pytest.raises(MetadataConfigError):
+                search_sync("Matrix")
+
+    def test_network_error_returns_empty(self):
+        from arm.services.metadata_sync import search_sync
+        with unittest.mock.patch('arm.services.metadata.search',
+                                 side_effect=httpx.ConnectError("offline")):
+            result = search_sync("Matrix")
+        assert result == []
+
+    def test_timeout_returns_empty(self):
+        from arm.services.metadata_sync import search_sync
+        with unittest.mock.patch('arm.services.metadata.search',
+                                 side_effect=httpx.TimeoutException("timeout")):
+            result = search_sync("Matrix")
+        assert result == []
+
+    def test_http_error_returns_empty(self):
+        from arm.services.metadata_sync import search_sync
+        with unittest.mock.patch('arm.services.metadata.search',
+                                 side_effect=httpx.HTTPError("500")):
+            result = search_sync("Matrix")
+        assert result == []
+
+
+class TestGetDetailsSync:
+    def test_returns_details(self):
+        from arm.services.metadata_sync import get_details_sync
+        detail = {"title": "Matrix", "year": "1999", "imdb_id": "tt0133093"}
+        with unittest.mock.patch('arm.services.metadata.get_details',
+                                 return_value=detail):
+            result = get_details_sync("tt0133093")
+        assert result == detail
+
+    def test_returns_none(self):
+        from arm.services.metadata_sync import get_details_sync
+        with unittest.mock.patch('arm.services.metadata.get_details',
+                                 return_value=None):
+            result = get_details_sync("tt9999999")
+        assert result is None
+
+    def test_propagates_metadata_config_error(self):
+        from arm.services.metadata import MetadataConfigError
+        from arm.services.metadata_sync import get_details_sync
+        with unittest.mock.patch('arm.services.metadata.get_details',
+                                 side_effect=MetadataConfigError("no key")):
+            with pytest.raises(MetadataConfigError):
+                get_details_sync("tt0133093")
+
+    def test_network_error_returns_none(self):
+        from arm.services.metadata_sync import get_details_sync
+        with unittest.mock.patch('arm.services.metadata.get_details',
+                                 side_effect=httpx.ConnectError("offline")):
+            result = get_details_sync("tt0133093")
+        assert result is None
+
+
+class TestLookupCrcSync:
+    def test_returns_result(self):
+        from arm.services.metadata_sync import lookup_crc_sync
+        crc_result = {"found": True, "results": [{"title": "Matrix"}]}
+        with unittest.mock.patch('arm.services.metadata.lookup_crc',
+                                 return_value=crc_result):
+            result = lookup_crc_sync("abc123")
+        assert result["found"] is True
+
+    def test_not_found(self):
+        from arm.services.metadata_sync import lookup_crc_sync
+        crc_result = {"found": False, "results": []}
+        with unittest.mock.patch('arm.services.metadata.lookup_crc',
+                                 return_value=crc_result):
+            result = lookup_crc_sync("unknown")
+        assert result["found"] is False


### PR DESCRIPTION
## Summary
- Guard `transcoder_notify()` to skip webhooks when `job is None` (setup failures like drive-not-ready/tray-open) or `job.job_id is None` (job created in memory but not committed — e.g. duplicate_run_check)
- Extend transcode-callback endpoint to accept `"transcoding"` status, transitioning job from `waiting_transcode` → `transcoding`

## Test plan
- [x] 690 ARM tests pass
- [ ] Insert disc, verify only one webhook sent per rip (not on error/exit paths)
- [ ] Verify job transitions: ripping → waiting_transcode → transcoding → success