### PR TITLE
fix: sync track.title when episode_name updated via PATCH

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -815,5 +815,9 @@ def update_track_fields(job_id: int, track_id: int, body: dict):
 
     for key, value in clean.items():
         setattr(track, key, value)
+    # Keep track.title in sync — the webhook payload reads track.title for
+    # the filename, so it must reflect the current episode_name when set.
+    if "episode_name" in clean and clean["episode_name"]:
+        track.title = clean["episode_name"]
     db.session.commit()
     return {"success": True, "job_id": job_id, "track_id": track_id, "updated": clean}

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -199,7 +199,9 @@ def _build_webhook_payload(title, body, job, raw_basename):
             r = rendered_map.get(str(track.track_number or ''), {})
             tracks_meta.append({
                 "track_number": str(track.track_number or ''),
-                "title": str(track.title or job.title or ''),
+                # Prefer episode_name for series tracks — track.title can be stale
+                # if the user corrected episodes via the UI after auto-match.
+                "title": str(getattr(track, 'episode_name', '') or track.title or job.title or ''),
                 "year": str(track.year or job.year or ''),
                 "video_type": str(track.video_type or job.video_type or ''),
                 "filename": str(track.filename or ''),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       - ${ARM_CONFIG_PATH}:/etc/arm/config
       - arm-db:/home/arm/db
       - ${ARM_MAKEMKV_PATH:-makemkv-settings}:/home/arm/.MakeMKV
+      # Transcoder work directory — lets the file browser show in-progress transcodes
+      - ${TRANSCODER_WORK_PATH:-./work}:/home/arm/media/transcode:ro
       # Live /dev mount ensures USB optical drives remain visible after
       # hot-plug, disconnect/reconnect, or device re-enumeration.
       - /dev:/dev

--- a/test/test_coverage_gaps_2.py
+++ b/test/test_coverage_gaps_2.py
@@ -169,6 +169,55 @@ class TestBuildWebhookPayload:
         payload = _build_webhook_payload("Test", "body", sample_job, "")
         assert "path" not in payload
 
+    def test_episode_name_preferred_over_track_title(self, app_context, job_with_tracks):
+        """Webhook title field prefers episode_name over track.title (stale auto-match fix)."""
+        from arm.ripper.utils import _build_webhook_payload
+
+        job, tracks = job_with_tracks
+        # Simulate the desync: track.title has stale auto-match, episode_name has correct value
+        tracks[0].title = "The Werewolf"
+        tracks[0].episode_name = "Firefall"
+        tracks[0].episode_number = "6"
+        db.session.commit()
+        db.session.refresh(job)
+
+        payload = _build_webhook_payload("Rip done", "body", job, "raw_dir")
+        t0 = payload["tracks"][0]
+        assert t0["title"] == "Firefall", "episode_name should take priority over stale track.title"
+        assert t0["episode_name"] == "Firefall"
+        assert t0["episode_number"] == "6"
+
+    def test_track_title_used_when_no_episode_name(self, app_context, job_with_tracks):
+        """When episode_name is empty, falls back to track.title then job.title."""
+        from arm.ripper.utils import _build_webhook_payload
+
+        job, tracks = job_with_tracks
+        tracks[0].title = "Custom Title"
+        tracks[0].episode_name = None
+        tracks[0].episode_number = None
+        # Track without title or episode_name falls back to job.title
+        tracks[1].title = None
+        tracks[1].episode_name = None
+        db.session.commit()
+        db.session.refresh(job)
+
+        payload = _build_webhook_payload("Rip done", "body", job, "raw_dir")
+        assert payload["tracks"][0]["title"] == "Custom Title"
+        assert payload["tracks"][1]["title"] == job.title
+
+    def test_empty_episode_name_does_not_override_title(self, app_context, job_with_tracks):
+        """Empty string episode_name should fall back to track.title."""
+        from arm.ripper.utils import _build_webhook_payload
+
+        job, tracks = job_with_tracks
+        tracks[0].title = "My Title"
+        tracks[0].episode_name = ""
+        db.session.commit()
+        db.session.refresh(job)
+
+        payload = _build_webhook_payload("Rip done", "body", job, "raw_dir")
+        assert payload["tracks"][0]["title"] == "My Title"
+
 
 # ── transcode_callback tests ─────────────────────────────────────────────
 

--- a/test/test_jobs_api.py
+++ b/test/test_jobs_api.py
@@ -304,6 +304,61 @@ class TestTrackFieldUpdates:
         )
         assert resp.status_code == 404
 
+    def test_patch_episode_name_syncs_title(self, app_context, job_with_tracks, client):
+        """Setting episode_name via PATCH must also update track.title so the
+        webhook payload uses the correct name for the output filename."""
+        job, tracks = job_with_tracks
+        track = tracks[0]
+        track.title = "Stale Auto-Match Name"
+        db.session.commit()
+
+        resp = client.patch(
+            f"/api/v1/jobs/{job.job_id}/tracks/{track.track_id}",
+            json={"episode_number": "6", "episode_name": "Firefall"},
+        )
+        assert resp.status_code == 200
+        db.session.expire_all()
+        refreshed = Track.query.get(track.track_id)
+        assert refreshed.episode_name == "Firefall"
+        assert refreshed.episode_number == "6"
+        # title must be synced to episode_name
+        assert refreshed.title == "Firefall"
+
+    def test_patch_empty_episode_name_preserves_title(self, app_context, job_with_tracks, client):
+        """Empty episode_name should NOT overwrite an existing track.title."""
+        job, tracks = job_with_tracks
+        track = tracks[0]
+        track.title = "Original Title"
+        db.session.commit()
+
+        resp = client.patch(
+            f"/api/v1/jobs/{job.job_id}/tracks/{track.track_id}",
+            json={"episode_name": ""},
+        )
+        assert resp.status_code == 200
+        db.session.expire_all()
+        refreshed = Track.query.get(track.track_id)
+        assert refreshed.episode_name == ""
+        # title should NOT be overwritten with empty string
+        assert refreshed.title == "Original Title"
+
+    def test_patch_episode_name_only_without_number(self, app_context, job_with_tracks, client):
+        """Patching episode_name alone (no episode_number) still syncs title."""
+        job, tracks = job_with_tracks
+        track = tracks[0]
+        track.title = "Old Name"
+        db.session.commit()
+
+        resp = client.patch(
+            f"/api/v1/jobs/{job.job_id}/tracks/{track.track_id}",
+            json={"episode_name": "New Episode"},
+        )
+        assert resp.status_code == 200
+        db.session.expire_all()
+        refreshed = Track.query.get(track.track_id)
+        assert refreshed.episode_name == "New Episode"
+        assert refreshed.title == "New Episode"
+
 
 class TestTvdbMatch:
     """Test POST /jobs/{id}/tvdb-match disc override logic."""

--- a/test/test_services.py
+++ b/test/test_services.py
@@ -48,6 +48,54 @@ class TestApplyMatches:
         assert track1.episode_number == "1"
         assert track2.episode_name == "Second"
 
+    def test_all_three_fields_synced(self, app_context):
+        """title, episode_number, episode_name are all set from the same match."""
+        from arm.services.tvdb_sync import _apply_matches
+        from arm.services.matching.base import MatchResult, TrackMatch
+
+        job = MagicMock()
+        track = MagicMock()
+        track.track_number = "0"
+        # Simulate stale title from a previous auto-match
+        track.title = "Stale Episode Name"
+        track.episode_number = "5"
+        track.episode_name = "Stale Episode Name"
+        job.tracks = [track]
+
+        result = MatchResult(
+            matcher="tvdb",
+            season=1,
+            matches=[
+                TrackMatch(track_number="0", episode_number=6,
+                           episode_name="Firefall", episode_runtime=51),
+            ],
+            match_count=1,
+        )
+
+        count = _apply_matches(job, result)
+        assert count == 1
+        # All three must be updated together
+        assert track.title == "Firefall"
+        assert track.episode_number == "6"  # stored as string
+        assert track.episode_name == "Firefall"
+
+    def test_empty_matches_returns_zero(self, app_context):
+        """Empty match list returns zero without modifying any tracks."""
+        from arm.services.tvdb_sync import _apply_matches
+        from arm.services.matching.base import MatchResult
+
+        job = MagicMock()
+        track = MagicMock()
+        track.track_number = "0"
+        track.title = "Original"
+        job.tracks = [track]
+
+        result = MatchResult(matcher="tvdb", season=1, matches=[], match_count=0)
+        count = _apply_matches(job, result)
+        assert count == 0
+        # Track should not be modified
+        assert track.title == "Original"
+
     def test_unmatched_tracks_skipped(self, app_context):
         from arm.services.tvdb_sync import _apply_matches
         from arm.services.matching.base import MatchResult, TrackMatch


### PR DESCRIPTION
## Summary
- Fix episode title desync: PATCH endpoint now syncs `track.title` when `episode_name` is updated, preventing wrong filenames in transcoder output
- Webhook payload prefers `episode_name` over stale `track.title` (defense-in-depth)
- Mount transcoder work dir into ARM container for file browser "Transcode" view

## Root cause
Multi-disc TV series (Kolchak disc 2) had all 5 episode files named after the wrong episode. Auto-match set `track.title`, then manual UI corrections updated `episode_name`/`episode_number` but not `track.title`. The webhook read the stale `track.title` for filenames.

## Test plan
- [x] 8 new tests across 3 files (1648 total, all passing)
- [x] `test_patch_episode_name_syncs_title` - core fix
- [x] `test_patch_empty_episode_name_preserves_title` - edge case
- [x] `test_patch_episode_name_only_without_number` - partial update
- [x] `test_episode_name_preferred_over_track_title` - webhook priority
- [x] `test_track_title_used_when_no_episode_name` - fallback chain
- [x] `test_empty_episode_name_does_not_override_title` - empty string
- [x] `test_all_three_fields_synced` - _apply_matches overwrites stale title
- [x] `test_empty_matches_returns_zero` - no-op case