### PR TITLE
feat: auto-initialize database on startup and add setup wizard endpoints

### DIFF
--- a/arm/api/v1/setup.py
+++ b/arm/api/v1/setup.py
@@ -1,0 +1,94 @@
+"""API v1 — Setup wizard endpoints."""
+import logging
+import os
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+import arm.config.config as cfg
+from arm.database import db
+from arm.services.config import arm_db_check
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["setup"])
+
+
+def _read_version() -> str:
+    """Read ARM version from VERSION file."""
+    for p in ("VERSION", os.path.join(cfg.arm_config.get("INSTALLPATH", "/opt/arm"), "VERSION")):
+        try:
+            with open(p) as f:
+                return f.read().strip()
+        except OSError:
+            continue
+    return "unknown"
+
+
+@router.get("/setup/status")
+def get_setup_status():
+    """Return setup state for the wizard.
+
+    Designed to work even when the database is not yet initialized —
+    all DB queries are wrapped in try/except so the endpoint always
+    returns a valid JSON response.
+    """
+    try:
+        db_status = arm_db_check()
+    except Exception:
+        db_status = {
+            "db_exists": False,
+            "db_current": False,
+            "head_revision": "unknown",
+            "db_revision": "unknown",
+        }
+
+    db_initialized = db_status.get("db_current", False)
+
+    # Check first_run via AppState.setup_complete
+    first_run = True
+    drive_count = 0
+    try:
+        from arm.models.app_state import AppState
+        state = AppState.get()
+        first_run = not state.setup_complete
+    except Exception:
+        pass  # Table may not exist yet
+
+    try:
+        from arm.models.system_drives import SystemDrives
+        drive_count = SystemDrives.query.count()
+    except Exception:
+        pass
+
+    return {
+        "db_exists": db_status.get("db_exists", False),
+        "db_initialized": db_initialized,
+        "db_current": db_initialized,
+        "db_version": db_status.get("db_revision", "unknown"),
+        "db_head": db_status.get("head_revision", "unknown"),
+        "first_run": first_run,
+        "arm_version": _read_version(),
+        "setup_steps": {
+            "database": "complete" if db_initialized else "pending",
+            "drives": f"{drive_count} detected",
+            "settings_reviewed": "complete" if not first_run else "pending",
+        },
+    }
+
+
+@router.post("/setup/complete")
+def complete_setup():
+    """Mark setup as done. Prevents the wizard from showing again."""
+    try:
+        from arm.models.app_state import AppState
+        state = AppState.get()
+        state.setup_complete = True
+        db.session.commit()
+        return {"success": True}
+    except Exception as e:
+        log.error("Failed to mark setup complete: %s", e)
+        return JSONResponse(
+            status_code=500,
+            content={"success": False, "error": str(e)},
+        )

--- a/arm/app.py
+++ b/arm/app.py
@@ -29,7 +29,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-from arm.api.v1 import jobs, logs, metadata, notifications, settings, system, drives, files  # noqa: E402
+from arm.api.v1 import jobs, logs, metadata, notifications, settings, system, drives, files, setup  # noqa: E402
 
 app.include_router(jobs.router)
 app.include_router(logs.router)
@@ -39,3 +39,4 @@ app.include_router(settings.router)
 app.include_router(system.router)
 app.include_router(drives.router)
 app.include_router(files.router)
+app.include_router(setup.router)

--- a/arm/migrations/versions/i3j4k5l6m7n8_app_state_add_setup_complete.py
+++ b/arm/migrations/versions/i3j4k5l6m7n8_app_state_add_setup_complete.py
@@ -18,22 +18,19 @@ def upgrade():
         batch_op.add_column(sa.Column('setup_complete', sa.Boolean(), nullable=False, server_default='0'))
 
     # Data migration: mark existing deployments as setup-complete so they
-    # don't see the setup wizard on upgrade.  During a fresh `alembic upgrade
-    # head` this migration is the newest, so no *other* revision will be in
-    # alembic_version yet — the check below detects that and leaves the
-    # default (False) in place.
+    # don't see the setup wizard on upgrade.  We detect an existing deployment
+    # by checking if the job table has any rows — fresh installs have zero jobs.
     conn = op.get_bind()
     try:
-        result = conn.execute(sa.text(
-            "SELECT COUNT(*) FROM app_state WHERE id = 1"
-        ))
-        if result.scalar() > 0:
-            # Row exists → this is an upgrade, not a fresh install
+        result = conn.execute(sa.text("SELECT COUNT(*) FROM job"))
+        job_count = result.scalar()
+        if job_count > 0:
+            # Jobs exist → existing deployment, skip the wizard
             conn.execute(sa.text(
                 "UPDATE app_state SET setup_complete = 1 WHERE id = 1"
             ))
     except Exception:
-        pass  # Table might not have any rows yet on fresh install
+        pass  # job table might not exist yet during fresh alembic upgrade head
 
 
 def downgrade():

--- a/arm/migrations/versions/i3j4k5l6m7n8_app_state_add_setup_complete.py
+++ b/arm/migrations/versions/i3j4k5l6m7n8_app_state_add_setup_complete.py
@@ -1,0 +1,41 @@
+"""Add setup_complete to app_state.
+
+Revision ID: i3j4k5l6m7n8
+Revises: h2i3j4k5l6m7
+Create Date: 2026-03-19
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'i3j4k5l6m7n8'
+down_revision = 'h2i3j4k5l6m7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('app_state') as batch_op:
+        batch_op.add_column(sa.Column('setup_complete', sa.Boolean(), nullable=False, server_default='0'))
+
+    # Data migration: mark existing deployments as setup-complete so they
+    # don't see the setup wizard on upgrade.  During a fresh `alembic upgrade
+    # head` this migration is the newest, so no *other* revision will be in
+    # alembic_version yet — the check below detects that and leaves the
+    # default (False) in place.
+    conn = op.get_bind()
+    try:
+        result = conn.execute(sa.text(
+            "SELECT COUNT(*) FROM app_state WHERE id = 1"
+        ))
+        if result.scalar() > 0:
+            # Row exists → this is an upgrade, not a fresh install
+            conn.execute(sa.text(
+                "UPDATE app_state SET setup_complete = 1 WHERE id = 1"
+            ))
+    except Exception:
+        pass  # Table might not have any rows yet on fresh install
+
+
+def downgrade():
+    with op.batch_alter_table('app_state') as batch_op:
+        batch_op.drop_column('setup_complete')

--- a/arm/models/app_state.py
+++ b/arm/models/app_state.py
@@ -12,16 +12,17 @@ class AppState(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     ripping_paused = db.Column(db.Boolean, default=False, nullable=False)
+    setup_complete = db.Column(db.Boolean, default=False, nullable=False)
 
     @classmethod
     def get(cls):
         """Return the singleton row, creating it if it doesn't exist."""
         state = cls.query.get(1)
         if state is None:
-            state = cls(id=1, ripping_paused=False)
+            state = cls(id=1, ripping_paused=False, setup_complete=False)
             db.session.add(state)
             db.session.commit()
         return state
 
     def __repr__(self):
-        return f'<AppState ripping_paused={self.ripping_paused}>'
+        return f'<AppState ripping_paused={self.ripping_paused} setup_complete={self.setup_complete}>'

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -152,7 +152,8 @@ def main():
                     raise FileNotFoundError(f"{job.devpath} not found")
                 logging.info("Pre-scanning disc titles for review (attempt %d)...", attempt)
                 makemkv.prep_mkv()
-                makemkv.prescan_track_info(job, timeout=300)
+                prescan_timeout = int(cfg.arm_config.get('PRESCAN_TIMEOUT', 300))
+                makemkv.prescan_track_info(job, timeout=prescan_timeout)
                 db.session.expire(job, ['tracks'])
                 tracks = list(job.tracks)
                 if len(tracks) == 0:

--- a/arm/runui.py
+++ b/arm/runui.py
@@ -28,6 +28,13 @@ def _clear_stale_pause():
 
 def startup():
     db.init_engine('sqlite:///' + cfg.arm_config['DBFILE'])
+    try:
+        svc_config.check_db_version(
+            cfg.arm_config['INSTALLPATH'],
+            cfg.arm_config['DBFILE'],
+        )
+    except Exception as e:
+        logging.error("Database initialization failed: %s", e)
     _clear_stale_pause()
     db_update = svc_config.arm_db_check()
     if db_update["db_current"]:

--- a/arm/services/config.py
+++ b/arm/services/config.py
@@ -77,8 +77,9 @@ def check_db_version(install_path, db_file):
         c.execute('SELECT version_num FROM alembic_version')
         db_version = c.fetchone()[0]
     except sqlite3.OperationalError:
-        log.warning("alembic_version table missing — database may need migration.")
+        log.warning("alembic_version table missing — running migrations to initialize database.")
         conn.close()
+        _alembic_upgrade(mig_dir, db_uri)
         return
 
     log.debug(f"Database version is: {db_version}")

--- a/setup/arm.yaml
+++ b/setup/arm.yaml
@@ -92,6 +92,11 @@ MAX_CONCURRENT_MAKEMKVINFO: 0
 # of this period, ARM exits gracefully instead of throwing an error.
 DRIVE_READY_TIMEOUT: 60
 
+# How long (in seconds) to wait for MakeMKV pre-scan to complete per attempt.
+# Large discs (e.g. 40+ title UHD Blu-rays) may need 600s or more.
+# The pre-scan runs up to 3 attempts before giving up.
+PRESCAN_TIMEOUT: 300
+
 # Additional parameters for dd. e.g. "conv=noerror,sync" for ignoring read errors
 # "status=progress" to log progress
 DATA_RIP_PARAMETERS: ""

--- a/test/test_services.py
+++ b/test/test_services.py
@@ -1117,13 +1117,15 @@ class TestCheckDbVersion:
         conn.commit()
         conn.close()
 
-        with patch("alembic.script.ScriptDirectory") as mock_sd:
+        with patch("alembic.script.ScriptDirectory") as mock_sd, \
+             patch("arm.services.config._alembic_upgrade") as mock_upgrade:
             mock_script = MagicMock()
             mock_script.get_current_head.return_value = "abc123"
             mock_sd.from_config.return_value = mock_script
 
-            # Should not raise — handles OperationalError gracefully
+            # Should run migrations when alembic_version table is missing
             check_db_version(str(tmp_path), db_file)
+            mock_upgrade.assert_called_once()
 
 
 class TestGenerateComments:

--- a/test/test_setup_api.py
+++ b/test/test_setup_api.py
@@ -1,0 +1,109 @@
+"""Tests for the setup wizard API endpoints (arm/api/v1/setup.py)."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(app_context):
+    """FastAPI test client."""
+    from arm.app import app
+    with TestClient(app, raise_server_exceptions=True) as client:
+        yield client
+
+
+class TestSetupStatus:
+    """Test GET /api/v1/setup/status endpoint."""
+
+    def test_returns_200(self, client):
+        response = client.get('/api/v1/setup/status')
+        assert response.status_code == 200
+
+    def test_returns_required_fields(self, client):
+        response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert 'db_exists' in data
+        assert 'db_initialized' in data
+        assert 'db_current' in data
+        assert 'first_run' in data
+        assert 'arm_version' in data
+        assert 'setup_steps' in data
+
+    def test_first_run_true_on_fresh_db(self, client):
+        """Fresh DB has setup_complete=False, so first_run should be True."""
+        response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert data['first_run'] is True
+
+    def test_setup_steps_database_present(self, client):
+        """Database step should be present in setup_steps."""
+        response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert 'database' in data['setup_steps']
+        assert data['setup_steps']['database'] in ('complete', 'pending')
+
+    def test_setup_steps_settings_pending(self, client):
+        """Fresh DB has setup_complete=False, so settings_reviewed should be pending."""
+        response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert data['setup_steps']['settings_reviewed'] == 'pending'
+
+    def test_drives_step_shows_count(self, client):
+        """Drives step should show a count string."""
+        response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert 'detected' in data['setup_steps']['drives']
+
+    def test_first_run_false_after_complete(self, client):
+        """After completing setup, first_run should be False."""
+        client.post('/api/v1/setup/complete')
+        response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert data['first_run'] is False
+
+    def test_db_not_initialized_when_check_fails(self, client):
+        """When arm_db_check raises, db_initialized should be False."""
+        with patch('arm.api.v1.setup.arm_db_check', side_effect=Exception('fail')):
+            response = client.get('/api/v1/setup/status')
+            data = response.json()
+            assert data['db_initialized'] is False
+
+    def test_arm_version_returned(self, client):
+        """Should return a version string."""
+        response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert isinstance(data['arm_version'], str)
+
+
+class TestSetupComplete:
+    """Test POST /api/v1/setup/complete endpoint."""
+
+    def test_returns_success(self, client):
+        response = client.post('/api/v1/setup/complete')
+        assert response.status_code == 200
+        assert response.json()['success'] is True
+
+    def test_sets_setup_complete_flag(self, client):
+        """After POST, AppState.setup_complete should be True."""
+        client.post('/api/v1/setup/complete')
+
+        from arm.models.app_state import AppState
+        state = AppState.get()
+        assert state.setup_complete is True
+
+    def test_idempotent(self, client):
+        """Calling complete twice should not error."""
+        resp1 = client.post('/api/v1/setup/complete')
+        resp2 = client.post('/api/v1/setup/complete')
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+
+    def test_complete_then_status_shows_done(self, client):
+        """After completing, settings_reviewed should show complete."""
+        client.post('/api/v1/setup/complete')
+        response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert data['setup_steps']['settings_reviewed'] == 'complete'
+        assert data['first_run'] is False


### PR DESCRIPTION
## Summary

Fixes the broken first-run state where the ARM backend starts with an empty database (no tables), causing 500 errors on all DB-dependent endpoints.

### Changes
- **Fix `check_db_version()`**: runs Alembic migrations when DB file exists but has no tables (previously returned silently)
- **Auto-init on startup**: `startup()` in `runui.py` now calls `check_db_version()` before `arm_db_check()`
- **Setup wizard endpoints**: `GET /api/v1/setup/status` and `POST /api/v1/setup/complete`
- **AppState migration**: adds `setup_complete` boolean with data migration for existing deployments

### Test Plan
- [x] 1469 tests pass
- [x] Fresh Docker deploy: 10 tables created automatically
- [x] `/api/v1/setup/status` returns `first_run: true` on fresh install
- [x] `/api/v1/jobs` no longer returns 500