### PR TITLE
fix: use pytest.approx for float comparison (SonarCloud S1244)

### DIFF
--- a/test/test_rip_logic.py
+++ b/test/test_rip_logic.py
@@ -791,7 +791,7 @@ class TestTrackInfoProcessorIntegration:
         # State should be reset after adding
         assert proc.seconds == 0
         assert proc.aspect == ""
-        assert proc.fps == 0.0
+        assert proc.fps == pytest.approx(0.0)
         assert proc.filename == ""
         assert proc.chapters == 0
         assert proc.filesize == 0


### PR DESCRIPTION
## Summary
- Replace `assert proc.fps == 0.0` with `assert proc.fps == pytest.approx(0.0)` to fix SonarCloud S1244 (float equality check)
- This was flagged as a reliability bug causing a C rating on the quality gate

## Test plan
- [ ] SonarCloud quality gate passes (Reliability Rating = A)
- [ ] All existing tests still pass