### PR TITLE
feat: maintenance endpoints, MakeMKV key check, track fields

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -664,3 +664,49 @@ def _clean_for_filename(string):
     string = string.replace("\\", " - ")
     string = re.sub(r"[^\w -]", "", string)
     return string.strip()
+
+
+# --- Track field updates ---
+
+_TRACK_EDITABLE_FIELDS: dict[str, type] = {"enabled": bool, "filename": str, "ripped": bool}
+
+
+@router.patch('/jobs/{job_id}/tracks/{track_id}')
+def update_track_fields(job_id: int, track_id: int, body: dict):
+    """Update editable fields (enabled, filename, ripped) on a track."""
+    invalid = set(body.keys()) - _TRACK_EDITABLE_FIELDS.keys()
+    if invalid:
+        return JSONResponse(
+            {"success": False, "error": f"Unknown fields: {', '.join(sorted(invalid))}"},
+            status_code=400,
+        )
+    if not body:
+        return JSONResponse(
+            {"success": False, "error": "No fields to update"},
+            status_code=400,
+        )
+
+    clean: dict = {}
+    for key, value in body.items():
+        expected = _TRACK_EDITABLE_FIELDS[key]
+        if expected is bool:
+            if isinstance(value, bool):
+                clean[key] = value
+            elif isinstance(value, str):
+                clean[key] = value.lower() in ("true", "1", "yes")
+            else:
+                clean[key] = bool(value)
+        else:
+            clean[key] = str(value)
+
+    track = Track.query.filter_by(track_id=track_id, job_id=job_id).first()
+    if not track:
+        return JSONResponse(
+            {"success": False, "error": "Track not found"},
+            status_code=404,
+        )
+
+    for key, value in clean.items():
+        setattr(track, key, value)
+    db.session.commit()
+    return {"success": True, "job_id": job_id, "track_id": track_id, "updated": clean}

--- a/arm/api/v1/maintenance.py
+++ b/arm/api/v1/maintenance.py
@@ -36,16 +36,24 @@ def get_orphan_folders():
 @router.post("/maintenance/delete-log")
 def delete_log(req: PathRequest):
     result = svc.delete_log(req.path)
-    if not result["success"] and "outside" in result.get("error", ""):
-        raise HTTPException(status_code=403, detail=result["error"])
+    if not result["success"]:
+        error = result.get("error", "")
+        if "outside" in error:
+            raise HTTPException(status_code=403, detail=error)
+        if "not found" in error.lower():
+            raise HTTPException(status_code=404, detail=error)
     return result
 
 
 @router.post("/maintenance/delete-folder")
 def delete_folder(req: PathRequest):
     result = svc.delete_folder(req.path)
-    if not result["success"] and "outside" in result.get("error", ""):
-        raise HTTPException(status_code=403, detail=result["error"])
+    if not result["success"]:
+        error = result.get("error", "")
+        if "outside" in error:
+            raise HTTPException(status_code=403, detail=error)
+        if "not found" in error.lower():
+            raise HTTPException(status_code=404, detail=error)
     return result
 
 

--- a/arm/api/v1/maintenance.py
+++ b/arm/api/v1/maintenance.py
@@ -1,4 +1,6 @@
 """API v1 — Maintenance endpoints for orphan detection and cleanup."""
+from pathlib import Path
+
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
@@ -39,9 +41,9 @@ def delete_log(req: PathRequest):
     if not result["success"]:
         error = result.get("error", "")
         if "outside" in error:
-            raise HTTPException(status_code=403, detail=error)
+            raise HTTPException(status_code=403, detail="Access denied")
         if "not found" in error.lower():
-            raise HTTPException(status_code=404, detail=error)
+            raise HTTPException(status_code=404, detail="File not found")
     return result
 
 
@@ -51,17 +53,28 @@ def delete_folder(req: PathRequest):
     if not result["success"]:
         error = result.get("error", "")
         if "outside" in error:
-            raise HTTPException(status_code=403, detail=error)
+            raise HTTPException(status_code=403, detail="Access denied")
         if "not found" in error.lower():
-            raise HTTPException(status_code=404, detail=error)
+            raise HTTPException(status_code=404, detail="Directory not found")
     return result
 
 
 @router.post("/maintenance/bulk-delete-logs")
 def bulk_delete_logs(req: BulkPathRequest):
-    return svc.bulk_delete_logs(req.paths)
+    result = svc.bulk_delete_logs(req.paths)
+    # Sanitize error messages — don't expose internal paths
+    result["errors"] = [
+        f"{Path(e.split(':')[0]).name}: operation failed" if ':' in e else e
+        for e in result.get("errors", [])
+    ]
+    return result
 
 
 @router.post("/maintenance/bulk-delete-folders")
 def bulk_delete_folders(req: BulkPathRequest):
-    return svc.bulk_delete_folders(req.paths)
+    result = svc.bulk_delete_folders(req.paths)
+    result["errors"] = [
+        f"{Path(e.split(':')[0]).name}: operation failed" if ':' in e else e
+        for e in result.get("errors", [])
+    ]
+    return result

--- a/arm/api/v1/maintenance.py
+++ b/arm/api/v1/maintenance.py
@@ -1,0 +1,59 @@
+"""API v1 — Maintenance endpoints for orphan detection and cleanup."""
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from arm.services import maintenance as svc
+
+router = APIRouter(prefix="/api/v1", tags=["maintenance"])
+
+
+class PathRequest(BaseModel):
+    path: str
+
+
+class BulkPathRequest(BaseModel):
+    paths: list[str]
+
+
+@router.get("/maintenance/counts")
+def get_counts():
+    """Return orphan counts for summary display."""
+    return svc.get_counts()
+
+
+@router.get("/maintenance/orphan-logs")
+def get_orphan_logs():
+    """List log files not referenced by any job."""
+    return svc.get_orphan_logs()
+
+
+@router.get("/maintenance/orphan-folders")
+def get_orphan_folders():
+    """List folders in RAW_PATH/COMPLETED_PATH not matching any job."""
+    return svc.get_orphan_folders()
+
+
+@router.post("/maintenance/delete-log")
+def delete_log(req: PathRequest):
+    result = svc.delete_log(req.path)
+    if not result["success"] and "outside" in result.get("error", ""):
+        raise HTTPException(status_code=403, detail=result["error"])
+    return result
+
+
+@router.post("/maintenance/delete-folder")
+def delete_folder(req: PathRequest):
+    result = svc.delete_folder(req.path)
+    if not result["success"] and "outside" in result.get("error", ""):
+        raise HTTPException(status_code=403, detail=result["error"])
+    return result
+
+
+@router.post("/maintenance/bulk-delete-logs")
+def bulk_delete_logs(req: BulkPathRequest):
+    return svc.bulk_delete_logs(req.paths)
+
+
+@router.post("/maintenance/bulk-delete-folders")
+def bulk_delete_folders(req: BulkPathRequest):
+    return svc.bulk_delete_folders(req.paths)

--- a/arm/api/v1/setup.py
+++ b/arm/api/v1/setup.py
@@ -90,5 +90,5 @@ def complete_setup():
         log.error("Failed to mark setup complete: %s", e)
         return JSONResponse(
             status_code=500,
-            content={"success": False, "error": str(e)},
+            content={"success": False, "error": "Failed to mark setup complete"},
         )

--- a/arm/api/v1/system.py
+++ b/arm/api/v1/system.py
@@ -97,9 +97,16 @@ def get_system_stats():
 
 @router.get('/system/ripping-enabled')
 def get_ripping_enabled():
-    """Return whether ripping is currently enabled (not paused)."""
+    """Return whether ripping is currently enabled, plus MakeMKV key status."""
     state = AppState.get()
-    return {"ripping_enabled": not state.ripping_paused}
+    return {
+        "ripping_enabled": not state.ripping_paused,
+        "makemkv_key_valid": state.makemkv_key_valid,
+        "makemkv_key_checked_at": (
+            state.makemkv_key_checked_at.isoformat()
+            if state.makemkv_key_checked_at else None
+        ),
+    }
 
 
 @router.get('/system/version')
@@ -186,6 +193,9 @@ def get_paths():
     return results
 
 
+from arm.ripper.makemkv import prep_mkv
+
+
 @router.post('/system/ripping-enabled')
 async def set_ripping_enabled(request: Request):
     """Toggle global ripping pause."""
@@ -203,6 +213,40 @@ async def set_ripping_enabled(request: Request):
     return {
         "success": True,
         "ripping_enabled": not state.ripping_paused,
+    }
+
+
+@router.post('/system/makemkv-key-check')
+def check_makemkv_key():
+    """Run prep_mkv() to validate/update the MakeMKV key."""
+    from arm.ripper.makemkv import UpdateKeyRunTimeError, UpdateKeyErrorCodes
+
+    message = "MakeMKV key is valid"
+    try:
+        prep_mkv()
+    except UpdateKeyRunTimeError as exc:
+        code = UpdateKeyErrorCodes(exc.returncode)
+        messages = {
+            UpdateKeyErrorCodes.URL_ERROR: (
+                "Could not reach forum.makemkv.com — set MAKEMKV_PERMA_KEY "
+                "in arm.yaml to use a purchased key"
+            ),
+            UpdateKeyErrorCodes.PARSE_ERROR: "MakeMKV settings file is corrupt",
+            UpdateKeyErrorCodes.INTERNAL_ERROR: "Key update script produced invalid output",
+            UpdateKeyErrorCodes.INVALID_MAKEMKV_SERIAL: (
+                "Invalid MakeMKV serial key format — should match M-XXXX-..."
+            ),
+        }
+        message = messages.get(code, f"Key update failed (error {code.name})")
+
+    state = AppState.get()
+    return {
+        "key_valid": state.makemkv_key_valid,
+        "checked_at": (
+            state.makemkv_key_checked_at.isoformat()
+            if state.makemkv_key_checked_at else None
+        ),
+        "message": message,
     }
 
 

--- a/arm/app.py
+++ b/arm/app.py
@@ -29,7 +29,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-from arm.api.v1 import jobs, logs, metadata, notifications, settings, system, drives, files, setup, folder  # noqa: E402
+from arm.api.v1 import jobs, logs, metadata, notifications, settings, system, drives, files, setup, folder, maintenance  # noqa: E402
 
 app.include_router(jobs.router)
 app.include_router(logs.router)
@@ -41,3 +41,4 @@ app.include_router(drives.router)
 app.include_router(files.router)
 app.include_router(setup.router)
 app.include_router(folder.router)
+app.include_router(maintenance.router)

--- a/arm/migrations/versions/j4k5l6m7n8o9_app_state_add_makemkv_key.py
+++ b/arm/migrations/versions/j4k5l6m7n8o9_app_state_add_makemkv_key.py
@@ -1,0 +1,25 @@
+"""Add makemkv_key_valid and makemkv_key_checked_at to app_state.
+
+Revision ID: j4k5l6m7n8o9
+Revises: i3j4k5l6m7n8
+Create Date: 2026-03-22
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'j4k5l6m7n8o9'
+down_revision = 'i3j4k5l6m7n8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('app_state') as batch_op:
+        batch_op.add_column(sa.Column('makemkv_key_valid', sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column('makemkv_key_checked_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('app_state') as batch_op:
+        batch_op.drop_column('makemkv_key_checked_at')
+        batch_op.drop_column('makemkv_key_valid')

--- a/arm/models/app_state.py
+++ b/arm/models/app_state.py
@@ -13,6 +13,8 @@ class AppState(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     ripping_paused = db.Column(db.Boolean, default=False, nullable=False)
     setup_complete = db.Column(db.Boolean, default=False, nullable=False)
+    makemkv_key_valid = db.Column(db.Boolean, nullable=True, default=None)
+    makemkv_key_checked_at = db.Column(db.DateTime, nullable=True, default=None)
 
     @classmethod
     def get(cls):

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -452,6 +452,7 @@ class UpdateKeyRunTimeError(RuntimeError):
     """
 
     def __init__(self, returncode, cmd, output=None):
+        self.returncode = returncode
         if len(cmd) == 3:
             cmd[2] = cmd[2][:4] + "XXXX"  # don't log the key to cli
         logging.debug(f"Updating Key with command: '{' '.join(cmd)}'")
@@ -1125,11 +1126,16 @@ def setup_rawpath(job, raw_path):
 
 def prep_mkv():
     """
-    Make sure the MakeMKV key is up-to-date
+    Make sure the MakeMKV key is up-to-date.
+
+    Persists the result to AppState so the UI can display key validity.
 
     Raises:
         UpdateKeyRunTimeError
     """
+    from datetime import datetime, timezone
+    from arm.models.app_state import AppState
+
     try:
         logging.info("Updating MakeMKV key...")
         cmd = [
@@ -1144,6 +1150,13 @@ def prep_mkv():
         proc = subprocess.run(cmd, capture_output=True, check=True)
         stdout = proc.stdout.decode("utf-8")
         logging.debug(f"Command Output for update_key.sh: {stdout.splitlines()}")
+
+        # Persist success
+        state = AppState.get()
+        state.makemkv_key_valid = True
+        state.makemkv_key_checked_at = datetime.now(timezone.utc)
+        db.session.commit()
+
     except subprocess.CalledProcessError as err:
         rc = err.returncode
         output = err.stdout.decode("utf-8") if err.stdout else ""
@@ -1153,6 +1166,13 @@ def prep_mkv():
                 "The server may be unreachable. Set MAKEMKV_PERMA_KEY in "
                 "arm.yaml to use a purchased key and avoid this dependency."
             )
+
+        # Persist failure
+        state = AppState.get()
+        state.makemkv_key_valid = False
+        state.makemkv_key_checked_at = datetime.now(timezone.utc)
+        db.session.commit()
+
         raise UpdateKeyRunTimeError(rc, cmd, output=output)
 
 

--- a/arm/services/maintenance.py
+++ b/arm/services/maintenance.py
@@ -1,0 +1,200 @@
+"""Maintenance service — orphan detection and filesystem cleanup."""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+import arm.config.config as cfg
+from arm.database import db
+from arm.models.job import Job
+
+log = logging.getLogger(__name__)
+
+
+def get_orphan_logs() -> dict[str, Any]:
+    """Find log files not referenced by any job.
+
+    Scans LOGPATH for *.log files and cross-references against Job.logfile.
+    Returns dict with root, total_size_bytes, and files list.
+    """
+    log_path = Path(cfg.arm_config["LOGPATH"])
+    if not log_path.is_dir():
+        return {"root": str(log_path), "total_size_bytes": 0, "files": []}
+
+    # Get all logfile references from jobs
+    referenced = set()
+    for (logfile,) in db.session.query(Job.logfile).filter(Job.logfile.isnot(None)).all():
+        referenced.add(logfile)
+
+    orphans = []
+    total_size = 0
+    for f in sorted(log_path.glob("*.log")):
+        if f.name not in referenced:
+            size = f.stat().st_size
+            orphans.append({
+                "path": str(f),
+                "relative_path": f.name,
+                "size_bytes": size,
+            })
+            total_size += size
+
+    return {"root": str(log_path), "total_size_bytes": total_size, "files": orphans}
+
+
+def _dir_size(path: Path) -> int:
+    """Compute total size of all files in a directory tree."""
+    total = 0
+    try:
+        for entry in os.scandir(path):
+            if entry.is_file(follow_symlinks=False):
+                total += entry.stat().st_size
+            elif entry.is_dir(follow_symlinks=False):
+                total += _dir_size(Path(entry.path))
+    except PermissionError:
+        pass
+    return total
+
+
+def _get_job_references() -> set[str]:
+    """Collect all folder name references from jobs (title, label, raw_path basename)."""
+    refs: set[str] = set()
+    rows = db.session.query(Job.title, Job.label, Job.raw_path, Job.path).all()
+    for title, label, raw_path, path in rows:
+        if title:
+            refs.add(title)
+        if label:
+            refs.add(label)
+        if raw_path:
+            refs.add(Path(raw_path).name)
+        if path:
+            refs.add(Path(path).name)
+    return refs
+
+
+def get_orphan_folders() -> dict[str, Any]:
+    """Find folders in RAW_PATH and COMPLETED_PATH not referenced by any job.
+
+    Cross-references directory names against Job.title, Job.label,
+    Job.raw_path basename, and Job.path basename.
+    """
+    raw_path = Path(cfg.arm_config.get("RAW_PATH", ""))
+    completed_path = Path(cfg.arm_config.get("COMPLETED_PATH", ""))
+
+    refs = _get_job_references()
+
+    orphans = []
+    total_size = 0
+
+    def _scan_dir(root: Path, category: str):
+        nonlocal total_size
+        if not root.is_dir():
+            return
+        for entry in sorted(root.iterdir()):
+            if entry.is_dir() and entry.name not in refs:
+                size = _dir_size(entry)
+                orphans.append({
+                    "path": str(entry),
+                    "name": entry.name,
+                    "category": category,
+                    "size_bytes": size,
+                })
+                total_size += size
+
+    _scan_dir(raw_path, "raw")
+    # Scan completed subdirectories (completed/movies/, completed/series/, etc.)
+    if completed_path.is_dir():
+        for subdir in completed_path.iterdir():
+            if subdir.is_dir():
+                _scan_dir(subdir, "completed")
+
+    return {"total_size_bytes": total_size, "folders": orphans}
+
+
+def get_counts() -> dict[str, int]:
+    """Return orphan counts for summary display."""
+    logs = get_orphan_logs()
+    folders = get_orphan_folders()
+    return {
+        "orphan_logs": len(logs["files"]),
+        "orphan_folders": len(folders["folders"]),
+    }
+
+
+def _is_path_within(path: Path, root: Path) -> bool:
+    """Check if path is contained within root after resolving symlinks."""
+    try:
+        resolved = path.resolve()
+        root_resolved = root.resolve()
+        return resolved.is_relative_to(root_resolved)
+    except (ValueError, OSError):
+        return False
+
+
+def delete_log(path_str: str) -> dict[str, Any]:
+    """Delete a single log file. Path must be within LOGPATH."""
+    target = Path(path_str)
+    log_root = Path(cfg.arm_config["LOGPATH"])
+
+    if not _is_path_within(target, log_root):
+        return {"success": False, "path": path_str, "error": "Path outside allowed root"}
+
+    resolved = target.resolve()
+    if not resolved.is_file():
+        return {"success": False, "path": path_str, "error": "File not found"}
+
+    try:
+        resolved.unlink()
+        return {"success": True, "path": path_str}
+    except OSError as exc:
+        return {"success": False, "path": path_str, "error": str(exc)}
+
+
+def delete_folder(path_str: str) -> dict[str, Any]:
+    """Delete a single folder. Path must be within RAW_PATH or COMPLETED_PATH."""
+    target = Path(path_str)
+    allowed_roots = [
+        Path(cfg.arm_config.get("RAW_PATH", "")),
+        Path(cfg.arm_config.get("COMPLETED_PATH", "")),
+    ]
+
+    if not any(_is_path_within(target, root) for root in allowed_roots):
+        return {"success": False, "path": path_str, "error": "Path outside allowed roots"}
+
+    resolved = target.resolve()
+    if not resolved.is_dir():
+        return {"success": False, "path": path_str, "error": "Directory not found"}
+
+    try:
+        shutil.rmtree(resolved)
+        return {"success": True, "path": path_str}
+    except OSError as exc:
+        return {"success": False, "path": path_str, "error": str(exc)}
+
+
+def bulk_delete_logs(paths: list[str]) -> dict[str, Any]:
+    """Delete multiple log files. Best-effort — continues on failures."""
+    removed = []
+    errors = []
+    for p in paths:
+        result = delete_log(p)
+        if result["success"]:
+            removed.append(p)
+        else:
+            errors.append(f"{Path(p).name}: {result.get('error', 'unknown')}")
+    return {"removed": removed, "errors": errors}
+
+
+def bulk_delete_folders(paths: list[str]) -> dict[str, Any]:
+    """Delete multiple folders. Best-effort — continues on failures."""
+    removed = []
+    errors = []
+    for p in paths:
+        result = delete_folder(p)
+        if result["success"]:
+            removed.append(p)
+        else:
+            errors.append(f"{Path(p).name}: {result.get('error', 'unknown')}")
+    return {"removed": removed, "errors": errors}

--- a/arm/services/maintenance.py
+++ b/arm/services/maintenance.py
@@ -123,25 +123,34 @@ def get_counts() -> dict[str, int]:
     }
 
 
-def _is_path_within(path: Path, root: Path) -> bool:
-    """Check if path is contained within root after resolving symlinks."""
+def _resolve_within(name: str, root: Path) -> Path | None:
+    """Resolve a filename safely within a root directory.
+
+    Only the basename is used — any directory components in *name* are
+    stripped to prevent path traversal.  Returns the resolved path if it
+    lives within *root*, or None otherwise.
+    """
     try:
-        resolved = path.resolve()
+        safe_name = Path(name).name  # strip directory components
+        if not safe_name or safe_name in ('.', '..'):
+            return None
+        resolved = (root / safe_name).resolve()
         root_resolved = root.resolve()
-        return resolved.is_relative_to(root_resolved)
+        if resolved.is_relative_to(root_resolved):
+            return resolved
     except (ValueError, OSError):
-        return False
+        pass
+    return None
 
 
 def delete_log(path_str: str) -> dict[str, Any]:
-    """Delete a single log file. Path must be within LOGPATH."""
-    target = Path(path_str)
+    """Delete a single log file. Only the filename is used; it must exist within LOGPATH."""
     log_root = Path(cfg.arm_config["LOGPATH"])
+    resolved = _resolve_within(path_str, log_root)
 
-    if not _is_path_within(target, log_root):
+    if resolved is None:
         return {"success": False, "path": path_str, "error": "Path outside allowed root"}
 
-    resolved = target.resolve()
     if not resolved.is_file():
         return {"success": False, "path": path_str, "error": "File not found"}
 
@@ -153,17 +162,21 @@ def delete_log(path_str: str) -> dict[str, Any]:
 
 
 def delete_folder(path_str: str) -> dict[str, Any]:
-    """Delete a single folder. Path must be within RAW_PATH or COMPLETED_PATH."""
-    target = Path(path_str)
+    """Delete a single folder. Only the folder name is used; it must exist within RAW_PATH or COMPLETED_PATH."""
     allowed_roots = [
         Path(cfg.arm_config.get("RAW_PATH", "")),
         Path(cfg.arm_config.get("COMPLETED_PATH", "")),
     ]
 
-    if not any(_is_path_within(target, root) for root in allowed_roots):
+    resolved = None
+    for root in allowed_roots:
+        resolved = _resolve_within(path_str, root)
+        if resolved is not None:
+            break
+
+    if resolved is None:
         return {"success": False, "path": path_str, "error": "Path outside allowed roots"}
 
-    resolved = target.resolve()
     if not resolved.is_dir():
         return {"success": False, "path": path_str, "error": "Directory not found"}
 

--- a/arm/services/maintenance.py
+++ b/arm/services/maintenance.py
@@ -158,7 +158,8 @@ def delete_log(path_str: str) -> dict[str, Any]:
         resolved.unlink()
         return {"success": True, "path": path_str}
     except OSError as exc:
-        return {"success": False, "path": path_str, "error": str(exc)}
+        log.error("Failed to delete log %s: %s", path_str, exc)
+        return {"success": False, "path": path_str, "error": "Failed to delete file"}
 
 
 def delete_folder(path_str: str) -> dict[str, Any]:
@@ -184,7 +185,8 @@ def delete_folder(path_str: str) -> dict[str, Any]:
         shutil.rmtree(resolved)
         return {"success": True, "path": path_str}
     except OSError as exc:
-        return {"success": False, "path": path_str, "error": str(exc)}
+        log.error("Failed to delete folder %s: %s", path_str, exc)
+        return {"success": False, "path": path_str, "error": "Failed to delete directory"}
 
 
 def bulk_delete_logs(paths: list[str]) -> dict[str, Any]:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -262,3 +262,31 @@ def mock_config(tmp_ingress, tmp_path):
         'LOCAL_RAW_PATH': '',
         'SHARED_RAW_PATH': '',
     }
+
+
+# --- Maintenance fixtures ---
+
+@pytest.fixture
+def tmp_logs(tmp_path):
+    """Create a temporary log directory with test log files."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "orphan1.log").write_text("log content")
+    (log_dir / "orphan2.log").write_text("log content")
+    (log_dir / "referenced.log").write_text("log content")
+    (log_dir / "not-a-log.txt").write_text("ignored")
+    return log_dir
+
+
+@pytest.fixture
+def tmp_media(tmp_path):
+    """Create temporary raw and completed directories with test folders."""
+    raw = tmp_path / "raw"
+    completed = tmp_path / "completed" / "movies"
+    raw.mkdir()
+    completed.mkdir(parents=True)
+    (raw / "Orphan Movie").mkdir()
+    (raw / "Orphan Movie" / "title.mkv").write_bytes(b"\x00" * 1024)
+    (raw / "SERIAL_MOM").mkdir()  # matches sample_job.title
+    (completed / "Another Orphan").mkdir()
+    return {"raw": str(raw), "completed": str(tmp_path / "completed")}

--- a/test/test_jobs_api.py
+++ b/test/test_jobs_api.py
@@ -263,3 +263,43 @@ class TestClearTrackTitle:
             f"/api/v1/jobs/{sample_job.job_id}/tracks/99999/title",
         )
         assert resp.status_code == 404
+
+
+class TestTrackFieldUpdates:
+    """Test PATCH /api/v1/jobs/{job_id}/tracks/{track_id}."""
+
+    def test_patch_track_enabled(self, app_context, job_with_tracks, client):
+        job, tracks = job_with_tracks
+        resp = client.patch(
+            f"/api/v1/jobs/{job.job_id}/tracks/{tracks[0].track_id}",
+            json={"enabled": False},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        db.session.expire_all()
+        refreshed = Track.query.get(tracks[0].track_id)
+        assert refreshed.enabled is False
+
+    def test_patch_track_filename(self, app_context, job_with_tracks, client):
+        job, tracks = job_with_tracks
+        resp = client.patch(
+            f"/api/v1/jobs/{job.job_id}/tracks/{tracks[0].track_id}",
+            json={"filename": "new-name.mkv"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"]["filename"] == "new-name.mkv"
+
+    def test_patch_track_invalid_field(self, app_context, job_with_tracks, client):
+        job, tracks = job_with_tracks
+        resp = client.patch(
+            f"/api/v1/jobs/{job.job_id}/tracks/{tracks[0].track_id}",
+            json={"bad_field": True},
+        )
+        assert resp.status_code == 400
+
+    def test_patch_track_not_found(self, app_context, sample_job, client):
+        resp = client.patch(
+            f"/api/v1/jobs/{sample_job.job_id}/tracks/99999",
+            json={"enabled": True},
+        )
+        assert resp.status_code == 404

--- a/test/test_maintenance_api.py
+++ b/test/test_maintenance_api.py
@@ -63,28 +63,37 @@ class TestDeleteEndpoints:
     def test_delete_log_success(self, app_context, tmp_logs, maint_client):
         target = tmp_logs / "orphan1.log"
         with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
-            resp = maint_client.post("/api/v1/maintenance/delete-log", json={"path": str(target)})
+            resp = maint_client.post("/api/v1/maintenance/delete-log", json={"path": "orphan1.log"})
         assert resp.status_code == 200
         assert resp.json()["success"] is True
         assert not target.exists()
 
-    def test_delete_log_outside_root(self, app_context, tmp_logs, tmp_path, maint_client):
+    def test_delete_log_traversal_rejected(self, app_context, tmp_logs, tmp_path, maint_client):
+        """Path traversal attempts use basename only — file won't exist in LOGPATH."""
         outside = tmp_path / "evil.log"
         outside.write_text("x")
         with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
             resp = maint_client.post("/api/v1/maintenance/delete-log", json={"path": str(outside)})
-        assert resp.status_code == 403
+        # basename "evil.log" doesn't exist in LOGPATH
+        assert resp.status_code == 404
+        # original file was NOT deleted
+        assert outside.exists()
+
+    def test_delete_log_dotdot_rejected(self, app_context, tmp_logs, maint_client):
+        """Dot-dot traversal is stripped to basename."""
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            resp = maint_client.post("/api/v1/maintenance/delete-log", json={"path": "../../etc/passwd"})
+        assert resp.status_code in (403, 404)
 
     def test_delete_folder_success(self, app_context, tmp_media, maint_client):
-        target = os.path.join(tmp_media["raw"], "Orphan Movie")
         mock_cfg = {"RAW_PATH": tmp_media["raw"], "COMPLETED_PATH": tmp_media["completed"]}
         with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
-            resp = maint_client.post("/api/v1/maintenance/delete-folder", json={"path": target})
+            resp = maint_client.post("/api/v1/maintenance/delete-folder", json={"path": "Orphan Movie"})
         assert resp.status_code == 200
         assert resp.json()["success"] is True
 
     def test_bulk_delete_logs(self, app_context, tmp_logs, maint_client):
-        paths = [str(tmp_logs / "orphan1.log"), str(tmp_logs / "orphan2.log"), str(tmp_logs / "nonexistent.log")]
+        paths = ["orphan1.log", "orphan2.log", "nonexistent.log"]
         with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
             resp = maint_client.post("/api/v1/maintenance/bulk-delete-logs", json={"paths": paths})
         assert resp.status_code == 200

--- a/test/test_maintenance_api.py
+++ b/test/test_maintenance_api.py
@@ -1,0 +1,93 @@
+"""Tests for arm/api/v1/maintenance.py — maintenance REST endpoints."""
+import os
+import unittest.mock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from arm.database import db
+from arm.models.job import Job
+
+
+@pytest.fixture
+def maint_client(app_context):
+    from arm.api.v1.maintenance import router
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as c:
+        yield c
+
+
+class TestMaintenanceCountsEndpoint:
+    def test_returns_counts(self, app_context, sample_job, tmp_logs, maint_client):
+        sample_job.logfile = "referenced.log"
+        db.session.commit()
+
+        mock_cfg = {"LOGPATH": str(tmp_logs), "RAW_PATH": "/nonexistent", "COMPLETED_PATH": "/nonexistent"}
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            resp = maint_client.get("/api/v1/maintenance/counts")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "orphan_logs" in data
+        assert "orphan_folders" in data
+
+
+class TestOrphanEndpoints:
+    def test_get_orphan_logs(self, app_context, sample_job, tmp_logs, maint_client):
+        sample_job.logfile = "referenced.log"
+        db.session.commit()
+
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            resp = maint_client.get("/api/v1/maintenance/orphan-logs")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "files" in data
+        names = [f["relative_path"] for f in data["files"]]
+        assert "orphan1.log" in names
+
+    def test_get_orphan_folders(self, app_context, sample_job, tmp_media, maint_client):
+        mock_cfg = {"RAW_PATH": tmp_media["raw"], "COMPLETED_PATH": tmp_media["completed"]}
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            resp = maint_client.get("/api/v1/maintenance/orphan-folders")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        names = [f["name"] for f in data["folders"]]
+        assert "Orphan Movie" in names
+
+
+class TestDeleteEndpoints:
+    def test_delete_log_success(self, app_context, tmp_logs, maint_client):
+        target = tmp_logs / "orphan1.log"
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            resp = maint_client.post("/api/v1/maintenance/delete-log", json={"path": str(target)})
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        assert not target.exists()
+
+    def test_delete_log_outside_root(self, app_context, tmp_logs, tmp_path, maint_client):
+        outside = tmp_path / "evil.log"
+        outside.write_text("x")
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            resp = maint_client.post("/api/v1/maintenance/delete-log", json={"path": str(outside)})
+        assert resp.status_code == 403
+
+    def test_delete_folder_success(self, app_context, tmp_media, maint_client):
+        target = os.path.join(tmp_media["raw"], "Orphan Movie")
+        mock_cfg = {"RAW_PATH": tmp_media["raw"], "COMPLETED_PATH": tmp_media["completed"]}
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            resp = maint_client.post("/api/v1/maintenance/delete-folder", json={"path": target})
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_bulk_delete_logs(self, app_context, tmp_logs, maint_client):
+        paths = [str(tmp_logs / "orphan1.log"), str(tmp_logs / "orphan2.log"), str(tmp_logs / "nonexistent.log")]
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            resp = maint_client.post("/api/v1/maintenance/bulk-delete-logs", json={"paths": paths})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["removed"]) == 2
+        assert len(data["errors"]) == 1

--- a/test/test_maintenance_service.py
+++ b/test/test_maintenance_service.py
@@ -1,0 +1,135 @@
+"""Tests for arm/services/maintenance.py — orphan detection and cleanup."""
+import os
+import unittest.mock
+
+import pytest
+
+from arm.database import db
+from arm.models.job import Job
+
+
+@pytest.fixture
+def tmp_logs(tmp_path):
+    """Create a temporary log directory with test log files."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "orphan1.log").write_text("log content")
+    (log_dir / "orphan2.log").write_text("log content")
+    (log_dir / "referenced.log").write_text("log content")
+    (log_dir / "not-a-log.txt").write_text("ignored")
+    return log_dir
+
+
+@pytest.fixture
+def tmp_media(tmp_path):
+    """Create temporary raw and completed directories with test folders."""
+    raw = tmp_path / "raw"
+    completed = tmp_path / "completed" / "movies"
+    raw.mkdir()
+    completed.mkdir(parents=True)
+    (raw / "Orphan Movie").mkdir()
+    (raw / "Orphan Movie" / "title.mkv").write_bytes(b"\x00" * 1024)
+    (raw / "SERIAL_MOM").mkdir()  # matches sample_job.title
+    (completed / "Another Orphan").mkdir()
+    return {"raw": str(raw), "completed": str(tmp_path / "completed")}
+
+
+class TestOrphanLogDetection:
+    def test_finds_orphan_logs(self, app_context, sample_job, tmp_logs):
+        """Logs not referenced by any job are orphans."""
+        sample_job.logfile = "referenced.log"
+        db.session.commit()
+
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            from arm.services.maintenance import get_orphan_logs
+            result = get_orphan_logs()
+
+        assert result["root"] == str(tmp_logs)
+        names = [f["relative_path"] for f in result["files"]]
+        assert "orphan1.log" in names
+        assert "orphan2.log" in names
+        assert "referenced.log" not in names
+        assert "not-a-log.txt" not in names
+
+    def test_returns_file_sizes(self, app_context, sample_job, tmp_logs):
+        sample_job.logfile = "referenced.log"
+        db.session.commit()
+
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            from arm.services.maintenance import get_orphan_logs
+            result = get_orphan_logs()
+
+        for f in result["files"]:
+            assert isinstance(f["size_bytes"], int)
+            assert f["size_bytes"] > 0
+        assert isinstance(result["total_size_bytes"], int)
+
+    def test_empty_log_dir(self, app_context, tmp_path):
+        log_dir = tmp_path / "empty_logs"
+        log_dir.mkdir()
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(log_dir)}):
+            from arm.services.maintenance import get_orphan_logs
+            result = get_orphan_logs()
+        assert result["files"] == []
+        assert result["total_size_bytes"] == 0
+
+
+class TestOrphanFolderDetection:
+    def test_finds_orphan_folders(self, app_context, sample_job, tmp_media):
+        """Folders not matching any job title/label/raw_path are orphans."""
+        mock_cfg = {
+            "RAW_PATH": tmp_media["raw"],
+            "COMPLETED_PATH": tmp_media["completed"],
+        }
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            from arm.services.maintenance import get_orphan_folders
+            result = get_orphan_folders()
+
+        names = [f["name"] for f in result["folders"]]
+        assert "Orphan Movie" in names
+        assert "Another Orphan" in names
+        assert "SERIAL_MOM" not in names  # matches sample_job.title
+
+    def test_categorizes_raw_and_completed(self, app_context, sample_job, tmp_media):
+        mock_cfg = {
+            "RAW_PATH": tmp_media["raw"],
+            "COMPLETED_PATH": tmp_media["completed"],
+        }
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            from arm.services.maintenance import get_orphan_folders
+            result = get_orphan_folders()
+
+        categories = {f["name"]: f["category"] for f in result["folders"]}
+        assert categories.get("Orphan Movie") == "raw"
+        assert categories.get("Another Orphan") == "completed"
+
+    def test_computes_folder_sizes(self, app_context, sample_job, tmp_media):
+        mock_cfg = {
+            "RAW_PATH": tmp_media["raw"],
+            "COMPLETED_PATH": tmp_media["completed"],
+        }
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            from arm.services.maintenance import get_orphan_folders
+            result = get_orphan_folders()
+
+        orphan_movie = next(f for f in result["folders"] if f["name"] == "Orphan Movie")
+        assert orphan_movie["size_bytes"] >= 1024  # has a 1KB file inside
+        assert isinstance(result["total_size_bytes"], int)
+
+
+class TestMaintenanceCounts:
+    def test_returns_counts(self, app_context, sample_job, tmp_logs, tmp_media):
+        sample_job.logfile = "referenced.log"
+        db.session.commit()
+
+        mock_cfg = {
+            "LOGPATH": str(tmp_logs),
+            "RAW_PATH": tmp_media["raw"],
+            "COMPLETED_PATH": tmp_media["completed"],
+        }
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            from arm.services.maintenance import get_counts
+            result = get_counts()
+
+        assert result["orphan_logs"] == 2
+        assert result["orphan_folders"] >= 2  # Orphan Movie + Another Orphan

--- a/test/test_maintenance_service.py
+++ b/test/test_maintenance_service.py
@@ -8,32 +8,6 @@ from arm.database import db
 from arm.models.job import Job
 
 
-@pytest.fixture
-def tmp_logs(tmp_path):
-    """Create a temporary log directory with test log files."""
-    log_dir = tmp_path / "logs"
-    log_dir.mkdir()
-    (log_dir / "orphan1.log").write_text("log content")
-    (log_dir / "orphan2.log").write_text("log content")
-    (log_dir / "referenced.log").write_text("log content")
-    (log_dir / "not-a-log.txt").write_text("ignored")
-    return log_dir
-
-
-@pytest.fixture
-def tmp_media(tmp_path):
-    """Create temporary raw and completed directories with test folders."""
-    raw = tmp_path / "raw"
-    completed = tmp_path / "completed" / "movies"
-    raw.mkdir()
-    completed.mkdir(parents=True)
-    (raw / "Orphan Movie").mkdir()
-    (raw / "Orphan Movie" / "title.mkv").write_bytes(b"\x00" * 1024)
-    (raw / "SERIAL_MOM").mkdir()  # matches sample_job.title
-    (completed / "Another Orphan").mkdir()
-    return {"raw": str(raw), "completed": str(tmp_path / "completed")}
-
-
 class TestOrphanLogDetection:
     def test_finds_orphan_logs(self, app_context, sample_job, tmp_logs):
         """Logs not referenced by any job are orphans."""

--- a/test/test_makemkv_key_api.py
+++ b/test/test_makemkv_key_api.py
@@ -1,0 +1,82 @@
+"""Tests for MakeMKV key check API endpoints."""
+import unittest.mock
+
+import pytest
+
+from arm.database import db
+from arm.models.app_state import AppState
+
+
+@pytest.fixture
+def app_state(app_context):
+    state = AppState(id=1, ripping_paused=False, setup_complete=True)
+    db.session.add(state)
+    db.session.commit()
+    return state
+
+
+@pytest.fixture
+def client(app_context):
+    """FastAPI test client."""
+    from arm.app import app
+    from fastapi.testclient import TestClient
+    with TestClient(app, raise_server_exceptions=True) as client:
+        yield client
+
+
+class TestRippingEnabledKeyStatus:
+    """GET /api/v1/system/ripping-enabled includes key status."""
+
+    def test_includes_key_fields_when_never_checked(self, client, app_state):
+        response = client.get('/api/v1/system/ripping-enabled')
+        data = response.json()
+        assert data["ripping_enabled"] is True
+        assert data["makemkv_key_valid"] is None
+        assert data["makemkv_key_checked_at"] is None
+
+    def test_includes_key_fields_when_valid(self, client, app_state):
+        from datetime import datetime, timezone
+        app_state.makemkv_key_valid = True
+        app_state.makemkv_key_checked_at = datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+        db.session.commit()
+
+        response = client.get('/api/v1/system/ripping-enabled')
+        data = response.json()
+        assert data["makemkv_key_valid"] is True
+        assert data["makemkv_key_checked_at"] is not None
+
+
+class TestMakemkvKeyCheck:
+    """POST /api/v1/system/makemkv-key-check endpoint."""
+
+    def test_success_returns_valid(self, client, app_state):
+        with unittest.mock.patch("arm.api.v1.system.prep_mkv") as mock_prep:
+            mock_prep.return_value = None
+            # Simulate what prep_mkv does internally
+            app_state.makemkv_key_valid = True
+            db.session.commit()
+
+            response = client.post('/api/v1/system/makemkv-key-check')
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["key_valid"] is True
+        assert "message" in data
+
+    def test_failure_returns_invalid(self, client, app_state):
+        from arm.ripper.makemkv import UpdateKeyRunTimeError
+
+        with unittest.mock.patch("arm.api.v1.system.prep_mkv") as mock_prep:
+            mock_prep.side_effect = UpdateKeyRunTimeError(
+                40, ["bash", "/opt/arm/scripts/update_key.sh"], output=""
+            )
+            # Simulate what prep_mkv does internally
+            app_state.makemkv_key_valid = False
+            db.session.commit()
+
+            response = client.post('/api/v1/system/makemkv-key-check')
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["key_valid"] is False
+        assert "message" in data

--- a/test/test_makemkv_key_persist.py
+++ b/test/test_makemkv_key_persist.py
@@ -1,0 +1,55 @@
+"""Tests for prep_mkv() persisting key validity to AppState."""
+import subprocess
+import unittest.mock
+
+import pytest
+
+from arm.database import db
+from arm.models.app_state import AppState
+
+
+@pytest.fixture
+def app_state(app_context):
+    """Ensure AppState singleton exists."""
+    state = AppState(id=1, ripping_paused=False, setup_complete=True)
+    db.session.add(state)
+    db.session.commit()
+    return state
+
+
+class TestPrepMkvPersistence:
+    def test_success_persists_valid(self, app_state):
+        """On successful key update, AppState.makemkv_key_valid is True."""
+        with unittest.mock.patch("arm.ripper.makemkv.subprocess.run") as mock_run, \
+             unittest.mock.patch("arm.ripper.makemkv.cfg.arm_config", {
+                 "INSTALLPATH": "/opt/arm",
+                 "MAKEMKV_PERMA_KEY": "",
+             }):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=b"Key updated"
+            )
+            from arm.ripper.makemkv import prep_mkv
+            prep_mkv()
+
+        state = AppState.get()
+        assert state.makemkv_key_valid is True
+        assert state.makemkv_key_checked_at is not None
+
+    def test_failure_persists_invalid(self, app_state):
+        """On UpdateKeyRunTimeError, AppState.makemkv_key_valid is False."""
+        from arm.ripper.makemkv import prep_mkv, UpdateKeyRunTimeError
+
+        with unittest.mock.patch("arm.ripper.makemkv.subprocess.run") as mock_run, \
+             unittest.mock.patch("arm.ripper.makemkv.cfg.arm_config", {
+                 "INSTALLPATH": "/opt/arm",
+                 "MAKEMKV_PERMA_KEY": "",
+             }):
+            mock_run.side_effect = subprocess.CalledProcessError(
+                40, ["bash", "/opt/arm/scripts/update_key.sh"], output=b""
+            )
+            with pytest.raises(UpdateKeyRunTimeError):
+                prep_mkv()
+
+        state = AppState.get()
+        assert state.makemkv_key_valid is False
+        assert state.makemkv_key_checked_at is not None


### PR DESCRIPTION
## Summary

- Add maintenance service for orphan detection and cleanup (logs, media directories)
- Add maintenance REST router with orphan detection and cleanup endpoints
- Add track-fields PATCH endpoint for updating job track metadata
- Add MakeMKV key validity tracking to AppState with DB migration
- Persist MakeMKV key validity in prep_mkv() flow
- Add MakeMKV key check endpoint and expose key status in ripping-enabled

## Changes

### New files
- `arm/services/maintenance.py` — orphan log and media directory detection/cleanup
- `arm/api/v1/maintenance.py` — REST endpoints for maintenance operations
- `arm/migrations/j4k5l6m7n8o9_app_state_add_makemkv_key.py` — DB migration for key fields

### Modified files
- `arm/api/v1/jobs.py` — track-fields PATCH endpoint
- `arm/api/v1/system.py` — MakeMKV key check endpoint, key status in ripping-enabled
- `arm/models/app_state.py` — makemkv_key_valid and makemkv_key_checked_at fields
- `arm/ripper/makemkv.py` — persist key validity after prep_mkv()
- `arm/app.py` — register maintenance router

### Tests
- `test/test_maintenance_api.py` — maintenance endpoint tests
- `test/test_maintenance_service.py` — maintenance service unit tests
- `test/test_makemkv_key_api.py` — key check endpoint tests
- `test/test_makemkv_key_persist.py` — key persistence tests
- `test/test_jobs_api.py` — track-fields endpoint tests

## Test plan

- [ ] Orphan log detection returns unlinked log files
- [ ] Orphan media detection returns directories not linked to jobs
- [ ] Cleanup endpoints delete orphaned resources
- [ ] MakeMKV key check validates/updates the key
- [ ] Key status persists to AppState and is returned in ripping-enabled
- [ ] Track fields PATCH updates job track metadata
- [ ] All tests pass