### PR TITLE
feat: windowed positional episode matching for multi-disc sets

### DIFF
--- a/arm/services/matching/tvdb_matcher.py
+++ b/arm/services/matching/tvdb_matcher.py
@@ -170,17 +170,13 @@ def match_tracks_to_episodes(
     disc_total: int | None = None,
     exclude_episodes: set[int] | None = None,
 ) -> list[dict]:
-    """Match tracks to episodes by runtime similarity.
+    """Match tracks to episodes using disc-windowed positional assignment.
 
-    Uses greedy nearest-neighbor: build all (track, episode) pairs ranked
-    by runtime delta, assign smallest first, no reuse.
-
-    When disc_number is provided, adds a position bias so that later discs
-    prefer later episodes (prevents all discs matching early episodes when
-    runtimes are identical).
-
-    When exclude_episodes is provided, those episode numbers are skipped
-    entirely (used for cross-disc deduplication).
+    Strategy:
+    1. When disc info is available, compute an episode window for this disc
+       and assign tracks positionally (track 0 → first episode in window).
+    2. Runtime is used as validation, not as the primary signal.
+    3. Falls back to greedy runtime matching when no disc info is given.
 
     Args:
         tracks: [{"track_number": "0", "length": 3407}, ...]
@@ -203,59 +199,163 @@ def match_tracks_to_episodes(
             log.info("All episodes excluded by cross-disc filter")
             return []
 
-    # Calculate expected episode position for this disc.
-    # Computed after exclusion filtering so the bias is relative to the
-    # remaining candidates, not the full season — this is intentional.
-    use_position_bias = disc_number is not None and disc_number > 0
-    if use_position_bias:
-        disc_count = disc_total or disc_number
-        expected_center = (disc_number - 0.5) / disc_count * len(episodes)
+    # Identify main tracks (>= 2 min), sorted by track number
+    main_tracks = sorted(
+        [t for t in tracks if (t.get("length") or 0) >= 120],
+        key=lambda t: int(t.get("track_number") or 0),
+    )
+    if not main_tracks:
+        return []
+
+    # Sort episodes by number for positional assignment
+    episodes = sorted(episodes, key=lambda ep: ep["number"])
+
+    use_disc_window = disc_number is not None and disc_number > 0
+    if use_disc_window:
+        return _match_windowed(main_tracks, episodes, tolerance, disc_number, disc_total)
     else:
-        expected_center = 0.0
+        return _match_greedy(main_tracks, episodes, tolerance)
 
-    # Position weight: how much (in seconds) each episode-position offset
-    # penalises the score.  When disc info is available, being one episode
-    # away from the expected center adds pos_weight seconds to the cost —
-    # making position a real factor rather than just a tiebreaker.
-    # 60s per position means a 5-episode offset costs 300s, comparable to
-    # typical runtime inaccuracies between TVDB and actual disc runtimes.
-    pos_weight = 60.0 if use_position_bias else 0.0
 
-    # Build cost matrix
+def _match_windowed(
+    main_tracks: list[dict],
+    episodes: list[dict],
+    tolerance: int,
+    disc_number: int,
+    disc_total: int | None,
+) -> list[dict]:
+    """Windowed positional matching: disc position determines episode range.
+
+    1. Compute a generous window (1.5x expected disc share) centered on
+       this disc's expected position in the season.
+    2. Pair tracks to windowed episodes positionally (T0→first, T1→second).
+    3. Validate each pair with runtime tolerance; flag but keep mismatches.
+    4. If the window produces fewer matches than greedy would, fall back.
+    """
+    n_tracks = len(main_tracks)
+    n_episodes = len(episodes)
+    disc_count = disc_total or disc_number
+
+    # Expected share per disc and center position
+    share = n_episodes / disc_count
+    center = (disc_number - 0.5) * share
+
+    # Window: 1.5x the expected share, clamped to episode bounds
+    half_window = max(share * 0.75, n_tracks * 0.75)
+    win_start = max(0, int(center - half_window))
+    win_end = min(n_episodes, int(center + half_window + 1))
+
+    # Ensure window is at least as wide as the number of tracks
+    if win_end - win_start < n_tracks:
+        # Expand symmetrically, clamped
+        deficit = n_tracks - (win_end - win_start)
+        win_start = max(0, win_start - (deficit + 1) // 2)
+        win_end = min(n_episodes, win_end + (deficit + 1) // 2)
+
+    windowed = episodes[win_start:win_end]
+
+    log.info(
+        "Disc %d/%d: episode window E%d-E%d (%d candidates for %d tracks)",
+        disc_number, disc_count,
+        windowed[0]["number"] if windowed else 0,
+        windowed[-1]["number"] if windowed else 0,
+        len(windowed), n_tracks,
+    )
+
+    # Positional assignment: pair tracks with windowed episodes by position
+    # When more episodes than tracks, pick the best-fitting slice
+    if len(windowed) > n_tracks:
+        # Find the contiguous slice of n_tracks episodes with minimum
+        # total runtime delta against the tracks.
+        # Bias the offset toward where the disc center falls within the window
+        # so that disc 4/4 prefers the END of its window, disc 1/4 the START.
+        expected_offset = center - win_start - n_tracks / 2
+        expected_offset = max(0, min(len(windowed) - n_tracks, expected_offset))
+
+        best_offset = 0
+        best_cost = float("inf")
+        for offset in range(len(windowed) - n_tracks + 1):
+            cost = sum(
+                abs((main_tracks[i].get("length") or 0) - (windowed[offset + i].get("runtime") or 0))
+                for i in range(n_tracks)
+            )
+            cost += abs(offset - expected_offset) * 30  # bias toward expected position
+            if cost < best_cost:
+                best_cost = cost
+                best_offset = offset
+        selected = windowed[best_offset:best_offset + n_tracks]
+    elif len(windowed) < n_tracks:
+        # Fewer episodes than tracks — match what we can positionally,
+        # remaining tracks get no match
+        selected = windowed
+    else:
+        selected = windowed
+
+    # Build positional matches
+    matches = []
+    for i, ep in enumerate(selected):
+        if i >= len(main_tracks):
+            break
+        track = main_tracks[i]
+        delta = abs((track.get("length") or 0) - (ep.get("runtime") or 0))
+        if delta <= tolerance:
+            matches.append({
+                "track_number": track["track_number"],
+                "episode_number": ep["number"],
+                "episode_name": ep["name"],
+                "episode_runtime": ep.get("runtime", 0),
+            })
+
+    # Fallback: if windowed matching got fewer results than greedy would,
+    # use greedy instead (handles edge cases where disc info is wrong)
+    greedy = _match_greedy(main_tracks, episodes, tolerance)
+    if len(greedy) > len(matches):
+        log.info(
+            "Windowed matching (%d) worse than greedy (%d), using greedy",
+            len(matches), len(greedy),
+        )
+        return greedy
+
+    return matches
+
+
+def _match_greedy(
+    main_tracks: list[dict],
+    episodes: list[dict],
+    tolerance: int,
+) -> list[dict]:
+    """Greedy runtime matching: no disc info, pure runtime similarity.
+
+    Builds all (track, episode) pairs within tolerance, assigns by
+    smallest delta first, then re-orders so track sequence matches
+    episode sequence.
+    """
     pairs = []
-    for ti, track in enumerate(tracks):
+    for ti, track in enumerate(main_tracks):
         t_len = track.get("length") or 0
-        if t_len < 120:  # skip very short tracks (menus, intros)
-            continue
         for ei, ep in enumerate(episodes):
             delta = abs(t_len - ep.get("runtime", 0))
             if delta <= tolerance:
-                pos_bias = abs(ei - expected_center) if use_position_bias else 0.0
-                score = delta + pos_bias * pos_weight
-                pairs.append((score, delta, pos_bias, ti, ei))
+                pairs.append((delta, ti, ei))
 
-    # Greedy assignment: lowest combined score first
     pairs.sort()
     used_tracks: set[int] = set()
     used_episodes: set[int] = set()
     matches = []
 
-    for _score, _delta, _pos_bias, ti, ei in pairs:
+    for _delta, ti, ei in pairs:
         if ti in used_tracks or ei in used_episodes:
             continue
         used_tracks.add(ti)
         used_episodes.add(ei)
         matches.append({
-            "track_number": tracks[ti]["track_number"],
+            "track_number": main_tracks[ti]["track_number"],
             "episode_number": episodes[ei]["number"],
             "episode_name": episodes[ei]["name"],
             "episode_runtime": episodes[ei].get("runtime", 0),
         })
 
-    # Re-order matches so track order maps to episode order.
-    # The greedy algorithm picks by score, which can scramble the natural
-    # track→episode sequence.  Sort both sides independently and re-pair
-    # so that the earliest track gets the earliest episode.
+    # Re-order: track sequence → episode sequence
     if len(matches) > 1:
         sorted_tracks = sorted(matches, key=lambda m: int(m["track_number"]))
         sorted_eps = sorted(matches, key=lambda m: m["episode_number"])

--- a/test/test_matching.py
+++ b/test/test_matching.py
@@ -42,6 +42,191 @@ class TestMatchResult:
         assert r.success is False
 
 
+class TestWindowedPositionalMatching:
+    """Test disc-windowed positional episode assignment."""
+
+    def _make_season(self, count=20, runtime=2700, first_two_runtime=3060):
+        """Build a season of episodes. First two have different runtime (like Kolchak)."""
+        eps = []
+        for i in range(1, count + 1):
+            r = first_two_runtime if i <= 2 else runtime
+            eps.append({"number": i, "name": f"Episode {i}", "runtime": r})
+        return eps
+
+    def _make_tracks(self, count=5, length=3087):
+        """Build main tracks with similar lengths."""
+        return [{"track_number": str(i), "length": length} for i in range(count)]
+
+    def test_disc_2_of_4_matches_episodes_6_to_10(self):
+        """Disc 2/4 of a 20-episode season should match E6-E10, not E1-E2."""
+        episodes = self._make_season(20)
+        tracks = self._make_tracks(5, length=3087)  # ~51m tracks
+
+        matches = match_tracks_to_episodes(
+            tracks, episodes, tolerance=600,
+            disc_number=2, disc_total=4,
+        )
+        eps = [m["episode_number"] for m in matches]
+        assert len(matches) == 5
+        assert eps == [6, 7, 8, 9, 10], f"Expected E6-E10, got E{eps}"
+
+    def test_disc_4_of_4_matches_last_episodes(self):
+        """Last disc should match the last episodes of the season."""
+        episodes = self._make_season(20)
+        tracks = self._make_tracks(5, length=3087)
+
+        matches = match_tracks_to_episodes(
+            tracks, episodes, tolerance=600,
+            disc_number=4, disc_total=4,
+        )
+        eps = [m["episode_number"] for m in matches]
+        assert len(matches) == 5
+        assert eps == [16, 17, 18, 19, 20], f"Expected E16-E20, got E{eps}"
+
+    def test_disc_1_of_4_matches_first_episodes(self):
+        """First disc should match the first episodes."""
+        episodes = self._make_season(20)
+        tracks = self._make_tracks(5, length=3087)
+
+        matches = match_tracks_to_episodes(
+            tracks, episodes, tolerance=600,
+            disc_number=1, disc_total=4,
+        )
+        eps = [m["episode_number"] for m in matches]
+        assert len(matches) == 5
+        assert eps == [1, 2, 3, 4, 5], f"Expected E1-E5, got E{eps}"
+
+    def test_uneven_distribution_6_5_5_4(self):
+        """Handles uneven episode distribution across discs."""
+        episodes = self._make_season(20, runtime=2700, first_two_runtime=2700)
+        # Disc 1 has 6 tracks (more than average 5)
+        tracks = self._make_tracks(6, length=2750)
+
+        matches = match_tracks_to_episodes(
+            tracks, episodes, tolerance=600,
+            disc_number=1, disc_total=4,
+        )
+        eps = [m["episode_number"] for m in matches]
+        assert len(matches) == 6
+        # Should get first 6 episodes
+        assert eps == [1, 2, 3, 4, 5, 6], f"Expected E1-E6, got E{eps}"
+
+    def test_disc_3_of_4_with_varied_runtimes(self):
+        """Disc 3 with Kolchak-like runtimes (E1-2=51m, rest=45m)."""
+        episodes = self._make_season(20)  # E1-2=3060s, E3-20=2700s
+        tracks = self._make_tracks(5, length=3087)  # all ~51m
+
+        matches = match_tracks_to_episodes(
+            tracks, episodes, tolerance=600,
+            disc_number=3, disc_total=4,
+        )
+        eps = [m["episode_number"] for m in matches]
+        assert len(matches) == 5
+        assert eps == [11, 12, 13, 14, 15], f"Expected E11-E15, got E{eps}"
+
+    def test_track_order_preserved(self):
+        """Track 0 gets earliest episode, track N gets latest."""
+        episodes = self._make_season(10, runtime=2700, first_two_runtime=2700)
+        tracks = [
+            {"track_number": "0", "length": 2750},
+            {"track_number": "1", "length": 2680},
+            {"track_number": "2", "length": 2720},
+        ]
+
+        matches = match_tracks_to_episodes(
+            tracks, episodes, tolerance=600,
+            disc_number=2, disc_total=4,
+        )
+        # Track numbers should be in ascending order, episode numbers too
+        tns = [m["track_number"] for m in matches]
+        eps = [m["episode_number"] for m in matches]
+        assert tns == sorted(tns, key=int)
+        assert eps == sorted(eps)
+
+    def test_no_disc_info_falls_back_to_greedy(self):
+        """Without disc info, uses greedy runtime matching."""
+        episodes = self._make_season(20)
+        tracks = self._make_tracks(5, length=3087)
+
+        matches = match_tracks_to_episodes(
+            tracks, episodes, tolerance=600,
+            disc_number=None, disc_total=None,
+        )
+        # Greedy will pick by runtime — E1/E2 (3060s) are closest to 3087s
+        assert len(matches) == 5
+        # Should still get 5 matches (greedy finds them)
+        eps = [m["episode_number"] for m in matches]
+        assert 1 in eps or 2 in eps  # greedy prefers runtime-close episodes
+
+    def test_tolerance_filters_bad_matches(self):
+        """Positional matches outside tolerance are skipped."""
+        episodes = [
+            {"number": 6, "name": "Ep 6", "runtime": 2700},
+            {"number": 7, "name": "Ep 7", "runtime": 2700},
+            {"number": 8, "name": "Ep 8", "runtime": 2700},
+        ]
+        # Track with very different runtime
+        tracks = [
+            {"track_number": "0", "length": 2750},   # close to 2700
+            {"track_number": "1", "length": 1200},    # 20 min — way off from 45m
+            {"track_number": "2", "length": 2680},    # close to 2700
+        ]
+
+        matches = match_tracks_to_episodes(
+            tracks, episodes, tolerance=300,
+            disc_number=2, disc_total=4,
+        )
+        # Track 1 (1200s) is too far from 2700s (delta=1500 > 300 tolerance)
+        assert len(matches) == 2
+        tns = {m["track_number"] for m in matches}
+        assert "1" not in tns
+
+    def test_windowed_fallback_to_greedy_when_worse(self):
+        """If windowed matching gets fewer results, greedy is used instead."""
+        episodes = self._make_season(20, runtime=2700, first_two_runtime=2700)
+        # Only 2 tracks, but they have runtimes matching E1-E2 (not in disc 3 window)
+        tracks = [
+            {"track_number": "0", "length": 2750},
+            {"track_number": "1", "length": 2680},
+        ]
+
+        matches = match_tracks_to_episodes(
+            tracks, episodes, tolerance=300,
+            disc_number=3, disc_total=4,
+        )
+        # Both windowed and greedy should get 2 matches — windowed picks from
+        # the disc 3 window, greedy picks by runtime
+        assert len(matches) == 2
+
+    def test_exclude_episodes_with_windowed(self):
+        """Cross-disc exclusion works with windowed matching."""
+        episodes = self._make_season(20, runtime=2700, first_two_runtime=2700)
+        tracks = self._make_tracks(3, length=2750)
+
+        matches = match_tracks_to_episodes(
+            tracks, episodes, tolerance=600,
+            disc_number=2, disc_total=4,
+            exclude_episodes={6, 7},  # E6-E7 already matched
+        )
+        # Should skip E6-E7 and match from remaining
+        eps = [m["episode_number"] for m in matches]
+        assert 6 not in eps
+        assert 7 not in eps
+        assert len(matches) == 3
+
+    def test_short_season_single_disc(self):
+        """Single disc with all episodes — no windowing needed."""
+        episodes = self._make_season(6, runtime=2700, first_two_runtime=2700)
+        tracks = self._make_tracks(6, length=2750)
+
+        matches = match_tracks_to_episodes(
+            tracks, episodes, tolerance=600,
+            disc_number=1, disc_total=1,
+        )
+        eps = [m["episode_number"] for m in matches]
+        assert eps == [1, 2, 3, 4, 5, 6]
+
+
 class TestCrossDiscExclusion:
     """Test exclude_episodes parameter in matching functions."""
 


### PR DESCRIPTION
## Summary
Replace greedy runtime-based matching with disc-windowed positional assignment when disc info is available.

- Compute episode window from disc position (1.5x expected share, generous for uneven distribution)
- Assign tracks to episodes positionally (T0→first episode in window, T1→second, etc.)
- Runtime validates positional matches but doesn't override position
- Sliding window within the range uses runtime + expected-position bias
- Falls back to greedy runtime matching when no disc info or when windowed produces fewer matches

**Root cause fixed:** Disc 2/4 of Kolchak (20 episodes) matched E1,E2,E7,E8,E9 instead of E6-E10. The greedy algorithm's tiebreaker favored runtime precision over position — a 32s delta beat a 392s delta even when position penalty made scores equal.

## Test plan
- [ ] `pytest test/test_matching.py -v` — 66 tests pass
- [ ] Disc 1/4 of 20 episodes → E1-E5
- [ ] Disc 2/4 of 20 episodes → E6-E10
- [ ] Disc 3/4 of 20 episodes → E11-E15
- [ ] Disc 4/4 of 20 episodes → E16-E20
- [ ] Uneven distribution (6 tracks on disc 1) → E1-E6
- [ ] No disc info → falls back to greedy runtime matching
- [ ] Cross-disc exclusion still works with windowed matching
- [ ] Tolerance still filters out bad runtime matches