### PR TITLE
feat: per-job naming pattern overrides and custom filenames

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -481,7 +481,7 @@ async def naming_preview(request: Request):
 @router.get('/jobs/{job_id}/naming-preview')
 def naming_preview_for_job(job_id: int):
     """Return rendered filenames for all tracks on a job using the naming engine."""
-    from arm.ripper.naming import render_track_title, render_track_folder, render_title, render_folder
+    from arm.ripper.naming import render_all_tracks, render_title, render_folder
 
     job = Job.query.get(job_id)
     if not job:
@@ -489,19 +489,68 @@ def naming_preview_for_job(job_id: int):
 
     config_dict = cfg.arm_config
 
-    tracks_preview = []
-    for track in sorted(job.tracks, key=lambda t: int(t.track_number or 0)):
-        tracks_preview.append({
-            "track_number": track.track_number,
-            "rendered_title": render_track_title(track, job, config_dict),
-            "rendered_folder": render_track_folder(track, job, config_dict),
-        })
-
     return {
         "success": True,
         "job_title": render_title(job, config_dict),
         "job_folder": render_folder(job, config_dict),
-        "tracks": tracks_preview,
+        "tracks": render_all_tracks(job, config_dict),
+    }
+
+
+@router.patch('/jobs/{job_id}/naming')
+async def update_job_naming(job_id: int, request: Request):
+    """Update per-job naming pattern overrides."""
+    from arm.ripper.naming import validate_pattern
+
+    job = Job.query.get(job_id)
+    if not job:
+        return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
+
+    body = await request.json()
+
+    for field in ('title_pattern_override', 'folder_pattern_override'):
+        if field in body:
+            value = body[field]
+            if value is not None and value != '':
+                result = validate_pattern(value)
+                if not result['valid']:
+                    return JSONResponse({
+                        "success": False,
+                        "error": f"Invalid variables in pattern: {result['invalid_vars']}",
+                        "invalid_vars": result['invalid_vars'],
+                        "suggestions": result['suggestions'],
+                    }, status_code=400)
+                setattr(job, field, value)
+            else:
+                setattr(job, field, None)
+
+    db.session.commit()
+    return {
+        "success": True,
+        "title_pattern_override": job.title_pattern_override,
+        "folder_pattern_override": job.folder_pattern_override,
+    }
+
+
+@router.post('/naming/validate')
+async def validate_naming_pattern(request: Request):
+    """Validate a naming pattern against known variables."""
+    from arm.ripper.naming import validate_pattern
+
+    body = await request.json()
+    pattern = body.get('pattern', '')
+    if not pattern:
+        return {"valid": True, "invalid_vars": [], "suggestions": {}}
+    return validate_pattern(pattern)
+
+
+@router.get('/naming/variables')
+def get_naming_variables():
+    """Return the list of valid naming pattern variables."""
+    from arm.ripper.naming import VALID_VARS, PATTERN_VARIABLES
+    return {
+        "variables": sorted(VALID_VARS),
+        "descriptions": PATTERN_VARIABLES,
     }
 
 
@@ -726,7 +775,7 @@ def _clean_for_filename(string):
 
 # --- Track field updates ---
 
-_TRACK_EDITABLE_FIELDS: dict[str, type] = {"enabled": bool, "filename": str, "ripped": bool}
+_TRACK_EDITABLE_FIELDS: dict[str, type] = {"enabled": bool, "filename": str, "ripped": bool, "custom_filename": str}
 
 
 @router.patch('/jobs/{job_id}/tracks/{track_id}')

--- a/arm/migrations/versions/k6l7m8n9o0p1_naming_overrides.py
+++ b/arm/migrations/versions/k6l7m8n9o0p1_naming_overrides.py
@@ -1,0 +1,28 @@
+"""Add per-job naming pattern overrides and per-track custom filename.
+
+Revision ID: k6l7m8n9o0p1
+Revises: k5l6m7n8o9p0
+Create Date: 2026-03-25
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'k6l7m8n9o0p1'
+down_revision = 'k5l6m7n8o9p0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('job',
+                  sa.Column('title_pattern_override', sa.String(512), nullable=True))
+    op.add_column('job',
+                  sa.Column('folder_pattern_override', sa.String(512), nullable=True))
+    op.add_column('track',
+                  sa.Column('custom_filename', sa.String(512), nullable=True))
+
+
+def downgrade():
+    op.drop_column('job', 'title_pattern_override')
+    op.drop_column('job', 'folder_pattern_override')
+    op.drop_column('track', 'custom_filename')

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -162,6 +162,8 @@ class Job(db.Model):
     manual_pause = db.Column(db.Boolean)
     manual_mode = db.Column(db.Boolean)
     wait_start_time = db.Column(db.DateTime, nullable=True)
+    title_pattern_override = db.Column(db.String(512), nullable=True)
+    folder_pattern_override = db.Column(db.String(512), nullable=True)
     tracks = db.relationship('Track', backref='job', lazy='dynamic')
     config = db.relationship('Config', uselist=False, backref="job")
 

--- a/arm/models/track.py
+++ b/arm/models/track.py
@@ -31,6 +31,8 @@ class Track(db.Model):
     # Episode metadata from TVDB matching
     episode_number = db.Column(db.String(10), nullable=True)
     episode_name = db.Column(db.String(256), nullable=True)
+    # User-specified output filename (overrides pattern rendering)
+    custom_filename = db.Column(db.String(512), nullable=True)
 
     def __init__(self, job_id, track_number, length, aspect_ratio,
                  fps, main_feature, source, basename, filename,

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -101,10 +101,13 @@ def _get_pattern(config_dict, video_type, kind, job=None):
     over the global config pattern regardless of video_type.
     """
     if job is not None:
-        if kind == 'TITLE' and getattr(job, 'title_pattern_override', None):
-            return job.title_pattern_override
-        if kind == 'FOLDER' and getattr(job, 'folder_pattern_override', None):
-            return job.folder_pattern_override
+        override = None
+        if kind == 'TITLE':
+            override = getattr(job, 'title_pattern_override', None)
+        elif kind == 'FOLDER':
+            override = getattr(job, 'folder_pattern_override', None)
+        if override and isinstance(override, str):
+            return override
     prefix = _TYPE_PREFIX.get(video_type)
     if not prefix:
         # Fall back to movie patterns for unknown types

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -2,6 +2,7 @@
 
 Supports per-type patterns with {variable} placeholders.
 Variables are extracted from Job fields, preferring manual over auto values.
+Per-job pattern overrides and per-track custom filenames are supported.
 """
 import re
 
@@ -17,7 +18,7 @@ DEFAULTS = {
 }
 
 # Canonical list of variables available in naming patterns.
-# This is the single source of truth — UI and config docs derive from this.
+# This is the single source of truth — UI, validation, and config docs derive from this.
 PATTERN_VARIABLES = {
     'title':      'Disc title (prefers manual over auto-detected)',
     'year':       'Release year',
@@ -28,6 +29,9 @@ PATTERN_VARIABLES = {
     'label':      'Original disc label from drive',
     'video_type': 'Media type: movie, series, or music',
 }
+
+# Frozen set for fast validation — derived from PATTERN_VARIABLES
+VALID_VARS: frozenset = frozenset(PATTERN_VARIABLES.keys())
 
 # Map video_type to pattern key prefixes
 _TYPE_PREFIX = {
@@ -85,11 +89,22 @@ def _clean_for_filename(s):
     s = s.replace('&', 'and')
     s = s.replace('\\', ' - ')
     s = re.sub(r'[^\w .()-]', '', s)
-    return s.strip()
+    # Prevent path traversal — strip leading dots and collapse sequences
+    s = re.sub(r'\.{2,}', '.', s)
+    return s.strip('. ')
 
 
-def _get_pattern(config_dict, video_type, kind):
-    """Look up the pattern for a given video_type and kind (TITLE or FOLDER)."""
+def _get_pattern(config_dict, video_type, kind, job=None):
+    """Look up the pattern for a given video_type and kind (TITLE or FOLDER).
+
+    When job has a pattern override for the given kind, it takes priority
+    over the global config pattern regardless of video_type.
+    """
+    if job is not None:
+        if kind == 'TITLE' and getattr(job, 'title_pattern_override', None):
+            return job.title_pattern_override
+        if kind == 'FOLDER' and getattr(job, 'folder_pattern_override', None):
+            return job.folder_pattern_override
     prefix = _TYPE_PREFIX.get(video_type)
     if not prefix:
         # Fall back to movie patterns for unknown types
@@ -108,7 +123,7 @@ def render_title(job, config_dict=None):
     """
     variables = _build_variables(job)
     video_type = variables.get('video_type', '')
-    pattern = _get_pattern(config_dict, video_type, 'TITLE')
+    pattern = _get_pattern(config_dict, video_type, 'TITLE', job=job)
     rendered = pattern.format_map(variables)
     return _clean_empty_parens(rendered)
 
@@ -122,7 +137,7 @@ def render_folder(job, config_dict=None):
     import os
     variables = _build_variables(job)
     video_type = variables.get('video_type', '')
-    pattern = _get_pattern(config_dict, video_type, 'FOLDER')
+    pattern = _get_pattern(config_dict, video_type, 'FOLDER', job=job)
     rendered = pattern.format_map(variables)
     rendered = _clean_empty_parens(rendered)
     # Sanitize each path segment individually
@@ -172,13 +187,18 @@ def _build_track_variables(track, job):
 def render_track_title(track, job, config_dict=None):
     """Render a display title for a single track on a multi-title disc.
 
-    Starts with job-level defaults from _build_variables(), then overrides
-    with any track-level fields (title, year, video_type).
-    Returns the rendered string without extension — caller adds it.
+    Precedence:
+    1. track.custom_filename (sanitized, used as-is)
+    2. job pattern override → rendered with variables
+    3. global pattern → rendered with variables
     """
+    # Custom filename takes highest priority
+    if getattr(track, 'custom_filename', None):
+        return _clean_for_filename(track.custom_filename)
+
     variables = _build_track_variables(track, job)
     video_type = variables.get('video_type', '')
-    pattern = _get_pattern(config_dict, video_type, 'TITLE')
+    pattern = _get_pattern(config_dict, video_type, 'TITLE', job=job)
     rendered = pattern.format_map(variables)
     rendered = _clean_empty_parens(rendered)
     # When season is actually a disc number, replace S02 with D02
@@ -221,7 +241,7 @@ def render_track_folder(track, job, config_dict=None):
             else:
                 variables['season'] = '01'
     video_type = variables.get('video_type', '')
-    pattern = _get_pattern(config_dict, video_type, 'FOLDER')
+    pattern = _get_pattern(config_dict, video_type, 'FOLDER', job=job)
     rendered = pattern.format_map(variables)
     rendered = _clean_empty_parens(rendered)
     # Replace "Season XX" with "Disc XX" when using disc_number fallback
@@ -232,6 +252,36 @@ def render_track_folder(track, job, config_dict=None):
     return os.path.join(*segments) if segments else ''
 
 
+def render_all_tracks(job, config_dict=None):
+    """Render filenames for all tracks with duplicate collision detection.
+
+    Returns a list of dicts with track_number, rendered_title, rendered_folder.
+    When duplicate rendered_titles are detected, appends ' - Track {N}' to
+    disambiguate (covers both pattern collisions and cross-tier collisions
+    between custom_filename and pattern-rendered names).
+    """
+    results = []
+    for track in sorted(job.tracks, key=lambda t: int(t.track_number or 0)):
+        results.append({
+            "track_number": track.track_number,
+            "rendered_title": render_track_title(track, job, config_dict),
+            "rendered_folder": render_track_folder(track, job, config_dict),
+        })
+    # Detect duplicates and append track number
+    seen = {}
+    for r in results:
+        name = r["rendered_title"]
+        if name in seen:
+            # Mark both the first occurrence and this one
+            if seen[name] is not None:
+                seen[name]["rendered_title"] += f" - Track {seen[name]['track_number']}"
+                seen[name] = None  # already fixed
+            r["rendered_title"] += f" - Track {r['track_number']}"
+        else:
+            seen[name] = r
+    return results
+
+
 def render_preview(pattern, variables):
     """Render a pattern with explicit variables dict (for API preview).
 
@@ -240,3 +290,43 @@ def render_preview(pattern, variables):
     safe_vars = _SafeDict(variables)
     rendered = pattern.format_map(safe_vars)
     return _clean_empty_parens(rendered)
+
+
+# ======================================================================
+# Pattern validation
+# ======================================================================
+
+
+def _levenshtein(s1, s2):
+    """Simple Levenshtein distance for fuzzy matching suggestions."""
+    if len(s1) < len(s2):
+        return _levenshtein(s2, s1)
+    if len(s2) == 0:
+        return len(s1)
+    prev_row = range(len(s2) + 1)
+    for i, c1 in enumerate(s1):
+        curr_row = [i + 1]
+        for j, c2 in enumerate(s2):
+            cost = 0 if c1 == c2 else 1
+            curr_row.append(min(
+                curr_row[j] + 1,
+                prev_row[j + 1] + 1,
+                prev_row[j] + cost,
+            ))
+        prev_row = curr_row
+    return prev_row[-1]
+
+
+def validate_pattern(pattern):
+    """Validate a naming pattern against VALID_VARS.
+
+    Returns {"valid": bool, "invalid_vars": [...], "suggestions": {...}}.
+    """
+    tokens = re.findall(r'\{(\w+)\}', pattern)
+    invalid = [t for t in tokens if t not in VALID_VARS]
+    suggestions = {}
+    for inv in invalid:
+        best = min(VALID_VARS, key=lambda v: _levenshtein(inv, v))
+        if _levenshtein(inv, best) <= 2:
+            suggestions[inv] = best
+    return {"valid": len(invalid) == 0, "invalid_vars": invalid, "suggestions": suggestions}

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -162,7 +162,7 @@ def _build_webhook_payload(title, body, job, raw_basename):
     doesn't need its own naming logic — ARM is the single source of truth
     for folder/file naming patterns configured in arm.yaml.
     """
-    from arm.ripper.naming import render_folder, render_title, render_track_title, render_track_folder, _clean_for_filename
+    from arm.ripper.naming import render_folder, render_title, render_all_tracks, _clean_for_filename
 
     payload = {"title": title, "body": body, "type": "info"}
     if raw_basename:
@@ -188,21 +188,24 @@ def _build_webhook_payload(title, body, job, raw_basename):
         # Always include per-track manifest with pre-rendered filenames.
         # ARM is the single source of truth for naming — the transcoder
         # uses these names directly and never invents its own.
+        # render_all_tracks handles duplicate detection and custom filenames.
         if getattr(job, 'multi_title', False):
             payload["multi_title"] = True
+        rendered = render_all_tracks(job, config_dict)
+        # Build a lookup from track_number → rendered result
+        rendered_map = {r["track_number"]: r for r in rendered}
         tracks_meta = []
         for track in job.tracks:
-            track_title = render_track_title(track, job, config_dict)
-            track_folder = render_track_folder(track, job, config_dict)
+            r = rendered_map.get(str(track.track_number or ''), {})
             tracks_meta.append({
                 "track_number": str(track.track_number or ''),
                 "title": str(track.title or job.title or ''),
                 "year": str(track.year or job.year or ''),
                 "video_type": str(track.video_type or job.video_type or ''),
                 "filename": str(track.filename or ''),
-                "has_custom_title": bool(track.title),
-                "folder_name": track_folder,
-                "title_name": _clean_for_filename(track_title) if track_title else '',
+                "has_custom_title": bool(track.title) or bool(getattr(track, 'custom_filename', None)),
+                "folder_name": r.get("rendered_folder", ''),
+                "title_name": _clean_for_filename(r.get("rendered_title", '')) if r.get("rendered_title") else '',
                 "episode_number": str(getattr(track, 'episode_number', '') or ''),
                 "episode_name": str(getattr(track, 'episode_name', '') or ''),
             })

--- a/test/test_naming.py
+++ b/test/test_naming.py
@@ -23,6 +23,7 @@ def _make_job(**kwargs):
         'season': None, 'season_manual': None, 'season_auto': None,
         'episode': None, 'episode_manual': None, 'episode_auto': None,
         'video_type': 'movie', 'label': None,
+        'title_pattern_override': None, 'folder_pattern_override': None,
     }
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -221,7 +222,7 @@ def _make_track(**kwargs):
     """Create a SimpleNamespace that quacks like a Track."""
     defaults = {
         'title': None, 'year': None, 'video_type': None,
-        'imdb_id': None, 'poster_url': None,
+        'imdb_id': None, 'poster_url': None, 'custom_filename': None,
     }
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -353,3 +354,228 @@ def test_track_folder_all_tracks_same_folder():
     # All should produce the same folder path
     assert len(set(folders)) == 1
     assert 'Show' in folders[0]
+
+
+# ======================================================================
+# Per-job naming overrides and custom filenames
+# ======================================================================
+
+from arm.ripper.naming import (
+    VALID_VARS, validate_pattern, render_all_tracks, _get_pattern,
+)
+
+
+class TestValidVars:
+    def test_valid_vars_matches_pattern_variables(self):
+        from arm.ripper.naming import PATTERN_VARIABLES
+        assert VALID_VARS == frozenset(PATTERN_VARIABLES.keys())
+
+    def test_contains_expected_vars(self):
+        for v in ('title', 'year', 'season', 'episode', 'label', 'video_type', 'artist', 'album'):
+            assert v in VALID_VARS
+
+
+class TestValidatePattern:
+    def test_valid_pattern(self):
+        result = validate_pattern('{title} S{season}E{episode}')
+        assert result['valid'] is True
+        assert result['invalid_vars'] == []
+
+    def test_invalid_variable(self):
+        result = validate_pattern('{title} S{season}E{episde}')
+        assert result['valid'] is False
+        assert 'episde' in result['invalid_vars']
+
+    def test_suggestion_for_typo(self):
+        result = validate_pattern('{titl}')
+        assert result['valid'] is False
+        assert result['suggestions'].get('titl') == 'title'
+
+    def test_no_suggestion_for_distant_typo(self):
+        result = validate_pattern('{xyzabc}')
+        assert result['valid'] is False
+        assert 'xyzabc' not in result['suggestions']
+
+    def test_empty_pattern_is_valid(self):
+        result = validate_pattern('literal text no vars')
+        assert result['valid'] is True
+
+    def test_multiple_invalid_vars(self):
+        result = validate_pattern('{titl} {yar}')
+        assert result['valid'] is False
+        assert len(result['invalid_vars']) == 2
+
+
+class TestGetPatternWithJobOverride:
+    def test_job_title_override_takes_priority(self):
+        job = _make_job(title_pattern_override='{title} - E{episode}')
+        config = {'TV_TITLE_PATTERN': '{title} S{season}E{episode}'}
+        result = _get_pattern(config, 'series', 'TITLE', job=job)
+        assert result == '{title} - E{episode}'
+
+    def test_job_folder_override_takes_priority(self):
+        job = _make_job(folder_pattern_override='{title}/S{season}')
+        config = {'TV_FOLDER_PATTERN': '{title}/Season {season}'}
+        result = _get_pattern(config, 'series', 'FOLDER', job=job)
+        assert result == '{title}/S{season}'
+
+    def test_no_override_uses_global(self):
+        job = _make_job()
+        config = {'TV_TITLE_PATTERN': '{title} S{season}E{episode}'}
+        result = _get_pattern(config, 'series', 'TITLE', job=job)
+        assert result == '{title} S{season}E{episode}'
+
+    def test_none_job_uses_global(self):
+        config = {'TV_TITLE_PATTERN': '{title} S{season}E{episode}'}
+        result = _get_pattern(config, 'series', 'TITLE', job=None)
+        assert result == '{title} S{season}E{episode}'
+
+    def test_override_is_video_type_agnostic(self):
+        """Job override applies regardless of video_type."""
+        job = _make_job(video_type='movie', title_pattern_override='{title} custom')
+        config = {'MOVIE_TITLE_PATTERN': '{title} ({year})'}
+        result = _get_pattern(config, 'movie', 'TITLE', job=job)
+        assert result == '{title} custom'
+
+
+class TestCustomFilename:
+    def test_custom_filename_overrides_pattern(self):
+        job = _make_job(title='Show', video_type='series', season='1')
+        track = _make_track(track_number='0', episode_number='1', custom_filename='My Custom Name')
+        result = render_track_title(track, job)
+        assert result == 'My Custom Name'
+
+    def test_custom_filename_is_sanitized(self):
+        job = _make_job(title='Show', video_type='series')
+        track = _make_track(track_number='0', custom_filename='Bad: Name & Stuff')
+        result = render_track_title(track, job)
+        assert ':' not in result
+        assert '&' not in result
+        assert 'Bad- Name and Stuff' == result
+
+    def test_custom_filename_prevents_path_traversal(self):
+        job = _make_job(title='Show')
+        track = _make_track(track_number='0', custom_filename='../../etc/passwd')
+        result = render_track_title(track, job)
+        assert '..' not in result
+        assert '/' not in result
+
+    def test_no_custom_filename_uses_pattern(self):
+        job = _make_job(title='Show', video_type='series', season='1')
+        track = _make_track(track_number='0', episode_number='5', custom_filename=None)
+        result = render_track_title(track, job)
+        assert 'S01E05' in result
+
+    def test_job_pattern_override_with_no_custom_filename(self):
+        job = _make_job(
+            title='Show', video_type='series', season='1',
+            title_pattern_override='{title} - E{episode}',
+        )
+        track = _make_track(track_number='0', episode_number='5')
+        result = render_track_title(track, job)
+        assert result == 'Show - E05'
+
+    def test_custom_filename_overrides_job_pattern(self):
+        """Custom filename beats job pattern override."""
+        job = _make_job(
+            title='Show', video_type='series', season='1',
+            title_pattern_override='{title} - E{episode}',
+        )
+        track = _make_track(track_number='0', episode_number='5', custom_filename='Override')
+        result = render_track_title(track, job)
+        assert result == 'Override'
+
+
+class TestRenderAllTracks:
+    def _make_job_with_tracks(self, tracks_data, **job_kwargs):
+        job = _make_job(**job_kwargs)
+        tracks = []
+        for td in tracks_data:
+            tracks.append(_make_track(**td))
+        job.tracks = tracks
+        return job
+
+    def test_renders_all_tracks(self):
+        job = self._make_job_with_tracks(
+            [
+                {'track_number': '0', 'episode_number': '1'},
+                {'track_number': '1', 'episode_number': '2'},
+            ],
+            title='Show', video_type='series', season='1',
+        )
+        results = render_all_tracks(job)
+        assert len(results) == 2
+        assert 'S01E01' in results[0]['rendered_title']
+        assert 'S01E02' in results[1]['rendered_title']
+
+    def test_duplicate_detection_appends_track_number(self):
+        """Literal pattern with no per-track variation → duplicates detected."""
+        job = self._make_job_with_tracks(
+            [
+                {'track_number': '0'},
+                {'track_number': '1'},
+            ],
+            title='Movie', video_type='movie', year='2024',
+            title_pattern_override='Same Name',
+        )
+        results = render_all_tracks(job)
+        titles = [r['rendered_title'] for r in results]
+        assert titles[0] != titles[1]
+        assert 'Track 0' in titles[0]
+        assert 'Track 1' in titles[1]
+
+    def test_cross_tier_duplicate_detection(self):
+        """Custom filename collides with pattern-rendered name."""
+        job = self._make_job_with_tracks(
+            [
+                {'track_number': '0', 'episode_number': '1', 'custom_filename': 'Show S01E02'},
+                {'track_number': '1', 'episode_number': '2'},
+            ],
+            title='Show', video_type='series', season='1',
+        )
+        results = render_all_tracks(job)
+        titles = [r['rendered_title'] for r in results]
+        # Both would be "Show S01E02" — duplicates should be disambiguated
+        assert titles[0] != titles[1]
+
+    def test_no_duplicates_no_modification(self):
+        job = self._make_job_with_tracks(
+            [
+                {'track_number': '0', 'episode_number': '1'},
+                {'track_number': '1', 'episode_number': '2'},
+            ],
+            title='Show', video_type='series', season='1',
+        )
+        results = render_all_tracks(job)
+        titles = [r['rendered_title'] for r in results]
+        assert 'Track' not in titles[0]
+        assert 'Track' not in titles[1]
+
+    def test_single_track_no_duplicate(self):
+        job = self._make_job_with_tracks(
+            [{'track_number': '0', 'custom_filename': 'Solo'}],
+            title='Movie', video_type='movie',
+        )
+        results = render_all_tracks(job)
+        assert results[0]['rendered_title'] == 'Solo'
+        assert 'Track' not in results[0]['rendered_title']
+
+
+class TestRenderWithJobFolderOverride:
+    def test_folder_override_applies(self):
+        job = _make_job(
+            title='Show', video_type='series', season='1',
+            folder_pattern_override='{title}/S{season}',
+        )
+        result = render_folder(job)
+        assert 'S01' in result
+        assert 'Season' not in result
+
+    def test_title_override_in_render_title(self):
+        job = _make_job(
+            title='Show', video_type='series', season='1',
+            title_pattern_override='{title} Episode {episode}',
+        )
+        result = render_title(job)
+        assert 'Episode' in result
+        assert 'S01' not in result


### PR DESCRIPTION
## Summary
- Add title_pattern_override and folder_pattern_override fields to Job model
- Add custom_filename field to Track model (distinct from MakeMKV filename)
- Three-tier precedence: custom_filename > job pattern override > global pattern
- VALID_VARS frozenset as single source of truth for pattern variables
- validate_pattern() with Levenshtein fuzzy matching suggestions
- render_all_tracks() with duplicate collision detection
- PATCH /jobs/{id}/naming endpoint with server-side validation
- POST /naming/validate and GET /naming/variables endpoints
- Updated webhook payload uses render_all_tracks()
- Hardened _clean_for_filename against path traversal
- Alembic migration for 3 new nullable columns

## Test plan
- [ ] `pytest test/test_naming.py -v` — 70 tests pass
- [ ] `pytest test/test_matching.py -v` — 66 tests pass
- [ ] Precedence: custom > job override > global
- [ ] Duplicate detection across custom + rendered names
- [ ] Invalid pattern variables rejected with suggestions