### PR TITLE
fix: prevent DB pool exhaustion in all background thread entry points

### DIFF
--- a/arm/database/__init__.py
+++ b/arm/database/__init__.py
@@ -98,6 +98,12 @@ class _DB:
             log.debug("Database engine already initialised — skipping.")
             return
         engine_kw.setdefault('pool_pre_ping', True)
+        # Increase pool size to handle concurrent background threads
+        # (disc rips, folder rips, prescans all run in daemon threads).
+        # Skip when caller provides a custom poolclass (e.g. StaticPool in tests).
+        if 'poolclass' not in engine_kw:
+            engine_kw.setdefault('pool_size', 20)
+            engine_kw.setdefault('max_overflow', 10)
         # SQLite: enable WAL mode (readers never block writers) and set a
         # 30-second busy_timeout so concurrent writes wait instead of
         # immediately raising SQLITE_BUSY.

--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -131,3 +131,6 @@ def rip_folder(job):
             logging.getLogger().removeHandler(file_handler)
             file_handler.close()
         structlog.contextvars.clear_contextvars()
+        # Release scoped session to prevent DB connection pool exhaustion
+        # (this function runs in a daemon thread)
+        db.session.remove()

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -414,3 +414,6 @@ if __name__ == "__main__":
             hours, minutes = divmod(minutes, 60)
             job.job_length = f'{hours:d}:{minutes:02d}:{seconds:02d}'
         db.session.commit()
+        # Release scoped session to prevent DB connection pool exhaustion
+        # (this function runs in a daemon thread spawned by udev/drive detection)
+        db.session.remove()


### PR DESCRIPTION
## Summary
- Add `db.session.remove()` to `rip_folder()` finally block (folder_ripper.py)
- Add `db.session.remove()` to `main()` rip entry point finally block (main.py)
- Increase pool_size from default 5 to 20 (skipped when StaticPool used in tests)

## Problem
Background daemon threads (disc rips, folder rips, prescans) hold scoped DB sessions for hours without releasing them. With the default pool of 5+10=15 connections, just a few concurrent jobs exhaust the pool, causing API timeouts and unresponsive UI.

## Test plan
- [x] 1599 tests pass