### PR TITLE
fix: set up per-job log file for folder import rips

### DIFF
--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -6,11 +6,14 @@ MakeMKV rip pipeline for folder-based imports (no physical drive).
 import logging
 import os
 
+import structlog
+
 import arm.config.config as cfg
 from arm.database import db
 from arm.models.job import JobState
 from arm.models.track import Track
 from arm.ripper import utils
+from arm.ripper.logger import _create_file_handler
 from arm.ripper.makemkv import (
     _reconcile_filenames,
     prep_mkv,
@@ -35,7 +38,20 @@ def rip_folder(job):
       8. Set status to TRANSCODE_WAITING on success, FAILURE on error
       9. No eject step (no physical drive)
     """
+    file_handler = None
     try:
+        # 0. Set up per-job log file so the UI can display rip progress
+        if job.logfile:
+            root_logger = logging.getLogger()
+            file_handler = _create_file_handler(job.logfile)
+            root_logger.addHandler(file_handler)
+            structlog.contextvars.clear_contextvars()
+            structlog.contextvars.bind_contextvars(
+                job_id=job.job_id,
+                source_type="folder",
+                source_path=job.source_path,
+            )
+
         # 1. Validate source folder
         source = job.source_path
         if not source or not os.path.isdir(source):
@@ -107,3 +123,8 @@ def rip_folder(job):
         except Exception:
             log.exception("Failed to update job status to FAILURE")
         raise
+    finally:
+        # Clean up the per-job file handler
+        if file_handler:
+            logging.getLogger().removeHandler(file_handler)
+            file_handler.close()

--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -41,7 +41,7 @@ def rip_folder(job):
     file_handler = None
     try:
         # 0. Set up per-job log file so the UI can display rip progress
-        if job.logfile:
+        if isinstance(getattr(job, "logfile", None), str) and job.logfile:
             root_logger = logging.getLogger()
             file_handler = _create_file_handler(job.logfile)
             root_logger.addHandler(file_handler)


### PR DESCRIPTION
## Summary
Folder import rips were missing per-job log files — the `rip_folder()` function set `job.logfile` but never created a file handler, so all log output went to stdout/arm.log only. The UI's log viewer showed "Log file not found".

Fix: Set up a per-job `FileHandler` at the start of `rip_folder()` using the existing logger infrastructure, with proper cleanup in a `finally` block.

## Test plan
- [ ] Start a folder import job
- [ ] Verify log file appears in `/home/arm/logs/`
- [ ] Verify UI log viewer shows rip progress