### PR TITLE
feat: harden disc detection chain against retriggering and timeouts

### DIFF
--- a/arm/data/comments.json
+++ b/arm/data/comments.json
@@ -25,6 +25,7 @@
   "DATE_FORMAT": "# Allows you to format the date/time to your own liking\n# This will be used throughout ARM and ARMui",
   "ALLOW_DUPLICATES": "## Do you want to allow Rips of the same disk multiple times\n## With this set as false the task will exit if it recognises the same movie being ripped\n## recommended to set to true for series ",
   "MAX_CONCURRENT_MAKEMKVINFO": "# Number of MakeMKV info calls that are allowed to run.\n#This can be set to 1 if makemkvcon info calls lead to crashes on backup or mkv calls.\n# Set to 0 to disable",
+  "DRIVE_READY_TIMEOUT": "# How long (in seconds) to wait for the drive to become ready after disc insertion.\n# Some drives take longer to spin up. If the drive reports NO_DISC for the majority\n# of this period, ARM exits gracefully instead of throwing an error.",
   "DATA_RIP_PARAMETERS": "# Additional parameters for dd. e.g. \"conv=noerror,sync\" for ignoring read errors",
   "METADATA_PROVIDER": "# This selects the metadata provider, Each provider has their own ups and downs\n# But a general rule would be \n# OMDB for movies and shows \n# TMDB for movies only\n# You will still need to provide an api key for the provider you have selected",
   "GET_AUDIO_TITLE": "# Set to one of \"none\", \"musicbrainz\", \"freecddb\"\n# if \"musicbrainz\" is used the disc information are asked from musicbrainz.org\n# if \"none\" is used no label is identified",

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -26,7 +26,7 @@ if find_spec("arm") is None:
 import arm.config.config as cfg  # noqa E402
 from arm.models.config import Config  # noqa: E402
 from arm.models.job import Job, JobState  # noqa: E402
-from arm.models.system_drives import SystemDrives  # noqa: E402
+from arm.models.system_drives import CDS, SystemDrives  # noqa: E402
 from arm.database import db  # noqa E402
 import arm.constants as constants  # noqa E402
 from arm.ripper import (arm_ripper, identify, logger,  # noqa: E402
@@ -203,15 +203,41 @@ def setup():
 
     # With some drives and some disks, there is a race condition between creating the Job()
     # below and the drive being ready, so give it a chance to get ready (observed with LG SP80NB80)
-    for num in range(1, 11):
+    drive_ready_timeout = int(cfg.arm_config.get('DRIVE_READY_TIMEOUT', 60))
+    poll_interval = 2
+    max_polls = max(drive_ready_timeout // poll_interval, 1)
+    no_disc_threshold = max_polls // 2  # >50% of timeout with NO_DISC → exit gracefully
+    no_disc_count = 0
+    drive_is_ready = False
+
+    for num in range(1, max_polls + 1):
         drive.tray_status()
         if drive.ready:
+            drive_is_ready = True
             break
-        msg = f"[{num} of 10] Drive [{drive.mount}] appears to be empty or is not ready. Waiting 1s"
-        logging.info(msg)
-        time.sleep(1)
-    else:  # no break
-        raise utils.RipperException(f"Timed out waiting for drive to be ready (ioctl tray status: {drive.tray}).")
+        state_name = drive.tray.name if drive.tray else "UNKNOWN"
+        if drive.tray == CDS.NO_DISC:
+            no_disc_count += 1
+        logging.info(
+            f"[{num}/{max_polls}] Drive [{drive.mount}] not ready "
+            f"(state: {state_name}). Waiting {poll_interval}s"
+        )
+        if no_disc_count > no_disc_threshold:
+            logging.info(
+                f"Drive [{drive.mount}] reported NO_DISC for majority of "
+                f"checks ({no_disc_count}/{num}). Exiting gracefully."
+            )
+            return False
+        time.sleep(poll_interval)
+
+    if not drive_is_ready:
+        state_name = drive.tray.name if drive.tray else "UNKNOWN"
+        logging.info(
+            f"Timed out waiting for drive [{drive.mount}] to be ready "
+            f"after {drive_ready_timeout}s (last state: {state_name}). "
+            f"Exiting gracefully."
+        )
+        return False
 
     # ARM Job starts
     # Create new job
@@ -259,12 +285,16 @@ def setup():
     utils.clean_old_jobs()
     # Log all params/attribs from the drive
     log_udev_params(devpath)
+    return True
 
 
 if __name__ == "__main__":
     job = None
     try:
-        setup()
+        ready = setup()
+        if not ready:
+            # Drive not ready or no disc — exit cleanly without error
+            sys.exit(0)
         main()
     except Exception as error:
         logging.critical("A fatal error has occurred and ARM is exiting.")

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -605,7 +605,9 @@ def clean_old_jobs():
     Check for running jobs - Update failed jobs that are no longer running\n
     :return: None
     """
-    active_jobs = db.session.query(Job).filter(Job.status.notin_(['fail', 'success'])).all()
+    # Exclude terminal states and transcode states (managed by the external transcoder)
+    excluded = ['fail', 'success', 'waiting_transcode', 'transcoding']
+    active_jobs = db.session.query(Job).filter(Job.status.notin_(excluded)).all()
     # Clean up abandoned jobs
     for job in active_jobs:
         if psutil.pid_exists(job.pid):
@@ -613,10 +615,8 @@ def clean_old_jobs():
             if job.pid_hash == hash(job_process):
                 logging.info(f"Job #{job.job_id} with PID {job.pid} is currently running.")
         else:
-            logging.info(f"Job #{job.job_id} with PID {job.pid} has been abandoned."
+            logging.info(f"Job #{job.job_id} with PID {job.pid} has been abandoned. "
                          f"Updating job status to fail.")
-            job.status = JobState.FAILURE.value
-            db.session.commit()
             database_updater({'status': JobState.FAILURE.value}, job)
 
 
@@ -677,6 +677,17 @@ def duplicate_run_check(dev_path):
     # check for running jobs by associated drive.
     drive = SystemDrives.query.filter_by(mount=dev_path).first()
     if not drive.processing:
+        # Drive is not currently processing — check post-eject grace period.
+        # After a rip finishes, the eject triggers udev again. If the previous
+        # job finished less than 30s ago, skip this run.
+        prev = drive.job_previous
+        if prev and prev.stop_time:
+            elapsed = (datetime.datetime.now() - prev.stop_time).total_seconds()
+            if elapsed < 30:
+                raise RipperException(
+                    f"Post-eject grace period: previous job on {dev_path} "
+                    f"finished {elapsed:.0f}s ago (< 30s)"
+                )
         return  # drive is not processing, so we are safe to start another run.
     job = drive.job_current
     logging.critical(f'Drive {dev_path} has an active Job ({job.job_id}): {job.status}.')

--- a/scripts/docker/docker_arm_wrapper.sh
+++ b/scripts/docker/docker_arm_wrapper.sh
@@ -1,36 +1,62 @@
 #!/bin/bash
+#
+# ARM Docker Wrapper — called by udev via 51-docker-arm.rules
+#
+# Responsibilities:
+#   1. Per-device flock to prevent concurrent ARM runs on the same drive
+#   2. Source environment variables (PATH etc. not available from udev)
+#   3. Log the detected disc type
+#   4. Launch ARM's main.py for the device
+#
+# The flock also prevents post-eject retriggering: the rip process still
+# holds the lock when the eject fires another udev event.
 
 DEVNAME=$1
 ARMLOG="/home/arm/logs/arm.log"
-echo "[ARM] Entering docker wrapper" | logger -t ARM -s
-echo "$(date) Entering docker wrapper" >> $ARMLOG
+LOCKFILE="/run/arm_${DEVNAME}.lock"
 
-set -a && source /etc/environment && set +a
-# ↑       ↑ set all env vars from this file (we need PATH, udev doesn't give it to us)
-# └ export all variables which are set
+# --- Per-device flock (non-blocking) ---
+# Opens the lock file on fd 9 and attempts a non-blocking exclusive lock.
+# If another ARM process already holds the lock for this device, exit cleanly.
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+    echo "$(date) [ARM] Lock held for ${DEVNAME}, another ARM process is running. Skipping." >> "$ARMLOG"
+    exit 0
+fi
+# Lock acquired — will auto-release when this process exits.
+
+echo "[ARM] Entering docker wrapper" | logger -t ARM -s
+echo "$(date) [ARM] Entering docker wrapper for ${DEVNAME}" >> "$ARMLOG"
+
+# --- Source environment (udev doesn't provide PATH) ---
+if [[ -f /etc/environment ]]; then
+    set -a && source /etc/environment && set +a
+fi
 
 #######################################################################################
 # Log Discovered Type and Start Rip
 #######################################################################################
 
-# ID_CDROM_MEDIA_BD = Bluray
+# ID_CDROM_MEDIA_BD = Blu-ray
 # ID_CDROM_MEDIA_CD = CD
 # ID_CDROM_MEDIA_DVD = DVD
 if [[ "$ID_CDROM_MEDIA_DVD" == "1" ]]; then
-    echo "$(date) [ARM] Starting ARM for DVD on ${DEVNAME}" >> $ARMLOG
+    echo "$(date) [ARM] Starting ARM for DVD on ${DEVNAME}" >> "$ARMLOG"
     echo "[ARM] Starting ARM for DVD on ${DEVNAME}" | logger -t ARM -s
 elif [[ "$ID_CDROM_MEDIA_BD" == "1" ]]; then
-	  echo "[ARM] Starting ARM for Bluray on ${DEVNAME}" >> $ARMLOG
-	  echo "$(date) [[ARM] Starting ARM for Bluray on ${DEVNAME}" | logger -t ARM -s
+    echo "$(date) [ARM] Starting ARM for Blu-ray on ${DEVNAME}" >> "$ARMLOG"
+    echo "[ARM] Starting ARM for Blu-ray on ${DEVNAME}" | logger -t ARM -s
 elif [[ "$ID_CDROM_MEDIA_CD" == "1" ]] || [[ "$ID_CDROM_MEDIA_CD_R" == "1" ]] || [[ "$ID_CDROM_MEDIA_CD_RW" == "1" ]]; then
-	  echo "[ARM] Starting ARM for CD on ${DEVNAME}" | logger -t ARM -s
-	  echo "$(date) [[ARM] Starting ARM for CD on ${DEVNAME}" >> $ARMLOG
+    echo "$(date) [ARM] Starting ARM for CD on ${DEVNAME}" >> "$ARMLOG"
+    echo "[ARM] Starting ARM for CD on ${DEVNAME}" | logger -t ARM -s
 elif [[ "$ID_FS_TYPE" != "" ]]; then
-	  echo "[ARM] Starting ARM for Data Disk on ${DEVNAME} with File System ${ID_FS_TYPE}" | logger -t ARM -s
-	  echo "$(date) [[ARM] Starting ARM for Data Disk on ${DEVNAME} with File System ${ID_FS_TYPE}" >> $ARMLOG
+    echo "$(date) [ARM] Starting ARM for Data Disk on ${DEVNAME} with FS ${ID_FS_TYPE}" >> "$ARMLOG"
+    echo "[ARM] Starting ARM for Data Disk on ${DEVNAME} with FS ${ID_FS_TYPE}" | logger -t ARM -s
 else
-	  echo "[ARM] Starting ARM for unknown disc type on ${DEVNAME}" | logger -t ARM -s
-	  echo "$(date) [ARM] Starting ARM for unknown disc type on ${DEVNAME}" >> $ARMLOG
+    echo "$(date) [ARM] No recognized disc type on ${DEVNAME}, skipping." >> "$ARMLOG"
+    echo "[ARM] No recognized disc type on ${DEVNAME}, skipping." | logger -t ARM -s
+    exit 0
 fi
-cd /home/arm
+
+cd /home/arm || exit 1
 python3 /opt/arm/arm/ripper/main.py -d "${DEVNAME}" | logger -t ARM -s

--- a/setup/51-docker-arm.rules
+++ b/setup/51-docker-arm.rules
@@ -1,4 +1,4 @@
 # ID_CDROM_MEDIA_BD = Bluray
 # ID_CDROM_MEDIA_DVD = DVD
 # ID_CDROM_MEDIA_CD = CD
-KERNEL=="sr[0-9]*", ACTION=="change", SUBSYSTEM=="block", ENV{ID_CDROM_MEDIA_STATE}!="blank", RUN+="/sbin/setuser arm /opt/arm/scripts/docker/docker_arm_wrapper.sh %k"
+KERNEL=="sr[0-9]*", ACTION=="change", SUBSYSTEM=="block", ENV{ID_CDROM_MEDIA}=="1", ENV{ID_CDROM_MEDIA_STATE}!="blank", RUN+="/sbin/setuser arm /opt/arm/scripts/docker/docker_arm_wrapper.sh %k"

--- a/setup/arm.yaml
+++ b/setup/arm.yaml
@@ -87,6 +87,11 @@ GROUP_TV_DISCS_UNDER_SERIES: false
 # Set to 0 to disable
 MAX_CONCURRENT_MAKEMKVINFO: 0
 
+# How long (in seconds) to wait for the drive to become ready after disc insertion.
+# Some drives take longer to spin up. If the drive reports NO_DISC for the majority
+# of this period, ARM exits gracefully instead of throwing an error.
+DRIVE_READY_TIMEOUT: 60
+
 # Additional parameters for dd. e.g. "conv=noerror,sync" for ignoring read errors
 # "status=progress" to log progress
 DATA_RIP_PARAMETERS: ""

--- a/test/test_rip_logic.py
+++ b/test/test_rip_logic.py
@@ -1,4 +1,5 @@
 """Tests for ripping business logic (no hardware required)."""
+import datetime
 import os
 import subprocess
 import unittest.mock
@@ -1247,3 +1248,170 @@ class TestMainfeatureMakemkv:
 
         assert captured_track['track'].track_number == "2"
         assert captured_track['track'].chapters == 28
+
+
+class TestDuplicateRunCheck:
+    """Test duplicate_run_check() grace period and active-job detection."""
+
+    def _make_drive(self, db, devpath, job_current=None, job_previous=None):
+        from arm.models.system_drives import SystemDrives
+        drive = SystemDrives()
+        drive.mount = devpath
+        drive.stale = False
+        if job_current:
+            drive.job_id_current = job_current.job_id
+        if job_previous:
+            drive.job_id_previous = job_previous.job_id
+        db.session.add(drive)
+        db.session.commit()
+        return drive
+
+    def test_active_job_raises(self, app_context, sample_job):
+        """Active job on drive should raise RipperException."""
+        from arm.ripper.utils import duplicate_run_check, RipperException
+        _, db = app_context
+
+        sample_job.start_time = datetime.datetime.now()
+        db.session.commit()
+        self._make_drive(db, sample_job.devpath, job_current=sample_job)
+
+        with pytest.raises(RipperException, match="Job already running"):
+            duplicate_run_check(sample_job.devpath)
+
+    def test_previous_job_within_grace_period_raises(self, app_context, sample_job):
+        """Previous job finished <30s ago should raise (grace period)."""
+        from arm.ripper.utils import duplicate_run_check, RipperException
+        from arm.models.job import Job
+        _, db = app_context
+
+        with unittest.mock.patch.object(Job, 'parse_udev'), \
+             unittest.mock.patch.object(Job, 'get_pid'):
+            prev_job = Job('/dev/sr0')
+        prev_job.status = "success"
+        prev_job.stop_time = datetime.datetime.now() - datetime.timedelta(seconds=5)
+        prev_job.devpath = sample_job.devpath
+        db.session.add(prev_job)
+        db.session.flush()
+
+        self._make_drive(db, sample_job.devpath, job_previous=prev_job)
+
+        with pytest.raises(RipperException, match="Post-eject grace period"):
+            duplicate_run_check(sample_job.devpath)
+
+    def test_previous_job_beyond_grace_period_passes(self, app_context, sample_job):
+        """Previous job finished >30s ago should NOT raise."""
+        from arm.ripper.utils import duplicate_run_check
+        from arm.models.job import Job
+        _, db = app_context
+
+        with unittest.mock.patch.object(Job, 'parse_udev'), \
+             unittest.mock.patch.object(Job, 'get_pid'):
+            prev_job = Job('/dev/sr0')
+        prev_job.status = "success"
+        prev_job.stop_time = datetime.datetime.now() - datetime.timedelta(seconds=60)
+        prev_job.devpath = sample_job.devpath
+        db.session.add(prev_job)
+        db.session.flush()
+
+        self._make_drive(db, sample_job.devpath, job_previous=prev_job)
+
+        duplicate_run_check(sample_job.devpath)
+
+    def test_no_previous_job_passes(self, app_context, sample_job):
+        """No previous job on drive should NOT raise."""
+        from arm.ripper.utils import duplicate_run_check
+        _, db = app_context
+
+        self._make_drive(db, sample_job.devpath)
+
+        duplicate_run_check(sample_job.devpath)
+
+
+class TestCleanOldJobs:
+    """Test clean_old_jobs() status exclusions."""
+
+    def _make_job(self, db, status, pid=99999):
+        from arm.models.job import Job
+        with unittest.mock.patch.object(Job, 'parse_udev'), \
+             unittest.mock.patch.object(Job, 'get_pid'):
+            job = Job('/dev/sr0')
+        job.status = status
+        job.pid = pid
+        job.pid_hash = 0
+        db.session.add(job)
+        db.session.commit()
+        return job
+
+    def test_waiting_transcode_not_marked_failed(self, app_context):
+        """Job in waiting_transcode with dead PID should NOT be marked failed."""
+        from arm.ripper.utils import clean_old_jobs
+        _, db = app_context
+
+        job = self._make_job(db, "waiting_transcode", pid=99999)
+
+        with unittest.mock.patch('arm.ripper.utils.psutil.pid_exists', return_value=False):
+            clean_old_jobs()
+
+        db.session.refresh(job)
+        assert job.status == "waiting_transcode"
+
+    def test_transcoding_not_marked_failed(self, app_context):
+        """Job in transcoding with dead PID should NOT be marked failed."""
+        from arm.ripper.utils import clean_old_jobs
+        _, db = app_context
+
+        job = self._make_job(db, "transcoding", pid=99999)
+
+        with unittest.mock.patch('arm.ripper.utils.psutil.pid_exists', return_value=False):
+            clean_old_jobs()
+
+        db.session.refresh(job)
+        assert job.status == "transcoding"
+
+    def test_active_with_dead_pid_marked_failed(self, app_context):
+        """Job in active state with dead PID should be marked failed."""
+        from arm.ripper.utils import clean_old_jobs
+        _, db = app_context
+
+        job = self._make_job(db, "active", pid=99999)
+
+        with unittest.mock.patch('arm.ripper.utils.psutil.pid_exists', return_value=False):
+            clean_old_jobs()
+
+        db.session.refresh(job)
+        assert job.status == "fail"
+
+
+class TestDriveReadinessTimeout:
+    """Test drive readiness polling logic in setup()."""
+
+    def test_disc_ok_ready_immediately(self, app_context, sample_job):
+        """DISC_OK on first poll should return ready."""
+        from arm.models.system_drives import CDS, SystemDrives
+        _, db = app_context
+
+        drive = SystemDrives()
+        drive.mount = sample_job.devpath
+        drive.stale = False
+        db.session.add(drive)
+        db.session.commit()
+
+        with unittest.mock.patch.object(SystemDrives, 'tray_status') as mock_ts:
+            mock_ts.side_effect = lambda: setattr(drive, '_tray', CDS.DISC_OK.value)
+            drive._tray = CDS.DISC_OK.value
+            assert drive.ready is True
+
+    def test_no_disc_returns_not_ready(self, app_context, sample_job):
+        """NO_DISC state should indicate drive is not ready."""
+        from arm.models.system_drives import CDS, SystemDrives
+        _, db = app_context
+
+        drive = SystemDrives()
+        drive.mount = sample_job.devpath
+        drive.stale = False
+        db.session.add(drive)
+        db.session.commit()
+
+        drive._tray = CDS.NO_DISC.value
+        assert drive.ready is False
+        assert drive.tray == CDS.NO_DISC


### PR DESCRIPTION
## Summary
- **docker_arm_wrapper.sh**: Per-device `flock` prevents concurrent ARM runs on the same drive and post-eject retriggering. Exits silently on unknown disc type. Fixes `[[ARM]` logging typos. Guards `/etc/environment` source.
- **51-docker-arm.rules**: Requires `ENV{ID_CDROM_MEDIA}=="1"` so udev only fires when kernel detects actual media.
- **main.py**: Configurable `DRIVE_READY_TIMEOUT` (default 60s, 2s poll intervals). Logs CDS state name. Graceful exit on NO_DISC majority or timeout instead of fatal `RipperException`.
- **utils.py**: 30s post-eject grace period in `duplicate_run_check()`. Excludes `waiting_transcode`/`transcoding` from `clean_old_jobs()` zombie cleanup.
- **Config**: Added `DRIVE_READY_TIMEOUT: 60` to `arm.yaml` and `comments.json`.
- **Tests**: 9 new tests covering grace period, transcode state exclusion, and drive readiness.

Companion PR: https://github.com/uprightbass360/automatic-ripping-machine-transcoder/pull/30 (per-device debounce in drive watcher)

## Test plan
- [ ] `pytest test/test_rip_logic.py -v` — all 25 tests pass
- [ ] `shellcheck scripts/docker/docker_arm_wrapper.sh` — clean (SC1091 info only)
- [ ] Insert disc → rip → eject does NOT trigger fatal error or duplicate job
- [ ] Power off/on USB drive → container restarts at most once
- [ ] `docker logs arm-rippers` — no "appears to be empty" spam after rip