### PR TITLE
fix: harden upstream ports (#60, #1605, #1639, #1660, #1664)

### DIFF
--- a/arm/api/v1/settings.py
+++ b/arm/api/v1/settings.py
@@ -92,6 +92,7 @@ async def update_config(request: Request):
 
     try:
         new_values = await asyncio.to_thread(_read_config)
+        new_values = new_values or {}
         cfg.arm_config.clear()
         cfg.arm_config.update(new_values)
     except Exception as e:

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -437,6 +437,8 @@ class Job(db.Model):
         # TV series disc label naming overrides the normal pipeline
         if self.video_type == "series" and getattr(self.config, 'USE_DISC_LABEL_FOR_TV', False):
             folder = get_tv_folder_name(self)
+            if not folder:
+                folder = self.formatted_title
             if getattr(self.config, 'GROUP_TV_DISCS_UNDER_SERIES', False):
                 parent = get_tv_series_parent_folder(self)
                 return os.path.join(self.config.COMPLETED_PATH, self.type_subfolder, parent, folder)

--- a/arm/ripper/arm_matcher.py
+++ b/arm/ripper/arm_matcher.py
@@ -196,6 +196,11 @@ def parse_label(raw_label: str) -> LabelInfo:
     for suffix in _BLURAY_SUFFIXES:
         s = s.replace(suffix, '')
 
+    # Treat hyphens and dots as word separators (after suffix removal to
+    # preserve literal hyphens in _BLURAY_SUFFIXES like ' - Blu-rayTM')
+    s = s.replace('-', ' ')
+    s = s.replace('.', ' ')
+
     # 5a. Extract season+disc combined suffixes (S1D1, S1_D1)
     m = _SEASON_DISC_RE.search(s)
     if m:

--- a/arm/ripper/arm_matcher.py
+++ b/arm/ripper/arm_matcher.py
@@ -24,6 +24,20 @@ class LabelInfo:
     raw_label: str           # original input: "LOTR_FELLOWSHIP_OF_THE_RING_P1"
     season_number: int | None = None  # 1, 2, etc. (None if not a TV season disc)
 
+    @property
+    def disc_identifier(self) -> str | None:
+        """Format season/disc as a compact identifier (e.g. 'S1D1', 'S2', 'D3').
+
+        Returns None when neither season nor disc number is available.
+        """
+        if self.season_number is not None and self.disc_number is not None:
+            return f"S{self.season_number}D{self.disc_number}"
+        if self.season_number is not None:
+            return f"S{self.season_number}"
+        if self.disc_number is not None:
+            return f"D{self.disc_number}"
+        return None
+
 
 @dataclass
 class MatchResult:

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -947,15 +947,15 @@ def save_disc_poster(final_directory, job):
     if job.disctype != "dvd" or not cfg.arm_config["RIP_POSTER"]:
         return
 
-    try:
-        result = subprocess.run(
-            ["mount", job.devpath],
-            capture_output=True, text=True,
-        )
-        if result.returncode != 0:
-            logging.error(f"Failed to mount {job.devpath}: {result.stderr.strip()}")
-            return
+    result = subprocess.run(
+        ["mount", job.devpath],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        logging.error(f"Failed to mount {job.devpath}: {result.stderr.strip()}")
+        return
 
+    try:
         ntsc_poster = os.path.join(job.mountpoint, "JACKET_P", "J00___5L.MP2")
         pal_poster = os.path.join(job.mountpoint, "JACKET_P", "J00___6L.MP2")
         poster_out = os.path.join(final_directory, "poster.png")

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -981,55 +981,6 @@ def save_disc_poster(final_directory, job):
             logging.error(f"Failed to umount {job.devpath}: {umount.stderr.strip()}")
 
 
-def parse_disc_label_for_identifiers(disc_label):
-    """Parse disc label to extract season/disc identifiers.
-
-    Supports multiple common patterns (case-insensitive):
-    - S##D## or S##_D## or S##-D## (e.g., S1D1, S01_D02, S1-D2)
-    - S##E##D## (e.g., S01E01D1, S1E1D1)
-    - Season##Disc## variations (e.g., Season1Disc1, Season 01 Disc 2)
-    - Separate S## and D## tokens anywhere in label
-
-    :param disc_label: The disc volume label string
-    :return: Normalized identifier string (e.g., "S1D1", "S01D02") or None
-    """
-    if not disc_label:
-        return None
-
-    # Pattern 1: S##[E##]D## with optional separators
-    pattern1 = re.compile(
-        r'S0*(\d{1,2})(?:[E_\-\s.]+0*(\d{1,2}))?[_\-\s.]*D0*(\d{1,2})',
-        re.IGNORECASE,
-    )
-    match = pattern1.search(disc_label)
-    if match:
-        season = match.group(1)
-        episode = match.group(2)
-        disc = match.group(3)
-        if episode:
-            return f"S{season}E{episode}D{disc}"
-        return f"S{season}D{disc}"
-
-    # Pattern 2: Season##Disc## with optional separators/spaces
-    pattern2 = re.compile(
-        r'Season[\s_\-]*0*(\d{1,2})[\s_\-]*Disc[\s_\-]*0*(\d{1,2})',
-        re.IGNORECASE,
-    )
-    match = pattern2.search(disc_label)
-    if match:
-        return f"S{match.group(1)}D{match.group(2)}"
-
-    # Pattern 3: Find S## and D## separately anywhere in the label
-    season_match = re.search(r'(?<![a-zA-Z])S0*(\d{1,2})(?!\d)', disc_label, re.IGNORECASE)
-    disc_match = re.search(
-        r'(?<![a-zA-Z])D(?:isc)?[\s_\-]*0*(\d{1,2})(?!\d)', disc_label, re.IGNORECASE
-    )
-    if season_match and disc_match:
-        return f"S{season_match.group(1)}D{disc_match.group(1)}"
-
-    logging.debug(f"Could not parse disc identifiers from label: '{disc_label}'")
-    return None
-
 
 def normalize_series_name(series_name):
     """Normalize series name into a safe, consistent folder name.
@@ -1066,8 +1017,10 @@ def get_tv_folder_name(job):
     Otherwise, falls back to standard naming via formatted_title.
 
     :param job: Job object containing title, label, year, etc.
-    :return: Folder name string
+    :return: Folder name string (never empty — falls back to formatted_title)
     """
+    from arm.ripper.arm_matcher import parse_label
+
     use_disc_label = getattr(job.config, 'USE_DISC_LABEL_FOR_TV', False) if hasattr(job, 'config') else False
 
     if not use_disc_label:
@@ -1079,12 +1032,13 @@ def get_tv_folder_name(job):
     series_name = job.title_manual if job.title_manual else job.title
     if not series_name:
         logging.warning("No series title available, falling back to standard naming")
-        return ""
+        return job.formatted_title
 
-    disc_identifier = parse_disc_label_for_identifiers(job.label)
-    if disc_identifier:
+    label_info = parse_label(job.label)
+    disc_id = label_info.disc_identifier
+    if disc_id:
         normalized_name = normalize_series_name(series_name)
-        folder_name = f"{normalized_name}_{disc_identifier}"
+        folder_name = f"{normalized_name}_{disc_id}"
         logging.info(f"Using disc label-based folder name: '{folder_name}' "
                      f"(from series '{series_name}' and label '{job.label}')")
         return folder_name

--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -142,6 +142,8 @@ apply_yaml_override TRANSCODER_URL ARM_TRANSCODER_URL
 apply_yaml_override TRANSCODER_WEBHOOK_SECRET ARM_TRANSCODER_WEBHOOK_SECRET
 apply_yaml_override LOCAL_RAW_PATH ARM_LOCAL_RAW_PATH
 apply_yaml_override SHARED_RAW_PATH ARM_SHARED_RAW_PATH
+# sed -i may reset file ownership to root — restore arm ownership
+chown arm:arm "$ARM_YAML" 2>/dev/null || true
 
 ##### abcde config setup
 # abcde.conf is expected in /etc by the abcde installation
@@ -154,7 +156,7 @@ fi
 # check if abcde is in config main location - only copy if it doesnt exist
 if ! [[ -f /etc/arm/config/abcde.conf ]]; then
   echo "abcde.conf doesnt exist"
-  cp /opt/arm/setup/.abcde.conf /etc/arm/config/abcde.conf
+  install -o arm -g arm -m 644 /opt/arm/setup/.abcde.conf /etc/arm/config/abcde.conf
   # chown arm:arm /etc/arm/config/abcde.conf
 fi
 # The system link to the fake default file -not really needed but as a precaution to the -C variable being blank

--- a/test/test_rip_logic.py
+++ b/test/test_rip_logic.py
@@ -1055,6 +1055,36 @@ class TestSettingsReload:
             cfg.arm_config_path = original_path
 
 
+class TestSettingsReloadNoneGuard:
+    """Config reload must not crash on empty YAML file (#1639)."""
+
+    def test_empty_yaml_does_not_crash(self, tmp_path):
+        import yaml
+        import arm.config.config as cfg
+
+        original_config = dict(cfg.arm_config)
+        original_path = cfg.arm_config_path
+
+        try:
+            config_file = tmp_path / "empty.yaml"
+            config_file.write_text("")
+
+            cfg.arm_config_path = str(config_file)
+            with open(cfg.arm_config_path, "r") as f:
+                new_values = yaml.safe_load(f)
+
+            # This is what the endpoint does — should not raise TypeError
+            new_values = new_values or {}
+            cfg.arm_config.clear()
+            cfg.arm_config.update(new_values)
+
+            assert isinstance(cfg.arm_config, dict)
+        finally:
+            cfg.arm_config.clear()
+            cfg.arm_config.update(original_config)
+            cfg.arm_config_path = original_path
+
+
 class TestSettingsEndpoint:
     """Test settings config write + reload code path for coverage (#1639)."""
 

--- a/test/test_rip_logic.py
+++ b/test/test_rip_logic.py
@@ -1454,3 +1454,42 @@ class TestDriveLookupGraceful:
         result = SystemDrives.query.filter_by(mount="/dev/sr99").first()
         assert result is not None
         assert result.mount == "/dev/sr99"
+
+
+class TestLabelSeparatorNormalization:
+    """Test that hyphens and dots in disc labels are treated as word separators (#60)."""
+
+    def test_hyphenated_label_normalized(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("THE-BOONDOCK-SAINTS")
+        assert info.title == "the boondock saints"
+
+    def test_hyphenated_sequel_normalized(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("SPIDER-MAN-2")
+        assert info.title == "spider man 2"
+
+    def test_bluray_suffix_still_removed(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("X-MEN - Blu-rayTM")
+        assert info.title == "x men"
+        assert "blu" not in info.title
+
+    def test_hyphenated_with_disc_suffix(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("X-MEN-FIRST-CLASS D1")
+        assert info.title == "x men first class"
+        assert info.disc_number == 1
+
+    def test_dot_separated_label(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("Breaking.Bad.S02.D02")
+        assert info.season_number == 2
+        assert info.disc_number == 2
+        assert "breaking" in info.title
+        assert "bad" in info.title
+
+    def test_dot_separated_title_only(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("The.Wire")
+        assert info.title == "the wire"

--- a/test/test_rip_logic.py
+++ b/test/test_rip_logic.py
@@ -1456,6 +1456,35 @@ class TestDriveLookupGraceful:
         assert result.mount == "/dev/sr99"
 
 
+class TestLabelInfoDiscIdentifier:
+    """Test LabelInfo.disc_identifier property."""
+
+    def test_season_and_disc(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("BB_S1D1")
+        assert info.disc_identifier == "S1D1"
+
+    def test_season_only(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("BB_S1")
+        assert info.disc_identifier == "S1"
+
+    def test_disc_only(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("BB_D2")
+        assert info.disc_identifier == "D2"
+
+    def test_no_identifiers(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("BREAKING_BAD_2008")
+        assert info.disc_identifier is None
+
+    def test_season_disc_with_leading_zeros(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("GOT_S05_D03")
+        assert info.disc_identifier == "S5D3"
+
+
 class TestLabelSeparatorNormalization:
     """Test that hyphens and dots in disc labels are treated as word separators (#60)."""
 

--- a/test/test_rip_logic.py
+++ b/test/test_rip_logic.py
@@ -365,62 +365,6 @@ class TestMakemkvDiscDiscovery:
         mock_get_drives.assert_not_called()
 
 
-class TestDiscLabelParsing:
-    """Test parse_disc_label_for_identifiers() (#1605)."""
-
-    def test_s_d_no_separator(self):
-        from arm.ripper.utils import parse_disc_label_for_identifiers
-        assert parse_disc_label_for_identifiers("BB_S1D1") == "S1D1"
-        assert parse_disc_label_for_identifiers("S01D02") == "S1D2"
-
-    def test_s_d_with_underscore(self):
-        from arm.ripper.utils import parse_disc_label_for_identifiers
-        assert parse_disc_label_for_identifiers("S1_D1") == "S1D1"
-        assert parse_disc_label_for_identifiers("S01_D02") == "S1D2"
-
-    def test_s_d_with_hyphen(self):
-        from arm.ripper.utils import parse_disc_label_for_identifiers
-        assert parse_disc_label_for_identifiers("S1-D1") == "S1D1"
-
-    def test_s_e_d_format(self):
-        from arm.ripper.utils import parse_disc_label_for_identifiers
-        assert parse_disc_label_for_identifiers("S1E1D1") == "S1E1D1"
-        assert parse_disc_label_for_identifiers("S01E01D1") == "S1E1D1"
-
-    def test_season_disc_word_format(self):
-        from arm.ripper.utils import parse_disc_label_for_identifiers
-        assert parse_disc_label_for_identifiers("Season1Disc1") == "S1D1"
-        assert parse_disc_label_for_identifiers("SEASON01DISC02") == "S1D2"
-        assert parse_disc_label_for_identifiers("Season 1 Disc 1") == "S1D1"
-
-    def test_separate_s_and_d_tokens(self):
-        from arm.ripper.utils import parse_disc_label_for_identifiers
-        assert parse_disc_label_for_identifiers("Breaking Bad S01 Disc 1") == "S1D1"
-        assert parse_disc_label_for_identifiers("GOT S5 D3") == "S5D3"
-
-    def test_case_insensitivity(self):
-        from arm.ripper.utils import parse_disc_label_for_identifiers
-        assert parse_disc_label_for_identifiers("s1d1") == "S1D1"
-        assert parse_disc_label_for_identifiers("BREAKING_BAD_S01_D02") == "S1D2"
-
-    def test_no_match_returns_none(self):
-        from arm.ripper.utils import parse_disc_label_for_identifiers
-        assert parse_disc_label_for_identifiers("BREAKING_BAD_2008") is None
-        assert parse_disc_label_for_identifiers("Disc1") is None
-        assert parse_disc_label_for_identifiers("S1") is None
-
-    def test_empty_or_none(self):
-        from arm.ripper.utils import parse_disc_label_for_identifiers
-        assert parse_disc_label_for_identifiers("") is None
-        assert parse_disc_label_for_identifiers(None) is None
-
-    def test_complex_labels(self):
-        from arm.ripper.utils import parse_disc_label_for_identifiers
-        assert parse_disc_label_for_identifiers("TheWire_S01_D01_BluRay") == "S1D1"
-        assert parse_disc_label_for_identifiers("GOT_Season_05_Disc_03") == "S5D3"
-        assert parse_disc_label_for_identifiers("Breaking.Bad.S02.D02") == "S2D2"
-
-
 class TestNormalizeSeriesName:
     """Test normalize_series_name() (#1605)."""
 
@@ -1001,30 +945,33 @@ class TestTrackInfoProcessorIntegration:
 class TestTVFolderNameEdgeCases:
     """Test get_tv_folder_name() edge cases for full coverage."""
 
-    def test_no_series_name_returns_empty(self, app_context, sample_job):
-        """When series title is None/empty, fall back to empty string."""
+    def test_no_series_name_falls_back_to_formatted_title(self, app_context, sample_job):
+        """When series title is None, fall back to formatted_title (not empty)."""
         from arm.ripper.utils import get_tv_folder_name
 
         sample_job.video_type = "series"
         sample_job.title = None
         sample_job.title_manual = None
         sample_job.label = "BB_S1D1"
+        sample_job.year = "2008"
         sample_job.config.USE_DISC_LABEL_FOR_TV = True
         result = get_tv_folder_name(sample_job)
-        assert result == ""
+        assert result == sample_job.formatted_title
+        assert result != ""
 
-    def test_empty_title_returns_empty(self, app_context, sample_job):
-        """When title is empty string and title_manual is None, return empty."""
+    def test_empty_title_falls_back_to_formatted_title(self, app_context, sample_job):
+        """When title is empty string, fall back to formatted_title."""
         from arm.ripper.utils import get_tv_folder_name
 
         sample_job.video_type = "series"
         sample_job.title = ""
         sample_job.title_manual = None
         sample_job.label = "BB_S1D1"
+        sample_job.year = "2008"
         sample_job.config.USE_DISC_LABEL_FOR_TV = True
 
         result = get_tv_folder_name(sample_job)
-        assert result == ""
+        assert result == sample_job.formatted_title
 
     def test_no_config_attribute(self, app_context, sample_job):
         """When job has no config attribute, fall back to formatted_title."""
@@ -1049,6 +996,23 @@ class TestTVFolderNameEdgeCases:
         sample_job.config.USE_DISC_LABEL_FOR_TV = True
         result = get_tv_folder_name(sample_job)
         assert result == "Breaking_Bad_S1D1"
+
+
+class TestBuildFinalPathEmptyFolderGuard:
+    """build_final_path must never produce a path ending in just the type subfolder."""
+
+    def test_none_title_falls_back_to_formatted_title(self, app_context, sample_job):
+        sample_job.video_type = "series"
+        sample_job.title = None
+        sample_job.title_manual = None
+        sample_job.label = "BB_S1D1"
+        sample_job.config.USE_DISC_LABEL_FOR_TV = True
+        sample_job.config.COMPLETED_PATH = "/media/completed"
+        path = sample_job.build_final_path()
+        # Must not end with just "tv/" — should have a folder name
+        assert not path.endswith("/tv/")
+        assert not path.endswith("/tv")
+        assert path.count("/") >= 3  # /media/completed/tv/something
 
 
 class TestSettingsReload:

--- a/test/test_rip_logic.py
+++ b/test/test_rip_logic.py
@@ -223,6 +223,25 @@ class TestSaveDiscPoster:
 
         mock_run.assert_not_called()
 
+    def test_mount_failure_skips_umount(self, app_context, sample_job):
+        """When mount fails, umount should NOT be called (#1664)."""
+        from arm.ripper.utils import save_disc_poster
+
+        sample_job.disctype = "dvd"
+        sample_job.devpath = "/dev/sr0"
+        sample_job.mountpoint = "/mnt/sr0"
+
+        with unittest.mock.patch('arm.ripper.utils.cfg') as mock_cfg, \
+             unittest.mock.patch('arm.ripper.utils.subprocess.run') as mock_run:
+            mock_cfg.arm_config = {"RIP_POSTER": True}
+            mock_run.return_value = unittest.mock.Mock(returncode=1, stderr="mount failed")
+
+            save_disc_poster("/tmp/final", sample_job)
+
+            # subprocess.run should be called once (mount) but NOT twice (umount)
+            assert mock_run.call_count == 1
+            assert mock_run.call_args_list[0][0][0][0] == "mount"
+
 
 class TestRipMusic:
     """Test rip_music() audio CD ripping logic."""


### PR DESCRIPTION
## Summary

Fixes safety issues found during audit of 6 upstream ports that were merged prematurely (PR #89).

- **#60** — Normalize hyphens and dots as word separators in `parse_label()`, placed after Blu-ray suffix removal to avoid breaking literal matching
- **#1605** — Consolidate duplicate `parse_disc_label_for_identifiers()` onto `arm_matcher.parse_label()`, fix empty folder bug (returned `""` instead of `formatted_title` when series title unavailable)
- **#1639** — Guard against `None` from `yaml.safe_load` on empty YAML files in config reload
- **#1660** — Use `install -o arm -g arm` for `abcde.conf` (was `cp`, created as root), restore `arm.yaml` ownership after `sed -i` overrides
- **#1664** — Move mount failure early-return before `try/finally` so `umount` only runs when mount succeeded

## Test plan

- [x] 1387 tests pass locally (9 pre-existing failures in `test_makemkv_coverage.py` unrelated)
- [x] Shell script syntax validated (`bash -n`)
- [ ] CI pipeline passes