### PR TITLE
fix: suppress spurious transcoder webhooks and accept transcoding callback

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -367,7 +367,7 @@ async def update_transcode_config(job_id: int, request: Request):
 async def transcode_callback(job_id: int, request: Request):
     """Receive status update from the external transcoder.
 
-    Expected payload: {"status": "completed"|"failed", "error": "..."}
+    Expected payload: {"status": "transcoding"|"completed"|"failed", "error": "..."}
     """
     job = Job.query.get(job_id)
     if not job:
@@ -376,7 +376,9 @@ async def transcode_callback(job_id: int, request: Request):
     body = await request.json()
     status = body.get("status")
 
-    if status == "completed":
+    if status == "transcoding":
+        job.status = JobState.TRANSCODE_ACTIVE.value
+    elif status == "completed":
         job.status = JobState.SUCCESS.value
         notification = Notifications(
             f"Job: {job.job_id} transcode complete",

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -131,6 +131,11 @@ def transcoder_notify(cfg, title, body, job=None):
     """Send a webhook notification to the arm-transcoder service.
     If LOCAL_RAW_PATH and SHARED_RAW_PATH are both set, moves the job's
     raw directory from local to shared storage before notifying."""
+    # Skip webhook for setup failures (no job) or uncommitted jobs
+    # (job created but not yet persisted to DB — e.g. duplicate_run_check).
+    if job is None or getattr(job, 'job_id', None) is None:
+        return
+
     transcoder_url = cfg.get('TRANSCODER_URL', '')
     if not transcoder_url:
         return


### PR DESCRIPTION
## Summary
- Guard `transcoder_notify()` to skip webhooks when `job is None` (setup failures like drive-not-ready/tray-open) or `job.job_id is None` (job created in memory but not committed — e.g. duplicate_run_check)
- Extend transcode-callback endpoint to accept `"transcoding"` status, transitioning job from `waiting_transcode` → `transcoding`

## Test plan
- [x] 690 ARM tests pass
- [ ] Insert disc, verify only one webhook sent per rip (not on error/exit paths)
- [ ] Verify job transitions: ripping → waiting_transcode → transcoding → success