### PR TITLE
feat: naming-preview API and DB pool exhaustion fix

### DIFF
--- a/arm/api/v1/folder.py
+++ b/arm/api/v1/folder.py
@@ -146,23 +146,34 @@ def create_folder_job(req: FolderCreateRequest):
 
 
 def _prescan_and_wait(job_id: int):
-    """Background: prescan tracks with MakeMKV, then move job to MANUAL_WAIT."""
+    """Background: prescan tracks with MakeMKV, then move job to MANUAL_WAIT.
+
+    Runs in a daemon thread. Must clean up the scoped DB session on exit
+    to prevent connection pool exhaustion.
+    """
     from arm.ripper.makemkv import prep_mkv, prescan_track_info
 
-    job = Job.query.get(job_id)
-    if not job:
-        log.error("Prescan: job %s not found", job_id)
-        return
-
     try:
-        prep_mkv()
-        prescan_track_info(job)
-        job.status = JobState.MANUAL_WAIT_STARTED.value
-        db.session.commit()
-        log.info("Prescan complete for job %s — %d tracks found, waiting for review",
-                 job_id, len(list(job.tracks)))
-    except Exception as exc:
-        log.error("Prescan failed for job %s: %s", job_id, exc)
-        job.status = JobState.MANUAL_WAIT_STARTED.value
-        job.errors = f"Prescan failed: {exc}"
-        db.session.commit()
+        job = Job.query.get(job_id)
+        if not job:
+            log.error("Prescan: job %s not found", job_id)
+            return
+
+        try:
+            prep_mkv()
+            prescan_track_info(job)
+            job.status = JobState.MANUAL_WAIT_STARTED.value
+            db.session.commit()
+            log.info("Prescan complete for job %s — %d tracks found, waiting for review",
+                     job_id, len(list(job.tracks)))
+        except Exception as exc:
+            log.error("Prescan failed for job %s: %s", job_id, exc)
+            try:
+                job.status = JobState.MANUAL_WAIT_STARTED.value
+                job.errors = f"Prescan failed: {exc}"
+                db.session.commit()
+            except Exception:
+                log.exception("Failed to update job %s status after prescan error", job_id)
+    finally:
+        # Release the scoped session for this thread to prevent pool exhaustion
+        db.session.remove()

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -478,6 +478,33 @@ async def naming_preview(request: Request):
     return {"success": True, "rendered": rendered}
 
 
+@router.get('/jobs/{job_id}/naming-preview')
+def naming_preview_for_job(job_id: int):
+    """Return rendered filenames for all tracks on a job using the naming engine."""
+    from arm.ripper.naming import render_track_title, render_track_folder, render_title, render_folder
+
+    job = Job.query.get(job_id)
+    if not job:
+        return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
+
+    config_dict = cfg.arm_config
+
+    tracks_preview = []
+    for track in sorted(job.tracks, key=lambda t: int(t.track_number or 0)):
+        tracks_preview.append({
+            "track_number": track.track_number,
+            "rendered_title": render_track_title(track, job, config_dict),
+            "rendered_folder": render_track_folder(track, job, config_dict),
+        })
+
+    return {
+        "success": True,
+        "job_title": render_title(job, config_dict),
+        "job_folder": render_folder(job, config_dict),
+        "tracks": tracks_preview,
+    }
+
+
 TRANSCODE_OVERRIDE_KEYS = {
     'video_encoder', 'video_quality', 'audio_encoder', 'subtitle_mode',
     'handbrake_preset', 'handbrake_preset_4k', 'handbrake_preset_dvd',

--- a/test/test_folder_api.py
+++ b/test/test_folder_api.py
@@ -271,6 +271,8 @@ class TestPrescanAndWait:
 
         mock_prep.assert_called_once()
         mock_prescan.assert_called_once_with(mock_job)
+        # Session must be cleaned up to prevent pool exhaustion
+        mock_db.session.remove.assert_called_once()
         assert mock_job.status == "waiting"
         mock_db.session.commit.assert_called()
 
@@ -292,6 +294,7 @@ class TestPrescanAndWait:
 
         assert mock_job.status == "waiting"
         assert "Prescan failed" in mock_job.errors
+        mock_db.session.remove.assert_called_once()
         assert "MakeMKV crashed" in mock_job.errors
         mock_db.session.commit.assert_called()
 
@@ -308,3 +311,26 @@ class TestPrescanAndWait:
 
         # DB commit should NOT be called since there's no job to update
         mock_db.session.commit.assert_not_called()
+        # Session must still be cleaned up
+        mock_db.session.remove.assert_called_once()
+
+    @patch("arm.api.v1.folder.db")
+    @patch("arm.api.v1.folder.Job")
+    def test_prescan_session_cleaned_on_commit_failure(self, mock_job_cls, mock_db):
+        """Session is cleaned up even when the error-path commit fails."""
+        from arm.api.v1.folder import _prescan_and_wait
+
+        mock_job = MagicMock()
+        mock_job.job_id = 12
+        mock_job.errors = None
+        mock_job_cls.query.get.return_value = mock_job
+        # First commit (in except block) raises
+        mock_db.session.commit.side_effect = RuntimeError("DB locked")
+
+        with patch("arm.ripper.makemkv.prep_mkv"), \
+             patch("arm.ripper.makemkv.prescan_track_info",
+                   side_effect=RuntimeError("MakeMKV crashed")):
+            _prescan_and_wait(12)
+
+        # Session must still be cleaned up despite double failure
+        mock_db.session.remove.assert_called_once()

--- a/test/test_jobs_api.py
+++ b/test/test_jobs_api.py
@@ -386,3 +386,39 @@ class TestTvdbMatch:
             json={"season": 1},
         )
         assert resp.status_code == 404
+
+
+class TestNamingPreviewForJob:
+    """Test GET /api/v1/jobs/{job_id}/naming-preview."""
+
+    def test_returns_rendered_titles_for_tracks(self, app_context, job_with_tracks, client):
+        job, tracks = job_with_tracks
+        job.video_type = 'series'
+        job.season = '1'
+        tracks[0].episode_number = '1'
+        tracks[0].episode_name = 'Pilot'
+        tracks[0].title = 'Pilot'
+        db.session.commit()
+
+        resp = client.get(f"/api/v1/jobs/{job.job_id}/naming-preview")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert "job_title" in data
+        assert "job_folder" in data
+        assert len(data["tracks"]) == 3
+        # First track should have rendered title with episode info
+        t0 = data["tracks"][0]
+        assert "rendered_title" in t0
+        assert "rendered_folder" in t0
+        assert t0["track_number"] is not None
+
+    def test_returns_404_for_missing_job(self, app_context, client):
+        resp = client.get("/api/v1/jobs/99999/naming-preview")
+        assert resp.status_code == 404
+
+    def test_empty_tracks(self, app_context, sample_job, client):
+        resp = client.get(f"/api/v1/jobs/{sample_job.job_id}/naming-preview")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["tracks"] == []


### PR DESCRIPTION
## Summary
- Add GET /api/v1/jobs/{job_id}/naming-preview endpoint using naming engine
- Fix DB pool exhaustion: _prescan_and_wait now cleans up scoped session in finally block

## Test plan
- [x] 1599 tests pass