### PR TITLE
feat: configurable PRESCAN_TIMEOUT setting

### DIFF
--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -152,7 +152,8 @@ def main():
                     raise FileNotFoundError(f"{job.devpath} not found")
                 logging.info("Pre-scanning disc titles for review (attempt %d)...", attempt)
                 makemkv.prep_mkv()
-                makemkv.prescan_track_info(job, timeout=300)
+                prescan_timeout = int(cfg.arm_config.get('PRESCAN_TIMEOUT', 300))
+                makemkv.prescan_track_info(job, timeout=prescan_timeout)
                 db.session.expire(job, ['tracks'])
                 tracks = list(job.tracks)
                 if len(tracks) == 0:

--- a/setup/arm.yaml
+++ b/setup/arm.yaml
@@ -92,6 +92,11 @@ MAX_CONCURRENT_MAKEMKVINFO: 0
 # of this period, ARM exits gracefully instead of throwing an error.
 DRIVE_READY_TIMEOUT: 60
 
+# How long (in seconds) to wait for MakeMKV pre-scan to complete per attempt.
+# Large discs (e.g. 40+ title UHD Blu-rays) may need 600s or more.
+# The pre-scan runs up to 3 attempts before giving up.
+PRESCAN_TIMEOUT: 300
+
 # Additional parameters for dd. e.g. "conv=noerror,sync" for ignoring read errors
 # "status=progress" to log progress
 DATA_RIP_PARAMETERS: ""


### PR DESCRIPTION
## Summary
- Adds `PRESCAN_TIMEOUT` to `arm.yaml` (default 300s, backward compatible)
- MakeMKV pre-scan timeout is now configurable instead of hardcoded
- Large UHD discs (40+ titles like LOTR Extended) need 600s+ for the info scan

## Scope for upcoming work

### Upstream cherry-picks (2 of 6 new commits)
- [ ] `9850e690` — #1696: Refactor logging & exception handling (adds ProcessHandler)
- [ ] `41852f0d` — #1691: Trim whitespace from form values on save (fixes pasted MakeMKV keys)
- Skip: #1677 (Debian installer), #1682 (macOS docs), #1685/#1700 (dep bumps)

### UI polish items
- [ ] New discs show "ready/active" instead of "Scanning" during MakeMKV pre-scan phase
- [ ] Hide TVDB button on movie jobs (only show for series/tv `video_type`)

### Drive investigation
- Pioneer BDR-S12JX showing L-EC UNCORRECTABLE ERROR on multiple brand new discs
- Same drive timing out on pre-scan info phase for known-good discs (LOTR)
- May need firmware update or drive replacement

## Test plan
- [x] Verify default 300s works when `PRESCAN_TIMEOUT` is not set in arm.yaml
- [x] Set `PRESCAN_TIMEOUT: 600` and verify large disc pre-scan completes
- [x] Deploy to hifi-server and test with LOTR disc