### PR TITLE
feat: episode matching overhaul — disc/season extraction and match table

### DIFF
--- a/arm/api/v1/folder.py
+++ b/arm/api/v1/folder.py
@@ -31,6 +31,9 @@ class FolderCreateRequest(BaseModel):
     imdb_id: Optional[str] = None
     poster_url: Optional[str] = None
     multi_title: bool = False
+    season: Optional[int] = None
+    disc_number: Optional[int] = None
+    disc_total: Optional[int] = None
 
 
 @router.post("/jobs/folder/scan")
@@ -108,6 +111,13 @@ def create_folder_job(req: FolderCreateRequest):
     if req.poster_url:
         job.poster_url = req.poster_url
     job.multi_title = req.multi_title
+    if req.season is not None:
+        job.season = str(req.season)
+        job.season_manual = str(req.season)
+    if req.disc_number is not None:
+        job.disc_number = req.disc_number
+    if req.disc_total is not None:
+        job.disc_total = req.disc_total
     job.status = JobState.IDENTIFYING.value
 
     db.session.add(job)

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -654,6 +654,9 @@ async def tvdb_match(job_id: int, request: Request):
     if not apply:
         job.disc_number = saved_disc_number
         job.disc_total = saved_disc_total
+    else:
+        # Persist disc overrides when applying
+        db.session.commit()
     return result
 
 

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -268,7 +268,7 @@ _FIELD_MAP = {
     'season': ('season', 'season_manual'),
     'episode': ('episode', 'episode_manual'),
 }
-_DIRECT_FIELDS = ('path', 'label', 'disctype')
+_DIRECT_FIELDS = ('path', 'label', 'disctype', 'disc_number', 'disc_total')
 _STRUCTURED_KEYS = frozenset(('artist', 'album', 'season', 'episode'))
 _VALID_DISCTYPES = ('dvd', 'bluray', 'bluray4k', 'music', 'data')
 
@@ -632,13 +632,28 @@ async def tvdb_match(job_id: int, request: Request):
     season = body.get("season")
     tolerance = body.get("tolerance")
     apply = bool(body.get("apply", False))
+    disc_number = body.get("disc_number")
+    disc_total = body.get("disc_total")
 
     if season is not None:
         season = int(season)
     if tolerance is not None:
         tolerance = int(tolerance)
 
+    # Temporarily set disc overrides on the job for this match run
+    saved_disc_number = job.disc_number
+    saved_disc_total = job.disc_total
+    if disc_number is not None:
+        job.disc_number = int(disc_number)
+    if disc_total is not None:
+        job.disc_total = int(disc_total)
+
     result = match_episodes_for_api(job, season=season, tolerance=tolerance, apply=apply)
+
+    # Restore originals if not applying (preview mode)
+    if not apply:
+        job.disc_number = saved_disc_number
+        job.disc_total = saved_disc_total
     return result
 
 

--- a/arm/ripper/arm_matcher.py
+++ b/arm/ripper/arm_matcher.py
@@ -22,6 +22,7 @@ class LabelInfo:
     disc_number: int | None  # 1, 2, etc. (None if not a numbered disc)
     disc_type: str | None    # "part", "disc", "bonus", "extras", "special_features"
     raw_label: str           # original input: "LOTR_FELLOWSHIP_OF_THE_RING_P1"
+    disc_total: int | None = None     # total discs in set (from "Disc N of M")
     season_number: int | None = None  # 1, 2, etc. (None if not a TV season disc)
 
     @property
@@ -75,7 +76,7 @@ class MatchSelection:
 # (e.g., "The Godfather Part II", "Dune: Part Two"), not a disc indicator.
 # Studios use P1/D1/DISC_1 for physical disc numbering.
 _DISC_SUFFIX_RE = re.compile(
-    r'[\s_-](P|D|DISC)[\s_-]?(\d+)$',
+    r'[\s_-](P|D|DISC)[\s_-]?(\d+)(?:[\s_-](?:OF|of)[\s_-]?(\d+))?$',
     re.IGNORECASE,
 )
 
@@ -145,30 +146,31 @@ def _classify_special_disc(raw_type):
 
 
 def _extract_disc_suffix(s):
-    """Extract disc number/type from the label string.
+    """Extract disc number/type/total from the label string.
 
-    Returns (remaining_string, disc_number, disc_type).
+    Returns (remaining_string, disc_number, disc_type, disc_total).
     """
     # Word-number suffixes first (DISC_ONE)
     m = _DISC_WORD_SUFFIX_RE.search(s)
     if m:
         keyword = m.group(1).lower()
         disc_type = 'part' if keyword == 'part' else 'disc'
-        return s[:m.start()], _WORD_NUMBERS[m.group(2).lower()], disc_type
+        return s[:m.start()], _WORD_NUMBERS[m.group(2).lower()], disc_type, None
 
-    # Numeric suffixes (P1, D2, DISC_1)
+    # Numeric suffixes (P1, D2, DISC_1, DISC 4 OF 4)
     m = _DISC_SUFFIX_RE.search(s)
     if m:
-        return s[:m.start()], int(m.group(2)), 'disc'
+        disc_total = int(m.group(3)) if m.group(3) else None
+        return s[:m.start()], int(m.group(2)), 'disc', disc_total
 
     # Special disc types (BONUS, EXTRAS, SPECIAL_FEATURES)
     m = _SPECIAL_DISC_RE.search(s)
     if m:
         disc_type = _classify_special_disc(m.group(1))
         if disc_type:
-            return s[:m.start()], None, disc_type
+            return s[:m.start()], None, disc_type, None
 
-    return s, None, None
+    return s, None, None, None
 
 
 def _extract_season_suffix(s):
@@ -201,6 +203,7 @@ def parse_label(raw_label: str) -> LabelInfo:
     s = raw_label
     disc_number = None
     disc_type = None
+    disc_total = None
     season_number = None
 
     # 1-4. Basic cleanup
@@ -223,8 +226,8 @@ def parse_label(raw_label: str) -> LabelInfo:
         disc_type = 'disc'
         s = s[:m.start()]
     else:
-        # 5b. Extract disc-only suffixes
-        s, disc_number, disc_type = _extract_disc_suffix(s)
+        # 5b. Extract disc-only suffixes (including "Disc N of M")
+        s, disc_number, disc_type, disc_total = _extract_disc_suffix(s)
         # 5c. Extract season-only suffixes
         s, season_number = _extract_season_suffix(s)
 
@@ -236,6 +239,7 @@ def parse_label(raw_label: str) -> LabelInfo:
         disc_number=disc_number,
         disc_type=disc_type,
         raw_label=raw_label,
+        disc_total=disc_total,
         season_number=season_number,
     )
 

--- a/arm/ripper/folder_scan.py
+++ b/arm/ripper/folder_scan.py
@@ -2,8 +2,11 @@
 import logging
 import os
 import re
+from pathlib import Path
 
 import xmltodict
+
+from arm.ripper.arm_matcher import parse_label
 
 logger = logging.getLogger(__name__)
 
@@ -40,12 +43,26 @@ def extract_metadata(folder_path: str, disc_type: str) -> dict:
     title_suggestion, year_suggestion = _parse_title_year(label, folder_path)
     folder_size = _calculate_folder_size(folder_path)
     stream_count = _count_streams(folder_path, disc_type)
+
+    # Extract disc/season metadata via centralized label parser
+    folder_name = Path(folder_path).name
+    label_info = parse_label(folder_name)
+    parent_info = parse_label(Path(folder_path).parent.name)
+
+    # Prefer disc info from the folder itself, season from parent if not in folder
+    disc_number = label_info.disc_number
+    disc_total = label_info.disc_total
+    season = label_info.season_number or parent_info.season_number
+
     return {
         "label": label,
         "title_suggestion": title_suggestion,
         "year_suggestion": year_suggestion,
         "folder_size_bytes": folder_size,
         "stream_count": stream_count,
+        "disc_number": disc_number,
+        "disc_total": disc_total,
+        "season": season,
     }
 
 

--- a/arm/ripper/folder_scan.py
+++ b/arm/ripper/folder_scan.py
@@ -8,6 +8,18 @@ import xmltodict
 
 from arm.ripper.arm_matcher import parse_label
 
+# Non-anchored regex for extracting disc info from folder names with trailing junk
+# e.g. "Show Name - Disc 4 of 4 - BD50 - Untouched"
+# Uses (?:^|[\s_-]) to also match at start of string (e.g. "Disc 1 - BD50")
+_FOLDER_DISC_RE = re.compile(
+    r'(?:^|[\s_-])(D|DISC)[\s_-]?(\d+)(?:[\s_-](?:OF|of)[\s_-]?(\d+))?',
+    re.IGNORECASE,
+)
+_FOLDER_SEASON_RE = re.compile(
+    r'(?:^|[\s_-])(?:S|SEASON)[\s_-]?(\d+)',
+    re.IGNORECASE,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -53,6 +65,21 @@ def extract_metadata(folder_path: str, disc_type: str) -> dict:
     disc_number = label_info.disc_number
     disc_total = label_info.disc_total
     season = label_info.season_number or parent_info.season_number
+
+    # Fallback: non-anchored regex for folder names with trailing junk
+    # e.g. "Show - Disc 4 of 4 - BD50 - Untouched" where parse_label fails
+    # because the disc pattern isn't at the end of the string
+    if disc_number is None:
+        m = _FOLDER_DISC_RE.search(folder_name)
+        if m:
+            disc_number = int(m.group(2))
+            disc_total = int(m.group(3)) if m.group(3) else None
+    if season is None:
+        m = _FOLDER_SEASON_RE.search(folder_name)
+        if not m:
+            m = _FOLDER_SEASON_RE.search(Path(folder_path).parent.name)
+        if m:
+            season = int(m.group(1))
 
     return {
         "label": label,

--- a/arm/services/matching/tvdb_matcher.py
+++ b/arm/services/matching/tvdb_matcher.py
@@ -203,7 +203,7 @@ def match_tracks_to_episodes(
             log.info("All episodes excluded by cross-disc filter")
             return []
 
-    # Calculate expected episode position for this disc (for tiebreaking).
+    # Calculate expected episode position for this disc.
     # Computed after exclusion filtering so the bias is relative to the
     # remaining candidates, not the full season — this is intentional.
     use_position_bias = disc_number is not None and disc_number > 0
@@ -212,6 +212,14 @@ def match_tracks_to_episodes(
         expected_center = (disc_number - 0.5) / disc_count * len(episodes)
     else:
         expected_center = 0.0
+
+    # Position weight: how much (in seconds) each episode-position offset
+    # penalises the score.  When disc info is available, being one episode
+    # away from the expected center adds pos_weight seconds to the cost —
+    # making position a real factor rather than just a tiebreaker.
+    # 60s per position means a 5-episode offset costs 300s, comparable to
+    # typical runtime inaccuracies between TVDB and actual disc runtimes.
+    pos_weight = 60.0 if use_position_bias else 0.0
 
     # Build cost matrix
     pairs = []
@@ -223,15 +231,16 @@ def match_tracks_to_episodes(
             delta = abs(t_len - ep.get("runtime", 0))
             if delta <= tolerance:
                 pos_bias = abs(ei - expected_center) if use_position_bias else 0.0
-                pairs.append((delta, pos_bias, ti, ei))
+                score = delta + pos_bias * pos_weight
+                pairs.append((score, delta, pos_bias, ti, ei))
 
-    # Greedy assignment: smallest delta first, position bias breaks ties
+    # Greedy assignment: lowest combined score first
     pairs.sort()
     used_tracks: set[int] = set()
     used_episodes: set[int] = set()
     matches = []
 
-    for delta, _pos_bias, ti, ei in pairs:
+    for _score, _delta, _pos_bias, ti, ei in pairs:
         if ti in used_tracks or ei in used_episodes:
             continue
         used_tracks.add(ti)

--- a/arm/services/matching/tvdb_matcher.py
+++ b/arm/services/matching/tvdb_matcher.py
@@ -252,6 +252,23 @@ def match_tracks_to_episodes(
             "episode_runtime": episodes[ei].get("runtime", 0),
         })
 
+    # Re-order matches so track order maps to episode order.
+    # The greedy algorithm picks by score, which can scramble the natural
+    # track→episode sequence.  Sort both sides independently and re-pair
+    # so that the earliest track gets the earliest episode.
+    if len(matches) > 1:
+        sorted_tracks = sorted(matches, key=lambda m: int(m["track_number"]))
+        sorted_eps = sorted(matches, key=lambda m: m["episode_number"])
+        matches = [
+            {
+                "track_number": t["track_number"],
+                "episode_number": e["episode_number"],
+                "episode_name": e["episode_name"],
+                "episode_runtime": e["episode_runtime"],
+            }
+            for t, e in zip(sorted_tracks, sorted_eps)
+        ]
+
     return matches
 
 

--- a/docs/superpowers/plans/2026-03-24-episode-matching-overhaul.md
+++ b/docs/superpowers/plans/2026-03-24-episode-matching-overhaul.md
@@ -1,0 +1,528 @@
+# Episode Matching Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable correct TVDB episode matching for multi-disc TV series folder imports by extracting disc/season metadata from paths, exposing it as editable fields, and building an episode match table with per-track dropdown reassignment.
+
+**Architecture:** Layer 1 (backend) extends `parse_label()` with disc_total, wires it into folder scan, adds season/disc fields to the create and update APIs. Layer 2 (frontend) builds a new `EpisodeMatch.svelte` component with match controls, a track-to-episode table with dropdowns, and prefills season/disc in the folder wizard.
+
+**Tech Stack:** Python/FastAPI (ARM-neu), SvelteKit/Svelte 5 runes (ARM-UI), pytest, vitest
+
+**Spec:** `docs/superpowers/specs/2026-03-24-episode-matching-overhaul-design.md`
+
+**Repos:**
+- ARM-neu: `/home/upb/src/automatic-ripping-machine-neu` (branch: `feat/episode-matching-overhaul`)
+- ARM-UI: `/home/upb/src/automatic-ripping-machine-ui` (branch: `feat/episode-matching-overhaul`)
+
+**Testing commands:**
+- ARM-neu: `/home/upb/src/automatic-ripping-machine-neu/.venv/bin/python -m pytest /home/upb/src/automatic-ripping-machine-neu/test/ -x -q --tb=short`
+- ARM-UI backend: `/home/upb/src/automatic-ripping-machine-ui/.venv/bin/python -m pytest /home/upb/src/automatic-ripping-machine-ui/tests/ -x -q --tb=short`
+- ARM-UI frontend build: run `npm run build` then `npx svelte-check --tsconfig ./tsconfig.json` from `/home/upb/src/automatic-ripping-machine-ui/frontend`
+- ARM-UI frontend tests: `npx vitest run` from `/home/upb/src/automatic-ripping-machine-ui/frontend`
+
+**Git commands:** Always use `git -C <repo-path>` for cross-repo operations. Never `cd && git`.
+
+---
+
+## Chunk 1: Backend — Label Parser & Folder Scan
+
+### Task 1: Add `disc_total` to `parse_label()`
+
+**Repo:** ARM-neu
+**Files:**
+- Modify: `arm/ripper/arm_matcher.py` (LabelInfo dataclass, _DISC_SUFFIX_RE, _extract_disc_suffix)
+- Modify: `test/test_arm_matcher.py`
+
+- [ ] **Step 1: Write tests for disc_total extraction**
+
+Add to `test/test_arm_matcher.py`:
+
+```python
+def test_parse_label_disc_of_total():
+    """parse_label extracts disc_total from 'Disc N of M' patterns."""
+    from arm.ripper.arm_matcher import parse_label
+    info = parse_label("SHOW_NAME_DISC_4_OF_4")
+    assert info.disc_number == 4
+    assert info.disc_total == 4
+    assert info.title == "show name"
+
+def test_parse_label_disc_of_total_spaces():
+    """parse_label handles 'Disc 2 of 6' with spaces."""
+    from arm.ripper.arm_matcher import parse_label
+    info = parse_label("Show Name Disc 2 of 6")
+    assert info.disc_number == 2
+    assert info.disc_total == 6
+
+def test_parse_label_disc_no_total():
+    """parse_label returns disc_total=None when no 'of M' present."""
+    from arm.ripper.arm_matcher import parse_label
+    info = parse_label("SHOW_DISC_3")
+    assert info.disc_number == 3
+    assert info.disc_total is None
+
+def test_parse_label_d_of_total():
+    """parse_label handles D2 of 4 shorthand."""
+    from arm.ripper.arm_matcher import parse_label
+    info = parse_label("SHOW_D2_OF_4")
+    assert info.disc_number == 2
+    assert info.disc_total == 4
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/upb/src/automatic-ripping-machine-neu/.venv/bin/python -m pytest /home/upb/src/automatic-ripping-machine-neu/test/test_arm_matcher.py -x -q --tb=short -k disc_total`
+Expected: FAIL — LabelInfo has no `disc_total` attribute
+
+- [ ] **Step 3: Add `disc_total` to `LabelInfo`**
+
+In `arm/ripper/arm_matcher.py`, add to the LabelInfo dataclass (around line 22):
+
+```python
+disc_total: int | None = None
+```
+
+- [ ] **Step 4: Extend `_DISC_SUFFIX_RE` to capture "of N"**
+
+Replace the existing regex (lines 77-80) with one that has an optional `of N` group:
+
+```python
+_DISC_SUFFIX_RE = re.compile(
+    r'[\s_-](P|D|DISC)[\s_-]?(\d+)(?:\s*(?:OF|of)\s*(\d+))?$',
+    re.IGNORECASE,
+)
+```
+
+- [ ] **Step 5: Update `_extract_disc_suffix` to return disc_total**
+
+In `_extract_disc_suffix()` (around line 147), update the function to return a 4-tuple `(remaining, disc_number, disc_type, disc_total)` instead of 3-tuple. Extract group(3) from the regex match when present.
+
+Update all callers of `_extract_disc_suffix` in `parse_label()` to handle the 4th element and set `disc_total` on LabelInfo.
+
+- [ ] **Step 6: Run tests**
+
+Run: `/home/upb/src/automatic-ripping-machine-neu/.venv/bin/python -m pytest /home/upb/src/automatic-ripping-machine-neu/test/test_arm_matcher.py -x -q --tb=short`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /home/upb/src/automatic-ripping-machine-neu add arm/ripper/arm_matcher.py test/test_arm_matcher.py
+git -C /home/upb/src/automatic-ripping-machine-neu commit -m "feat: extract disc_total from 'Disc N of M' patterns in parse_label()"
+```
+
+---
+
+### Task 2: Wire `parse_label()` into folder scan
+
+**Repo:** ARM-neu
+**Files:**
+- Modify: `arm/ripper/folder_scan.py`
+- Modify or create: `test/test_folder_scan.py`
+
+- [ ] **Step 1: Write tests for folder scan metadata extraction**
+
+```python
+def test_scan_folder_extracts_disc_number(tmp_path):
+    """scan_folder returns disc_number/disc_total parsed from folder name."""
+    from arm.ripper.folder_scan import extract_metadata
+    # Create a minimal BDMV structure
+    disc_dir = tmp_path / "Show Name - Disc 3 of 4 - BD50"
+    (disc_dir / "BDMV" / "STREAM").mkdir(parents=True)
+    (disc_dir / "BDMV" / "STREAM" / "00001.m2ts").write_bytes(b"\x00" * 100)
+
+    meta = extract_metadata(str(disc_dir), "bluray")
+    assert meta["disc_number"] == 3
+    assert meta["disc_total"] == 4
+
+def test_scan_folder_extracts_season_from_parent(tmp_path):
+    """scan_folder extracts season from parent folder path."""
+    from arm.ripper.folder_scan import extract_metadata
+    parent = tmp_path / "Show Name Season 2"
+    disc_dir = parent / "Show Name - Disc 1 of 3"
+    (disc_dir / "BDMV" / "STREAM").mkdir(parents=True)
+    (disc_dir / "BDMV" / "STREAM" / "00001.m2ts").write_bytes(b"\x00" * 100)
+
+    meta = extract_metadata(str(disc_dir), "bluray")
+    assert meta["season"] == 2
+
+def test_scan_folder_no_disc_info():
+    """scan_folder returns None for disc fields when not parseable."""
+    from arm.ripper.folder_scan import extract_metadata
+    # Use a path without disc info (would need actual folder — test with mock)
+    # disc_number/disc_total/season should be None when not found
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Update `extract_metadata()` to use `parse_label()`**
+
+In `arm/ripper/folder_scan.py`, import `parse_label` from `arm_matcher`:
+
+```python
+from arm.ripper.arm_matcher import parse_label
+```
+
+In `extract_metadata()`, after getting the label, run `parse_label()` on the folder basename and also on the parent folder name. Add to the return dict:
+
+```python
+label_info = parse_label(Path(folder_path).name)
+parent_info = parse_label(Path(folder_path).parent.name)
+
+# Prefer disc info from the folder itself, season from parent if not in folder
+disc_number = label_info.disc_number
+disc_total = label_info.disc_total
+season = label_info.season_number or parent_info.season_number
+
+return {
+    "label": label,
+    "title_suggestion": title,
+    "year_suggestion": year,
+    "folder_size_bytes": folder_size,
+    "stream_count": stream_count,
+    "disc_number": disc_number,
+    "disc_total": disc_total,
+    "season": season,
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `/home/upb/src/automatic-ripping-machine-neu/.venv/bin/python -m pytest /home/upb/src/automatic-ripping-machine-neu/test/test_folder_scan.py -x -q --tb=short`
+Expected: ALL PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `/home/upb/src/automatic-ripping-machine-neu/.venv/bin/python -m pytest /home/upb/src/automatic-ripping-machine-neu/test/ -x -q --tb=short`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/upb/src/automatic-ripping-machine-neu add arm/ripper/folder_scan.py test/test_folder_scan.py
+git -C /home/upb/src/automatic-ripping-machine-neu commit -m "feat: extract disc/season metadata from folder paths via parse_label()"
+```
+
+---
+
+### Task 3: Add season/disc fields to folder create & job update APIs
+
+**Repo:** ARM-neu
+**Files:**
+- Modify: `arm/api/v1/folder.py` (FolderCreateRequest, create_folder_job)
+- Modify: `arm/api/v1/jobs.py` (_DIRECT_FIELDS, tvdb-match endpoint)
+- Modify: `test/test_folder_api.py`
+
+- [ ] **Step 1: Add fields to `FolderCreateRequest`**
+
+In `arm/api/v1/folder.py`, add to FolderCreateRequest:
+
+```python
+season: Optional[int] = None
+disc_number: Optional[int] = None
+disc_total: Optional[int] = None
+```
+
+In `create_folder_job()`, after setting `multi_title`, add:
+
+```python
+if req.season is not None:
+    job.season = str(req.season)
+    job.season_manual = str(req.season)
+if req.disc_number is not None:
+    job.disc_number = req.disc_number
+if req.disc_total is not None:
+    job.disc_total = req.disc_total
+```
+
+- [ ] **Step 2: Add disc fields to `_DIRECT_FIELDS` in jobs.py**
+
+In `arm/api/v1/jobs.py`, extend `_DIRECT_FIELDS` (line 271):
+
+```python
+_DIRECT_FIELDS = ('path', 'label', 'disctype', 'disc_number', 'disc_total')
+```
+
+- [ ] **Step 3: Extend tvdb-match endpoint to accept disc overrides**
+
+In the tvdb-match endpoint (around line 618), update the request body parsing:
+
+```python
+disc_number = body.get("disc_number")
+disc_total = body.get("disc_total")
+
+# Temporarily set on job for this match run if provided
+if disc_number is not None:
+    job.disc_number = disc_number
+if disc_total is not None:
+    job.disc_total = disc_total
+```
+
+Pass these through before calling `match_episodes_for_api()`.
+
+- [ ] **Step 4: Update tests**
+
+Update `test/test_folder_api.py` test_create_success to pass season/disc fields and assert they're stored.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `/home/upb/src/automatic-ripping-machine-neu/.venv/bin/python -m pytest /home/upb/src/automatic-ripping-machine-neu/test/ -x -q --tb=short`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/upb/src/automatic-ripping-machine-neu add arm/api/v1/folder.py arm/api/v1/jobs.py test/test_folder_api.py
+git -C /home/upb/src/automatic-ripping-machine-neu commit -m "feat: add season/disc_number/disc_total to folder create and job update APIs"
+```
+
+---
+
+## Chunk 2: Frontend — Episode Match Component
+
+### Task 4: Build `EpisodeMatch.svelte` component
+
+**Repo:** ARM-UI
+**Files:**
+- Create: `frontend/src/lib/components/EpisodeMatch.svelte`
+- Modify: `frontend/src/lib/api/jobs.ts` (extend tvdbMatch to pass disc params)
+
+- [ ] **Step 1: Extend `tvdbMatch` API call**
+
+In `frontend/src/lib/api/jobs.ts`, update the `tvdbMatch` function to accept disc_number and disc_total:
+
+```typescript
+export function tvdbMatch(
+    jobId: number,
+    opts?: {
+        season?: number | null;
+        tolerance?: number | null;
+        apply?: boolean;
+        disc_number?: number | null;
+        disc_total?: number | null;
+    }
+): Promise<TvdbMatchResponse> {
+    return apiFetch<TvdbMatchResponse>(`/api/jobs/${jobId}/tvdb-match`, {
+        method: 'POST',
+        body: JSON.stringify({
+            season: opts?.season ?? null,
+            tolerance: opts?.tolerance ?? null,
+            apply: opts?.apply ?? false,
+            disc_number: opts?.disc_number ?? null,
+            disc_total: opts?.disc_total ?? null,
+        })
+    });
+}
+```
+
+- [ ] **Step 2: Create `EpisodeMatch.svelte`**
+
+Create `frontend/src/lib/components/EpisodeMatch.svelte`. The component:
+
+Props:
+```typescript
+interface Props {
+    job: JobDetail;
+    onapply?: () => void;
+}
+```
+
+State:
+- `seasonInput` — prefilled from `job.season || job.season_auto`
+- `discInput` / `discTotalInput` — prefilled from `job.disc_number` / `job.disc_total`
+- `toleranceInput` — default 300
+- `matches` — array from match API response
+- `episodes` — all episodes for the season (from tvdb-episodes endpoint)
+- `assignments` — map of track_number → episode_number (editable)
+- `loading` / `error` states
+
+Layout:
+1. **Controls bar**: Season, Disc N of M, Tolerance inputs + "Match" button + stats
+2. **Match table**: Track | Duration | Episode (dropdown) | TVDB Runtime | Delta
+3. **Actions**: Apply Matches / Clear All
+
+Key behaviors:
+- On mount: if job already has tracks with episode_number set, show those
+- "Match" button: calls `tvdbMatch(job.job_id, { season, tolerance, disc_number, disc_total, apply: false })`
+- Populate dropdowns from `fetchTvdbEpisodes(job.job_id, season)`
+- Dropdown change updates local `assignments` map
+- "Apply" button: calls `tvdbMatch(...)` with `apply: true` OR updates tracks individually
+- Short tracks (< 120s) shown dimmed/collapsed
+
+- [ ] **Step 3: Run build check**
+
+Run from `/home/upb/src/automatic-ripping-machine-ui/frontend`:
+```
+npm run build && npx svelte-check --tsconfig ./tsconfig.json
+```
+Expected: 0 errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /home/upb/src/automatic-ripping-machine-ui add frontend/src/lib/components/EpisodeMatch.svelte frontend/src/lib/api/jobs.ts
+git -C /home/upb/src/automatic-ripping-machine-ui commit -m "feat: add EpisodeMatch component with match table and dropdown reassignment"
+```
+
+---
+
+### Task 5: Wire EpisodeMatch into review widget and job detail page
+
+**Repo:** ARM-UI
+**Files:**
+- Modify: `frontend/src/lib/components/DiscReviewWidget.svelte`
+- Modify: `frontend/src/routes/jobs/[id]/+page.svelte`
+
+- [ ] **Step 1: Update DiscReviewWidget**
+
+In `DiscReviewWidget.svelte`:
+- Change the import from `TvdbMatch` to `EpisodeMatch`
+- Rename button text from "TVDB" to "Episodes"
+- Update the panel to use `<EpisodeMatch job={detail} onapply={loadDetail} />`
+
+- [ ] **Step 2: Update job detail page**
+
+In `/routes/jobs/[id]/+page.svelte`:
+- Change the import from `TvdbMatch` to `EpisodeMatch`
+- Rename button text from "TVDB Episodes" to "Episodes"
+- Update the panel to use `<EpisodeMatch {job} onapply={loadJob} />`
+- Keep existing `TvdbMatch.svelte` file — don't delete it yet (may have other dependents)
+
+- [ ] **Step 3: Run build and tests**
+
+Run from `/home/upb/src/automatic-ripping-machine-ui/frontend`:
+```
+npm run build && npx svelte-check --tsconfig ./tsconfig.json && npx vitest run
+```
+Expected: 0 errors, all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /home/upb/src/automatic-ripping-machine-ui add frontend/src/lib/components/DiscReviewWidget.svelte frontend/src/routes/jobs/\[id\]/+page.svelte
+git -C /home/upb/src/automatic-ripping-machine-ui commit -m "feat: replace TVDB button with Episodes panel using EpisodeMatch component"
+```
+
+---
+
+### Task 6: Add season/disc fields to folder import wizard
+
+**Repo:** ARM-UI
+**Files:**
+- Modify: `frontend/src/lib/components/FolderImportWizard.svelte`
+- Modify: `frontend/src/lib/api/folder.ts` (or wherever FolderCreateRequest is defined)
+
+- [ ] **Step 1: Update FolderCreateRequest type**
+
+Add `season`, `disc_number`, `disc_total` to the request type:
+
+```typescript
+season?: number | null;
+disc_number?: number | null;
+disc_total?: number | null;
+```
+
+- [ ] **Step 2: Add state and prefill from scan**
+
+In `FolderImportWizard.svelte`, add state variables:
+
+```typescript
+let editSeason = $state<string>('');
+let editDiscNumber = $state<string>('');
+let editDiscTotal = $state<string>('');
+```
+
+In the scan response handler, prefill:
+
+```typescript
+editSeason = scanResult.season?.toString() || '';
+editDiscNumber = scanResult.disc_number?.toString() || '';
+editDiscTotal = scanResult.disc_total?.toString() || '';
+```
+
+- [ ] **Step 3: Add input fields to wizard step 2**
+
+Add fields for Season, Disc Number, Disc Total in the metadata editing step (step 2 of the wizard). Show these when `editType === 'series'` or always if you want movies to optionally have disc info too.
+
+- [ ] **Step 4: Pass to create API**
+
+Update the `handleImport` function to include the new fields:
+
+```typescript
+const data: FolderCreateRequest = {
+    ...existing fields,
+    season: editSeason ? Number(editSeason) : null,
+    disc_number: editDiscNumber ? Number(editDiscNumber) : null,
+    disc_total: editDiscTotal ? Number(editDiscTotal) : null,
+};
+```
+
+- [ ] **Step 5: Run build and tests**
+
+Run from `/home/upb/src/automatic-ripping-machine-ui/frontend`:
+```
+npm run build && npx svelte-check --tsconfig ./tsconfig.json && npx vitest run
+```
+Expected: 0 errors, all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/upb/src/automatic-ripping-machine-ui add frontend/src/lib/components/FolderImportWizard.svelte frontend/src/lib/api/folder.ts
+git -C /home/upb/src/automatic-ripping-machine-ui commit -m "feat: prefill season/disc fields in folder import wizard from scan"
+```
+
+---
+
+## Chunk 3: Full Test Pass & Deploy
+
+### Task 7: Full backend test suite
+
+**Repo:** ARM-neu
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `/home/upb/src/automatic-ripping-machine-neu/.venv/bin/python -m pytest /home/upb/src/automatic-ripping-machine-neu/test/ -x -q --tb=short`
+Expected: ALL PASS
+
+- [ ] **Step 2: Fix any failures and commit**
+
+### Task 8: Full frontend test suite
+
+**Repo:** ARM-UI
+
+- [ ] **Step 1: Run backend tests**
+
+Run: `/home/upb/src/automatic-ripping-machine-ui/.venv/bin/python -m pytest /home/upb/src/automatic-ripping-machine-ui/tests/ -x -q --tb=short`
+Expected: ALL PASS
+
+- [ ] **Step 2: Run frontend build + type check + tests**
+
+Run from `/home/upb/src/automatic-ripping-machine-ui/frontend`:
+```
+npm run build && npx svelte-check --tsconfig ./tsconfig.json && npx vitest run
+```
+Expected: Build succeeds, 0 type errors, all tests pass
+
+- [ ] **Step 3: Fix any failures and commit**
+
+### Task 9: Push and create PRs
+
+- [ ] **Step 1: Push ARM-neu**
+
+```bash
+git -C /home/upb/src/automatic-ripping-machine-neu push -u origin feat/episode-matching-overhaul
+```
+
+- [ ] **Step 2: Push ARM-UI**
+
+```bash
+git -C /home/upb/src/automatic-ripping-machine-ui push -u origin feat/episode-matching-overhaul
+```
+
+- [ ] **Step 3: Create PRs**
+
+Create PRs for both repos against their respective parent branches (`feat/id-based-log-naming` for ARM-neu, `feat/folder-import-review` for ARM-UI) using `GITHUB_TOKEN= gh pr create`.
+
+- [ ] **Step 4: Check CI**
+
+Wait for CI to pass on both PRs. Fix any failures.

--- a/docs/superpowers/specs/2026-03-24-episode-matching-overhaul-design.md
+++ b/docs/superpowers/specs/2026-03-24-episode-matching-overhaul-design.md
@@ -1,0 +1,231 @@
+# Episode Matching Overhaul
+
+**Date:** 2026-03-24
+**Status:** Draft
+**Repos:** automatic-ripping-machine-neu, automatic-ripping-machine-ui
+**Depends on:** feat/id-based-log-naming (ARM-neu), feat/folder-import-review (ARM-UI)
+
+## Problem
+
+The TVDB episode matcher can't produce correct results for multi-disc TV series folder imports because:
+
+1. **No season/disc metadata on folder jobs** — the folder import wizard doesn't collect season, disc number, or disc total. The matcher has position bias logic for multi-disc sets but gets no input.
+2. **No extraction from folder paths** — paths like `Kolchak - Disc 4 of 4` contain disc info but `folder_scan.py` doesn't extract it. The centralized `parse_label()` in `arm_matcher.py` already handles these patterns but isn't wired into the folder flow.
+3. **No way to fix matches** — after the matcher runs, the user sees results but can't reassign which episode maps to which track. The only option is to change parameters and re-run.
+4. **Episodes button not discoverable** — currently labeled "TVDB Episodes" which is jargon. The workflow should be Search → Episodes → Start.
+
+## Design
+
+### User Flow
+
+```
+1. Search   →  Pick show (sets title, year, IMDB, TVDB ID)
+2. Episodes →  Set season/disc → auto-match → review table → fix with dropdowns
+3. Start    →  Process with matched episode metadata for naming
+```
+
+### Layer 1: Metadata Extraction & Storage
+
+#### 1.1 Extend folder scan to extract disc/season metadata
+
+**File:** `arm/ripper/folder_scan.py`
+
+`scan_folder()` currently returns `disc_type`, `label`, `title_suggestion`, `year_suggestion`, `folder_size_bytes`, `stream_count`.
+
+Extend: after extracting the label, run `parse_label()` from `arm_matcher.py` on it. Add to the return dict:
+
+- `disc_number` — extracted disc number (int or null)
+- `disc_total` — extracted disc total (int or null). Note: `parse_label()` extracts disc number from patterns like `Disc 4` but not disc total from `of 4`. Extend the parser to also capture total from `Disc N of M` patterns.
+- `season` — extracted season number (int or null)
+
+Also parse the **parent folder** path for season info. Multi-disc sets often have structure like:
+```
+Show Name (Year) Season 1/
+  Show Name - Disc 1 of 4/BDMV/
+  Show Name - Disc 2 of 4/BDMV/
+```
+
+The disc folder may not contain season info, but the parent does.
+
+#### 1.2 Extend `parse_label()` to extract disc total
+
+**File:** `arm/ripper/arm_matcher.py`
+
+Current `_DISC_SUFFIX_RE` captures `Disc 4` but not `of 4`. Add a new regex or extend the existing one to capture the `of N` pattern:
+
+```
+Disc 4 of 4  →  disc_number=4, disc_total=4
+D2 of 6      →  disc_number=2, disc_total=6
+Disc 1       →  disc_number=1, disc_total=None
+```
+
+Update `LabelInfo` dataclass to include `disc_total: int | None`.
+
+Note: `_DISC_SUFFIX_RE` is anchored with `$` (end of string). The "of N" extension should be added as an optional group before the anchor: `(?:\s*of\s*(\d+))?$`. This keeps the existing single-disc match working while also capturing the total when present.
+
+#### 1.3 Add fields to folder create endpoint
+
+**File:** `arm/api/v1/folder.py`
+
+Add to `FolderCreateRequest`:
+```python
+season: Optional[int] = None
+disc_number: Optional[int] = None
+disc_total: Optional[int] = None
+```
+
+Store on the job object during creation. Follow the existing paired-field convention (`season` + `season_manual`) so the auto-detect logic in `_get_known_season()` picks up the value:
+```python
+if req.season is not None:
+    job.season = str(req.season)
+    job.season_manual = str(req.season)
+if req.disc_number is not None:
+    job.disc_number = req.disc_number
+if req.disc_total is not None:
+    job.disc_total = req.disc_total
+```
+
+#### 1.4 Job metadata update API
+
+**File:** `arm/api/v1/jobs.py`
+
+The existing title update endpoint (`PUT /jobs/{job_id}/title`) already handles title, year, video_type, imdb_id, poster_url, season, artist, album, and episode via `_FIELD_MAP`. Season is already accepted — no change needed for it.
+
+Add `disc_number` and `disc_total` to `_DIRECT_FIELDS` (or handle explicitly) since they are integer columns, not paired string fields:
+
+- `disc_number` (int)
+- `disc_total` (int)
+
+The TVDB matcher already reads `job.disc_number` and `job.disc_total` — so setting them via the update endpoint makes the matcher work correctly on the next run.
+
+#### 1.5 TVDB match endpoint enhancement
+
+**File:** `arm/api/v1/jobs.py` (tvdb-match endpoint)
+
+Currently accepts `season`, `tolerance`, `apply`. Add:
+
+- `disc_number` (optional int) — override for position bias
+- `disc_total` (optional int) — override for position bias
+
+When provided, these are used instead of the job's stored values for that match run. This lets the user experiment with different disc positions without saving first.
+
+### Layer 2: Episodes Panel UI
+
+#### 2.1 New `EpisodeMatch.svelte` component
+
+**File:** `frontend/src/lib/components/EpisodeMatch.svelte`
+
+Replace or wrap the existing `TvdbMatch.svelte`. The new component has:
+
+**Top controls bar:**
+- Season input (prefilled from job or auto-detect)
+- Disc number / disc total inputs (prefilled from job)
+- Tolerance input (default 300s)
+- "Re-match" button — re-runs the matcher with current control values
+- Match stats summary: "5 matched · 0 unmatched · 7 skipped"
+
+**Match table:**
+- Columns: Track (number + truncated filename), Duration, Matched Episode (dropdown), TVDB Runtime, Delta
+- Each episode dropdown contains all episodes from the selected season
+- "None (skip)" option to unassign a track
+- Short tracks (< 2 min) shown dimmed/collapsed at bottom as "skipped"
+- Delta column color-coded: green (< 60s), yellow (< 180s), red (> 180s)
+
+**Bottom actions:**
+- "Apply Matches" — saves episode assignments to track records in DB
+- "Clear All" — removes all episode assignments
+
+**Data flow:**
+1. Component mounts → fetches current match state from job tracks (existing `episode_number`/`episode_name` fields)
+2. Fetches all episodes for the selected season via `GET /jobs/{job_id}/tvdb-episodes?season=N` — populates dropdown options
+3. User adjusts controls → clicks "Re-match" → calls `POST /jobs/{job_id}/tvdb-match` with `apply: false` (preview)
+4. Preview populates the table with proposed matches
+5. User adjusts dropdowns manually if needed
+6. "Apply Matches" → calls tvdb-match with `apply: true` for auto-matched results, OR calls per-track update API for manual overrides
+
+#### 2.2 Wire into review widget and job detail page
+
+**Dashboard review widget** (`DiscReviewWidget.svelte`):
+- Rename "TVDB" button (currently labeled "TVDB") to "Episodes"
+- Point to new `EpisodeMatch` component
+- Only show for series or when IMDB/TVDB ID is set
+
+**Job detail page** (`/jobs/[id]/+page.svelte`):
+- Rename "TVDB Episodes" button (currently labeled "TVDB Episodes") to "Episodes"
+- Point to new `EpisodeMatch` component
+
+#### 2.3 Folder import wizard prefill
+
+**File:** `frontend/src/lib/components/FolderImportWizard.svelte`
+
+The scan response now includes `disc_number`, `disc_total`, `season`. Prefill these in the wizard's metadata step. Add editable fields for:
+- Season (number input)
+- Disc number (number input)
+- Disc total (number input)
+
+Pass to the create endpoint so the job starts with correct metadata.
+
+### Layer 3: Matching Algorithm (existing — minimal changes)
+
+The existing greedy nearest-neighbor matcher in `tvdb_matcher.py` already supports:
+- Season selection (explicit, auto-detect, or from job)
+- Position bias for disc number/total
+- Cross-disc exclusion via `cross_disc.py`
+- Runtime tolerance
+
+The only change needed: ensure the match endpoint passes `disc_number` and `disc_total` through to the matcher when provided in the request. Currently `match_tracks_to_episodes` reads these from the job object — the endpoint should update the job (or pass overrides) before calling the matcher.
+
+No algorithm changes required for Layer 1. The intelligence improvements (better handling of same-runtime episodes, explicit episode ranges) are future work once the data pipeline is solid.
+
+## Files Affected
+
+### ARM-neu
+
+| File | Change |
+|------|--------|
+| `arm/ripper/arm_matcher.py` | Add `disc_total` to `LabelInfo`, extend regex for "Disc N of M" |
+| `arm/ripper/folder_scan.py` | Run `parse_label()` on folder name, extract season from parent path |
+| `arm/api/v1/folder.py` | Add season/disc_number/disc_total to create request and job storage |
+| `arm/api/v1/jobs.py` | Extend title update to accept season/disc fields; extend tvdb-match to accept disc overrides |
+| `test/test_folder_scan.py` | Test disc/season extraction from folder paths |
+| `test/test_arm_matcher.py` | Test disc_total extraction |
+
+### ARM-UI
+
+| File | Change |
+|------|--------|
+| `frontend/src/lib/components/EpisodeMatch.svelte` | New component — match table with controls and dropdowns |
+| `frontend/src/lib/components/DiscReviewWidget.svelte` | Rename "TVDB" → "Episodes", use new component |
+| `frontend/src/routes/jobs/[id]/+page.svelte` | Rename "TVDB Episodes" → "Episodes", use new component |
+| `frontend/src/lib/components/FolderImportWizard.svelte` | Add season/disc fields, prefill from scan |
+| `frontend/src/lib/api/jobs.ts` | Extend tvdb-match API call to pass disc_number/disc_total |
+| `frontend/src/lib/components/TvdbMatch.svelte` | May be kept as inner component or replaced by EpisodeMatch |
+
+## Testing
+
+### Backend
+- `parse_label("Kolchak Disc 4 of 4")` → `disc_number=4, disc_total=4`
+- `parse_label("Show S02D03")` → `season=2, disc_number=3`
+- `scan_folder()` returns disc/season metadata from path
+- Folder create with season/disc stores on job
+- Title update accepts and saves season/disc/disc_total
+- TVDB match with disc_number override uses position bias correctly
+
+### Frontend
+- Episodes panel shows track-to-episode match table
+- Dropdowns allow reassignment
+- Re-match with different season/disc produces new results
+- Apply saves matches to DB
+- Wizard prefills disc/season from scan
+
+### Integration
+- Full flow: scan folder → wizard prefills S1 D4/4 → create job → review → Episodes panel → auto-match → correct episodes shown → Apply → Start
+
+## Decisions
+
+1. **Extend `parse_label()` rather than adding new parsing** — centralized label parsing stays in `arm_matcher.py`. `folder_scan.py` calls it instead of duplicating.
+2. **Parent folder parsing for season** — disc folders often lack season info, but the containing folder has it. Parse one level up.
+3. **New `EpisodeMatch.svelte` component** — cleaner than bolting a match table onto the existing `TvdbMatch.svelte`. May reuse TvdbMatch internals for the TVDB API calls.
+4. **Dropdowns for episode reassignment** — simple, accessible, no drag-and-drop complexity. Each track gets a dropdown populated with all episodes from the season.
+5. **Disc overrides in match request** — user can experiment without saving, reducing friction for "try disc 3 instead of 4" scenarios.
+6. **Rename TVDB → Episodes** — user-facing label should describe the action, not the data source.

--- a/test/test_folder_api.py
+++ b/test/test_folder_api.py
@@ -205,3 +205,106 @@ class TestFolderCreate:
         })
         assert resp.status_code == 400
         assert "Source folder not found" in resp.json()["error"]
+
+    @patch("arm.api.v1.folder.threading")
+    @patch("arm.api.v1.folder.db")
+    @patch("arm.api.v1.folder.validate_ingress_path")
+    @patch("arm.api.v1.folder.Job")
+    @patch("arm.api.v1.folder.cfg")
+    def test_create_with_season_and_disc_fields(
+        self, mock_cfg, mock_job_cls, mock_validate, mock_db, mock_threading
+    ):
+        """season, disc_number, disc_total are stored on the job."""
+        mock_cfg.arm_config = {"INGRESS_PATH": "/ingress", "VIDEOTYPE": "auto"}
+
+        mock_job = MagicMock()
+        mock_job.job_id = 55
+        mock_job.status = "identifying"
+        mock_job.source_type = "folder"
+        mock_job.source_path = "/ingress/tv_show"
+        mock_job_cls.from_folder.return_value = mock_job
+        mock_job_cls.query.filter.return_value.first.return_value = None
+
+        from fastapi.testclient import TestClient
+        from arm.app import app
+        client = TestClient(app)
+
+        resp = client.post("/api/v1/jobs/folder", json={
+            "source_path": "/ingress/tv_show",
+            "title": "My TV Show",
+            "year": "2025",
+            "video_type": "series",
+            "disctype": "bluray",
+            "season": 1,
+            "disc_number": 4,
+            "disc_total": 4,
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["success"] is True
+        assert data["job_id"] == 55
+        # Verify season fields
+        assert mock_job.season == "1"
+        assert mock_job.season_manual == "1"
+        # Verify disc fields
+        assert mock_job.disc_number == 4
+        assert mock_job.disc_total == 4
+
+
+class TestPrescanAndWait:
+    """Test _prescan_and_wait background function."""
+
+    @patch("arm.api.v1.folder.db")
+    @patch("arm.api.v1.folder.Job")
+    def test_prescan_success(self, mock_job_cls, mock_db):
+        """Job transitions from IDENTIFYING to MANUAL_WAIT_STARTED on success."""
+        from arm.api.v1.folder import _prescan_and_wait
+
+        mock_job = MagicMock()
+        mock_job.job_id = 10
+        mock_job.tracks = [MagicMock(), MagicMock()]
+        mock_job_cls.query.get.return_value = mock_job
+
+        with patch("arm.ripper.makemkv.prep_mkv") as mock_prep, \
+             patch("arm.ripper.makemkv.prescan_track_info") as mock_prescan:
+            _prescan_and_wait(10)
+
+        mock_prep.assert_called_once()
+        mock_prescan.assert_called_once_with(mock_job)
+        assert mock_job.status == "waiting"
+        mock_db.session.commit.assert_called()
+
+    @patch("arm.api.v1.folder.db")
+    @patch("arm.api.v1.folder.Job")
+    def test_prescan_failure_still_transitions(self, mock_job_cls, mock_db):
+        """On failure, job gets error message and still transitions to MANUAL_WAIT_STARTED."""
+        from arm.api.v1.folder import _prescan_and_wait
+
+        mock_job = MagicMock()
+        mock_job.job_id = 11
+        mock_job.errors = None
+        mock_job_cls.query.get.return_value = mock_job
+
+        with patch("arm.ripper.makemkv.prep_mkv"), \
+             patch("arm.ripper.makemkv.prescan_track_info",
+                   side_effect=RuntimeError("MakeMKV crashed")):
+            _prescan_and_wait(11)
+
+        assert mock_job.status == "waiting"
+        assert "Prescan failed" in mock_job.errors
+        assert "MakeMKV crashed" in mock_job.errors
+        mock_db.session.commit.assert_called()
+
+    @patch("arm.api.v1.folder.db")
+    @patch("arm.api.v1.folder.Job")
+    def test_prescan_job_not_found(self, mock_job_cls, mock_db):
+        """When job is not found, logs error and returns gracefully."""
+        from arm.api.v1.folder import _prescan_and_wait
+
+        mock_job_cls.query.get.return_value = None
+
+        # Should not raise
+        _prescan_and_wait(999)
+
+        # DB commit should NOT be called since there's no job to update
+        mock_db.session.commit.assert_not_called()

--- a/test/test_folder_ripper.py
+++ b/test/test_folder_ripper.py
@@ -179,3 +179,46 @@ class TestRipFolder:
 
         with pytest.raises(FileNotFoundError):
             rip_folder(job)
+
+    @patch("arm.ripper.folder_ripper.db")
+    @patch("arm.ripper.folder_ripper.structlog")
+    @patch("arm.ripper.folder_ripper.prescan_track_info", side_effect=RuntimeError("boom"))
+    @patch("arm.ripper.folder_ripper.setup_rawpath", return_value="/tmp/raw/Test")
+    @patch("arm.ripper.folder_ripper.prep_mkv")
+    def test_clear_contextvars_called_on_failure(
+        self, mock_prep, mock_setup, mock_prescan, mock_structlog, mock_db, tmp_path
+    ):
+        """structlog.contextvars.clear_contextvars() is called in the finally block even when rip fails."""
+        from arm.ripper.folder_ripper import rip_folder
+
+        job = self._make_job(tmp_path)
+
+        with patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
+            mock_cfg.arm_config = {"TRANSCODER_URL": ""}
+            with pytest.raises(RuntimeError, match="boom"):
+                rip_folder(job)
+
+        mock_structlog.contextvars.clear_contextvars.assert_called()
+
+    @patch("arm.ripper.folder_ripper.db")
+    @patch("arm.ripper.folder_ripper.prescan_track_info", side_effect=RuntimeError("boom"))
+    @patch("arm.ripper.folder_ripper.setup_rawpath", return_value="/tmp/raw/Test")
+    @patch("arm.ripper.folder_ripper.prep_mkv")
+    def test_file_handler_removed_on_failure(
+        self, mock_prep, mock_setup, mock_prescan, mock_db, tmp_path
+    ):
+        """File handler is removed from root logger on cleanup even when rip fails."""
+        import logging
+        from arm.ripper.folder_ripper import rip_folder
+
+        job = self._make_job(tmp_path)
+        root_logger = logging.getLogger()
+        handlers_before = len(root_logger.handlers)
+
+        with patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
+            mock_cfg.arm_config = {"TRANSCODER_URL": ""}
+            with pytest.raises(RuntimeError, match="boom"):
+                rip_folder(job)
+
+        # The handler added during rip should be removed in the finally block
+        assert len(root_logger.handlers) <= handlers_before

--- a/test/test_folder_scan.py
+++ b/test/test_folder_scan.py
@@ -112,6 +112,27 @@ class TestExtractMetadata:
         assert meta["season"] == 1
         assert meta["disc_number"] == 3
 
+    def test_extract_metadata_disc_with_trailing_junk(self, tmp_path):
+        """Fallback regex extracts disc info from names with trailing suffixes."""
+        from arm.ripper.folder_scan import extract_metadata
+        disc_dir = tmp_path / "Kolchak - The Night Stalker (1974 - 1975) - Disc 4 of 4 - BD50 - Untouched"
+        (disc_dir / "BDMV" / "STREAM").mkdir(parents=True)
+        (disc_dir / "BDMV" / "STREAM" / "00001.m2ts").write_bytes(b"\x00" * 100)
+        meta = extract_metadata(str(disc_dir), "bluray")
+        assert meta["disc_number"] == 4
+        assert meta["disc_total"] == 4
+
+    def test_extract_metadata_season_from_parent_with_trailing_junk(self, tmp_path):
+        """Fallback regex extracts season from parent folder names."""
+        from arm.ripper.folder_scan import extract_metadata
+        parent = tmp_path / "Show Name Season 2 - Complete"
+        disc_dir = parent / "Disc 1 - BD50"
+        (disc_dir / "BDMV" / "STREAM").mkdir(parents=True)
+        (disc_dir / "BDMV" / "STREAM" / "00001.m2ts").write_bytes(b"\x00" * 100)
+        meta = extract_metadata(str(disc_dir), "bluray")
+        assert meta["season"] == 2
+        assert meta["disc_number"] == 1
+
 
 class TestValidateIngressPath:
     def test_valid_path_passes(self, tmp_ingress, bdmv_folder):

--- a/test/test_folder_scan.py
+++ b/test/test_folder_scan.py
@@ -74,6 +74,44 @@ class TestExtractMetadata:
         assert meta["title_suggestion"] == "DVD Movie"
         assert meta["year_suggestion"] == "2020"
 
+    def test_extract_metadata_disc_number(self, tmp_path):
+        """extract_metadata returns disc_number/disc_total from folder name."""
+        from arm.ripper.folder_scan import extract_metadata
+        disc_dir = tmp_path / "Show Name Disc 3 of 4"
+        (disc_dir / "BDMV" / "STREAM").mkdir(parents=True)
+        (disc_dir / "BDMV" / "STREAM" / "00001.m2ts").write_bytes(b"\x00" * 100)
+        meta = extract_metadata(str(disc_dir), "bluray")
+        assert meta["disc_number"] == 3
+        assert meta["disc_total"] == 4
+
+    def test_extract_metadata_season_from_parent(self, tmp_path):
+        """extract_metadata extracts season from parent folder."""
+        from arm.ripper.folder_scan import extract_metadata
+        parent = tmp_path / "Show Name Season 2"
+        disc_dir = parent / "Show Name Disc 1"
+        (disc_dir / "BDMV" / "STREAM").mkdir(parents=True)
+        (disc_dir / "BDMV" / "STREAM" / "00001.m2ts").write_bytes(b"\x00" * 100)
+        meta = extract_metadata(str(disc_dir), "bluray")
+        assert meta["season"] == 2
+        assert meta["disc_number"] == 1
+
+    def test_extract_metadata_no_disc_info(self, bdmv_folder):
+        """extract_metadata returns None for disc fields when not parseable."""
+        from arm.ripper.folder_scan import extract_metadata
+        meta = extract_metadata(str(bdmv_folder), "bluray")
+        assert meta["disc_number"] is None
+        assert meta["disc_total"] is None
+
+    def test_extract_metadata_season_in_folder_name(self, tmp_path):
+        """Season from the disc folder itself takes priority."""
+        from arm.ripper.folder_scan import extract_metadata
+        disc_dir = tmp_path / "Show S01D03"
+        (disc_dir / "VIDEO_TS").mkdir(parents=True)
+        (disc_dir / "VIDEO_TS" / "VIDEO_TS.IFO").write_bytes(b"\x00" * 100)
+        meta = extract_metadata(str(disc_dir), "dvd")
+        assert meta["season"] == 1
+        assert meta["disc_number"] == 3
+
 
 class TestValidateIngressPath:
     def test_valid_path_passes(self, tmp_ingress, bdmv_folder):

--- a/test/test_jobs_api.py
+++ b/test/test_jobs_api.py
@@ -303,3 +303,86 @@ class TestTrackFieldUpdates:
             json={"enabled": True},
         )
         assert resp.status_code == 404
+
+
+class TestTvdbMatch:
+    """Test POST /jobs/{id}/tvdb-match disc override logic."""
+
+    def test_disc_overrides_set_on_job_before_matching(self, app_context, sample_job, client):
+        """disc_number and disc_total from request body are set on the job before matching."""
+        sample_job.disc_number = 1
+        sample_job.disc_total = 1
+        sample_job.status = "waiting"
+        db.session.commit()
+
+        captured_disc_number = None
+        captured_disc_total = None
+
+        def fake_match(job, season=None, tolerance=None, apply=False):
+            nonlocal captured_disc_number, captured_disc_total
+            captured_disc_number = job.disc_number
+            captured_disc_total = job.disc_total
+            return {"success": True, "matches": [], "preview": True}
+
+        with unittest.mock.patch("arm.services.tvdb_sync.match_episodes_for_api", side_effect=fake_match):
+            resp = client.post(
+                f"/api/v1/jobs/{sample_job.job_id}/tvdb-match",
+                json={"season": 2, "disc_number": 3, "disc_total": 6, "apply": False},
+            )
+
+        assert resp.status_code == 200
+        # The matcher should have seen the overridden values
+        assert captured_disc_number == 3
+        assert captured_disc_total == 6
+
+    def test_preview_mode_restores_originals(self, app_context, sample_job, client):
+        """In preview mode (apply=false), original disc values are restored after matching."""
+        sample_job.disc_number = 1
+        sample_job.disc_total = 2
+        sample_job.status = "waiting"
+        db.session.commit()
+
+        def fake_match(job, season=None, tolerance=None, apply=False):
+            return {"success": True, "matches": [], "preview": True}
+
+        with unittest.mock.patch("arm.services.tvdb_sync.match_episodes_for_api", side_effect=fake_match):
+            resp = client.post(
+                f"/api/v1/jobs/{sample_job.job_id}/tvdb-match",
+                json={"season": 1, "disc_number": 5, "disc_total": 10, "apply": False},
+            )
+
+        assert resp.status_code == 200
+        # Originals should be restored
+        db.session.expire(sample_job)
+        assert sample_job.disc_number == 1
+        assert sample_job.disc_total == 2
+
+    def test_apply_mode_persists_overrides(self, app_context, sample_job, client):
+        """In apply mode (apply=true), disc overrides persist on the job."""
+        sample_job.disc_number = 1
+        sample_job.disc_total = 2
+        sample_job.status = "waiting"
+        db.session.commit()
+
+        def fake_match(job, season=None, tolerance=None, apply=False):
+            return {"success": True, "matches": [], "applied": True}
+
+        with unittest.mock.patch("arm.services.tvdb_sync.match_episodes_for_api", side_effect=fake_match):
+            resp = client.post(
+                f"/api/v1/jobs/{sample_job.job_id}/tvdb-match",
+                json={"season": 1, "disc_number": 5, "disc_total": 10, "apply": True},
+            )
+
+        assert resp.status_code == 200
+        # Overrides should persist (not restored)
+        db.session.expire(sample_job)
+        assert sample_job.disc_number == 5
+        assert sample_job.disc_total == 10
+
+    def test_tvdb_match_job_not_found(self, app_context, client):
+        """Non-existent job returns 404."""
+        resp = client.post(
+            "/api/v1/jobs/99999/tvdb-match",
+            json={"season": 1},
+        )
+        assert resp.status_code == 404

--- a/test/test_rip_logic.py
+++ b/test/test_rip_logic.py
@@ -1535,3 +1535,39 @@ class TestLabelSeparatorNormalization:
         from arm.ripper.arm_matcher import parse_label
         info = parse_label("The.Wire")
         assert info.title == "the wire"
+
+
+class TestDiscTotal:
+    """Test disc_total extraction from 'Disc N of M' patterns."""
+
+    def test_disc_of_total_underscores(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("SHOW_NAME_DISC_4_OF_4")
+        assert info.disc_number == 4
+        assert info.disc_total == 4
+        assert info.title == "show name"
+
+    def test_disc_of_total_spaces(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("Show Name Disc 2 of 6")
+        assert info.disc_number == 2
+        assert info.disc_total == 6
+
+    def test_disc_no_total(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("SHOW_DISC_3")
+        assert info.disc_number == 3
+        assert info.disc_total is None
+
+    def test_d_of_total(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("SHOW_D2_OF_4")
+        assert info.disc_number == 2
+        assert info.disc_total == 4
+
+    def test_kolchak_real_world(self):
+        from arm.ripper.arm_matcher import parse_label
+        info = parse_label("Kolchak The Night Stalker Disc 4 of 4")
+        assert info.disc_number == 4
+        assert info.disc_total == 4
+        assert "kolchak" in info.title


### PR DESCRIPTION
## Summary
- Extract `disc_total` from 'Disc N of M' patterns in `parse_label()`
- Wire `parse_label()` into folder scan for disc/season metadata extraction
- Add season/disc_number/disc_total fields to folder create and job update APIs
- TVDB match endpoint accepts disc_number/disc_total overrides for position bias

## Test plan
- [x] Full test suite passes (1583 tests)
- [x] parse_label extracts disc_total from various patterns
- [x] folder scan returns disc/season from paths and parent folders