### PR TITLE
fix: resolve duplicate alembic revision ID

### DIFF
--- a/arm/migrations/versions/k5l6m7n8o9p0_app_state_add_makemkv_key.py
+++ b/arm/migrations/versions/k5l6m7n8o9p0_app_state_add_makemkv_key.py
@@ -1,14 +1,14 @@
 """Add makemkv_key_valid and makemkv_key_checked_at to app_state.
 
-Revision ID: j4k5l6m7n8o9
-Revises: i3j4k5l6m7n8
+Revision ID: k5l6m7n8o9p0
+Revises: j4k5l6m7n8o9
 Create Date: 2026-03-22
 """
 from alembic import op
 import sqlalchemy as sa
 
-revision = 'j4k5l6m7n8o9'
-down_revision = 'i3j4k5l6m7n8'
+revision = 'k5l6m7n8o9p0'
+down_revision = 'j4k5l6m7n8o9'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- Two migrations (`app_state_add_makemkv_key` and `job_add_folder_import`) shared revision ID `j4k5l6m7n8o9`, causing Alembic "Multiple heads" error on container startup
- Renamed makemkv_key migration to `k5l6m7n8o9p0` and chained it after folder_import
- Migration chain: `i3j4k5l6m7n8` → `j4k5l6m7n8o9` (folder_import) → `k5l6m7n8o9p0` (makemkv_key)

## Test plan
- [ ] ARM container starts without "Multiple heads" error
- [ ] Alembic migration chain resolves to single head