### PR TITLE
feat: drive eject/close, drive mode, and job stats endpoints

### DIFF
--- a/arm/api/v1/drives.py
+++ b/arm/api/v1/drives.py
@@ -316,9 +316,38 @@ async def update_drive(drive_id: int, request: Request):
     if 'uhd_capable' in body:
         drive.uhd_capable = bool(body['uhd_capable'])
         updated['uhd_capable'] = drive.uhd_capable
+    if 'drive_mode' in body:
+        mode = str(body['drive_mode']).strip().lower()
+        if mode not in ('auto', 'manual'):
+            return JSONResponse({"success": False, "error": "drive_mode must be 'auto' or 'manual'"}, status_code=400)
+        drive.drive_mode = mode
+        updated['drive_mode'] = drive.drive_mode
 
     if not updated:
         return JSONResponse({"success": False, "error": "No valid fields provided"}, status_code=400)
 
     db.session.commit()
     return {"success": True, "drive_id": drive.drive_id}
+
+
+@router.post('/drives/{drive_id}/eject')
+async def eject_drive(drive_id: int, request: Request):
+    """Eject, close, or toggle the drive tray."""
+    drive = SystemDrives.query.get(drive_id)
+    if not drive:
+        return JSONResponse({"success": False, "error": "Drive not found"}, status_code=404)
+
+    body = await request.json() if await request.body() else {}
+    method = body.get('method', 'toggle')
+    if method not in ('eject', 'close', 'toggle'):
+        return JSONResponse(
+            {"success": False, "error": "method must be 'eject', 'close', or 'toggle'"},
+            status_code=400,
+        )
+
+    try:
+        drive.eject(method=method)
+        return {"success": True, "drive_id": drive.drive_id, "method": method}
+    except Exception as e:
+        log.error("Drive %s eject(%s) failed: %s", drive_id, method, e)
+        return JSONResponse({"success": False, "error": str(e)}, status_code=500)

--- a/arm/api/v1/drives.py
+++ b/arm/api/v1/drives.py
@@ -350,4 +350,7 @@ async def eject_drive(drive_id: int, request: Request):
         return {"success": True, "drive_id": drive.drive_id, "method": method}
     except Exception as e:
         log.error("Drive %s eject(%s) failed: %s", drive_id, method, e)
-        return JSONResponse({"success": False, "error": str(e)}, status_code=500)
+        return JSONResponse(
+            {"success": False, "error": "Failed to control drive tray"},
+            status_code=500,
+        )

--- a/arm/api/v1/system.py
+++ b/arm/api/v1/system.py
@@ -204,3 +204,39 @@ async def set_ripping_enabled(request: Request):
         "success": True,
         "ripping_enabled": not state.ripping_paused,
     }
+
+
+@router.get('/system/stats/jobs')
+def get_job_stats():
+    """Return job counts grouped by status and video type."""
+    from arm.models.job import Job
+    from sqlalchemy import func
+
+    try:
+        # Counts by status
+        status_rows = (
+            db.session.query(Job.status, func.count(Job.job_id))
+            .group_by(Job.status)
+            .all()
+        )
+        by_status = {str(status): count for status, count in status_rows}
+
+        # Counts by video_type
+        type_rows = (
+            db.session.query(Job.video_type, func.count(Job.job_id))
+            .filter(Job.video_type.isnot(None))
+            .group_by(Job.video_type)
+            .all()
+        )
+        by_type = {str(vtype): count for vtype, count in type_rows}
+
+        total = sum(by_status.values())
+
+        return {
+            "by_status": by_status,
+            "by_type": by_type,
+            "total": total,
+        }
+    except Exception as e:
+        log.error("Failed to get job stats: %s", e)
+        return JSONResponse({"error": str(e)}, status_code=500)

--- a/arm/api/v1/system.py
+++ b/arm/api/v1/system.py
@@ -239,4 +239,7 @@ def get_job_stats():
         }
     except Exception as e:
         log.error("Failed to get job stats: %s", e)
-        return JSONResponse({"error": str(e)}, status_code=500)
+        return JSONResponse(
+            {"error": "Failed to retrieve job statistics"},
+            status_code=500,
+        )

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -152,7 +152,8 @@ def main():
                     raise FileNotFoundError(f"{job.devpath} not found")
                 logging.info("Pre-scanning disc titles for review (attempt %d)...", attempt)
                 makemkv.prep_mkv()
-                makemkv.prescan_track_info(job, timeout=300)
+                prescan_timeout = int(cfg.arm_config.get('PRESCAN_TIMEOUT', 300))
+                makemkv.prescan_track_info(job, timeout=prescan_timeout)
                 db.session.expire(job, ['tracks'])
                 tracks = list(job.tracks)
                 if len(tracks) == 0:

--- a/setup/arm.yaml
+++ b/setup/arm.yaml
@@ -92,6 +92,11 @@ MAX_CONCURRENT_MAKEMKVINFO: 0
 # of this period, ARM exits gracefully instead of throwing an error.
 DRIVE_READY_TIMEOUT: 60
 
+# How long (in seconds) to wait for MakeMKV pre-scan to complete per attempt.
+# Large discs (e.g. 40+ title UHD Blu-rays) may need 600s or more.
+# The pre-scan runs up to 3 attempts before giving up.
+PRESCAN_TIMEOUT: 300
+
 # Additional parameters for dd. e.g. "conv=noerror,sync" for ignoring read errors
 # "status=progress" to log progress
 DATA_RIP_PARAMETERS: ""

--- a/test/test_drive_system_controls.py
+++ b/test/test_drive_system_controls.py
@@ -1,0 +1,133 @@
+"""Tests for drive controls and system controls endpoints."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(app_context):
+    """FastAPI test client."""
+    from arm.app import app
+    with TestClient(app, raise_server_exceptions=True) as client:
+        yield client
+
+
+def _make_drive(db_obj, **overrides):
+    """Create a test drive in the DB."""
+    from arm.models.system_drives import SystemDrives
+    drive = SystemDrives()
+    drive.name = overrides.get('name', 'Test Drive')
+    drive.mount = overrides.get('mount', '/dev/sr0')
+    drive.drive_mode = overrides.get('drive_mode', 'auto')
+    db_obj.session.add(drive)
+    db_obj.session.commit()
+    return drive
+
+
+def _make_job(db_obj, **overrides):
+    """Create a test job in the DB by inserting directly."""
+    from sqlalchemy import text
+    title = overrides.get('title', 'Test')
+    status = overrides.get('status', 'success')
+    video_type = overrides.get('video_type', 'movie')
+    db_obj.session.execute(text(
+        "INSERT INTO job (title, status, video_type, devpath) VALUES (:t, :s, :v, :d)"
+    ), {"t": title, "s": status, "v": video_type, "d": "/dev/sr0"})
+    return None
+
+
+class TestDriveEject:
+    """Test POST /api/v1/drives/{drive_id}/eject endpoint."""
+
+    def test_eject_drive_not_found(self, client):
+        response = client.post('/api/v1/drives/99999/eject', json={"method": "eject"})
+        assert response.status_code == 404
+
+    def test_eject_invalid_method(self, client, app_context):
+        _, db_obj = app_context
+        drive = _make_drive(db_obj)
+        response = client.post(f'/api/v1/drives/{drive.drive_id}/eject', json={"method": "invalid"})
+        assert response.status_code == 400
+
+    def test_eject_default_toggle(self, client, app_context):
+        _, db_obj = app_context
+        drive = _make_drive(db_obj)
+        from arm.models.system_drives import SystemDrives
+        with patch.object(SystemDrives, 'eject') as mock_eject:
+            response = client.post(f'/api/v1/drives/{drive.drive_id}/eject')
+            assert response.status_code == 200
+            assert response.json()["method"] == "toggle"
+            mock_eject.assert_called_once_with(method="toggle")
+
+    def test_eject_method_eject(self, client, app_context):
+        _, db_obj = app_context
+        drive = _make_drive(db_obj)
+        from arm.models.system_drives import SystemDrives
+        with patch.object(SystemDrives, 'eject') as mock_eject:
+            response = client.post(f'/api/v1/drives/{drive.drive_id}/eject', json={"method": "eject"})
+            assert response.status_code == 200
+            assert response.json()["success"] is True
+
+    def test_eject_failure(self, client, app_context):
+        _, db_obj = app_context
+        drive = _make_drive(db_obj)
+        from arm.models.system_drives import SystemDrives
+        with patch.object(SystemDrives, 'eject', side_effect=RuntimeError("eject failed")):
+            response = client.post(f'/api/v1/drives/{drive.drive_id}/eject', json={"method": "eject"})
+            assert response.status_code == 500
+
+
+class TestDriveModeUpdate:
+    """Test PATCH /api/v1/drives/{drive_id} with drive_mode."""
+
+    def test_update_drive_mode_auto(self, client, app_context):
+        _, db_obj = app_context
+        drive = _make_drive(db_obj, drive_mode="manual")
+        response = client.patch(f'/api/v1/drives/{drive.drive_id}', json={"drive_mode": "auto"})
+        assert response.status_code == 200
+        db_obj.session.refresh(drive)
+        assert drive.drive_mode == "auto"
+
+    def test_update_drive_mode_manual(self, client, app_context):
+        _, db_obj = app_context
+        drive = _make_drive(db_obj, drive_mode="auto")
+        response = client.patch(f'/api/v1/drives/{drive.drive_id}', json={"drive_mode": "manual"})
+        assert response.status_code == 200
+        db_obj.session.refresh(drive)
+        assert drive.drive_mode == "manual"
+
+    def test_update_drive_mode_invalid(self, client, app_context):
+        _, db_obj = app_context
+        drive = _make_drive(db_obj)
+        response = client.patch(f'/api/v1/drives/{drive.drive_id}', json={"drive_mode": "turbo"})
+        assert response.status_code == 400
+
+
+class TestJobStats:
+    """Test GET /api/v1/system/stats/jobs endpoint."""
+
+    def test_job_stats_empty(self, client):
+        response = client.get('/api/v1/system/stats/jobs')
+        assert response.status_code == 200
+        data = response.json()
+        assert "by_status" in data
+        assert "by_type" in data
+        assert data["total"] == 0
+
+    def test_job_stats_with_jobs(self, client, app_context):
+        _, db_obj = app_context
+        _make_job(db_obj, title="M1", status="success", video_type="movie")
+        _make_job(db_obj, title="M2", status="success", video_type="movie")
+        _make_job(db_obj, title="S1", status="fail", video_type="series")
+        db_obj.session.commit()
+
+        response = client.get('/api/v1/system/stats/jobs')
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        assert data["by_status"].get("success") == 2
+        assert data["by_status"].get("fail") == 1
+        assert data["by_type"].get("movie") == 2
+        assert data["by_type"].get("series") == 1


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/drives/{drive_id}/eject` endpoint (eject, close, toggle methods)
- Add `drive_mode` field to PATCH `/api/v1/drives/{drive_id}` (auto/manual toggle)
- Add `GET /api/v1/system/stats/jobs` endpoint (job counts by status and type)
- 10 new tests covering all new endpoints

## Test plan
- [ ] Verify eject endpoint returns success with valid drive
- [ ] Verify eject returns 404 for missing drive
- [ ] Verify drive_mode PATCH accepts auto/manual, rejects invalid
- [ ] Verify job stats returns correct counts grouped by status and type
- [ ] All 10 new tests pass