### PR TITLE
fix: prevent file loss during scratch-to-shared NFS copy

### DIFF
--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -137,7 +137,13 @@ def bash_notify(cfg, title, body, job=None):
 
 
 def _move_to_shared_storage(cfg, raw_basename, job=None):
-    """Move raw directory from local scratch to shared storage if configured."""
+    """Move raw directory from local scratch to shared storage if configured.
+
+    Uses copytree + rmtree instead of shutil.move because move nests the
+    source inside an existing destination directory rather than merging.
+    This caused file loss when multiple discs of the same show shared a
+    raw directory name.
+    """
     local_raw = cfg.get('LOCAL_RAW_PATH', '')
     shared_raw = cfg.get('SHARED_RAW_PATH', '')
     if not (local_raw and shared_raw and raw_basename):
@@ -148,11 +154,25 @@ def _move_to_shared_storage(cfg, raw_basename, job=None):
         try:
             if job:
                 database_updater({'status': JobState.COPYING.value}, job)
-            os.makedirs(shared_raw, exist_ok=True)
-            shutil.move(src, dst)
-            logging.info(f"Moved {src} -> {dst}")
+            os.makedirs(dst, exist_ok=True)
+            src_files = [f for f in os.listdir(src) if os.path.isfile(os.path.join(src, f))]
+            logging.info(f"Copying {len(src_files)} files from {src} -> {dst}")
+            for fname in src_files:
+                src_file = os.path.join(src, fname)
+                dst_file = os.path.join(dst, fname)
+                shutil.copy2(src_file, dst_file)
+                logging.info(f"Copied {fname} ({os.path.getsize(dst_file)} bytes)")
+            # Verify all files arrived before removing source
+            dst_files = set(os.listdir(dst))
+            missing = [f for f in src_files if f not in dst_files]
+            if missing:
+                logging.error(f"File copy verification failed! Missing: {missing}")
+                raise OSError(f"Copy verification failed: {len(missing)} files missing at destination")
+            shutil.rmtree(src)
+            logging.info(f"Moved {len(src_files)} files from {src} -> {dst} (verified)")
         except OSError as e:
             logging.error(f"Failed to move {src} -> {dst}: {e}")
+            raise
 
 
 def _build_webhook_payload(title, body, job, raw_basename):

--- a/test/test_utils_coverage.py
+++ b/test/test_utils_coverage.py
@@ -101,7 +101,7 @@ class TestBashNotify:
 
 
 class TestMoveToSharedStorage:
-    """Test _move_to_shared_storage() file movement (lines 145-153)."""
+    """Test _move_to_shared_storage() file copy + verify + remove."""
 
     def test_moves_directory(self, tmp_path):
         from arm.ripper.utils import _move_to_shared_storage
@@ -113,7 +113,62 @@ class TestMoveToSharedStorage:
 
         cfg = {'LOCAL_RAW_PATH': local_raw, 'SHARED_RAW_PATH': shared_raw}
         _move_to_shared_storage(cfg, "movie")
-        assert os.path.isdir(os.path.join(shared_raw, "movie"))
+        assert os.path.isfile(os.path.join(shared_raw, "movie", "file.mkv"))
+        # Source should be removed after verified copy
+        assert not os.path.exists(os.path.join(local_raw, "movie"))
+
+    def test_merges_into_existing_directory(self, tmp_path):
+        """When destination dir already exists (e.g. from a previous disc),
+        files should merge into it rather than nesting as a subdirectory.
+        This was the root cause of the disc 4 track 5 file loss."""
+        from arm.ripper.utils import _move_to_shared_storage
+
+        local_raw = str(tmp_path / "local")
+        shared_raw = str(tmp_path / "shared")
+        src = os.path.join(local_raw, "Show")
+        dst = os.path.join(shared_raw, "Show")
+
+        os.makedirs(src)
+        os.makedirs(dst)
+        # Old file from previous disc (transcoder may not have cleaned dir)
+        (tmp_path / "shared" / "Show" / "old_disc3.mkv").write_bytes(b"old")
+        # New disc files
+        for i in range(6):
+            (tmp_path / "local" / "Show" / f"disc4_t0{i}.mkv").write_bytes(b"x" * (i + 1))
+
+        cfg = {'LOCAL_RAW_PATH': local_raw, 'SHARED_RAW_PATH': shared_raw}
+        _move_to_shared_storage(cfg, "Show")
+
+        # All 6 new files should be directly in dst (not nested)
+        dst_files = os.listdir(dst)
+        for i in range(6):
+            assert f"disc4_t0{i}.mkv" in dst_files, f"disc4_t0{i}.mkv missing from destination"
+        # Old file preserved
+        assert "old_disc3.mkv" in dst_files
+        # No nested subdirectory
+        assert "Show" not in dst_files, "Source was nested inside destination (shutil.move bug)"
+        # Source removed
+        assert not os.path.exists(src)
+
+    def test_multiple_files_all_verified(self, tmp_path):
+        """All source files must arrive at destination before source is removed."""
+        from arm.ripper.utils import _move_to_shared_storage
+
+        local_raw = str(tmp_path / "local")
+        shared_raw = str(tmp_path / "shared")
+        src = os.path.join(local_raw, "movie")
+        os.makedirs(src)
+        for i in range(5):
+            (tmp_path / "local" / "movie" / f"track_{i}.mkv").write_bytes(b"x" * 100)
+
+        cfg = {'LOCAL_RAW_PATH': local_raw, 'SHARED_RAW_PATH': shared_raw}
+        _move_to_shared_storage(cfg, "movie")
+
+        dst = os.path.join(shared_raw, "movie")
+        dst_files = os.listdir(dst)
+        assert len(dst_files) == 5
+        for i in range(5):
+            assert f"track_{i}.mkv" in dst_files
 
     def test_no_config_does_nothing(self, tmp_path):
         from arm.ripper.utils import _move_to_shared_storage
@@ -126,6 +181,21 @@ class TestMoveToSharedStorage:
 
         cfg = {'LOCAL_RAW_PATH': '/home/arm/media/local', 'SHARED_RAW_PATH': '/home/arm/media/shared'}
         _move_to_shared_storage(cfg, "")  # Should not raise
+
+    def test_copy_failure_raises(self, tmp_path):
+        """OSError during copy should propagate (not be silently swallowed)."""
+        from arm.ripper.utils import _move_to_shared_storage
+
+        local_raw = str(tmp_path / "local")
+        shared_raw = str(tmp_path / "shared")
+        src = os.path.join(local_raw, "movie")
+        os.makedirs(src)
+        (tmp_path / "local" / "movie" / "file.mkv").write_bytes(b"data")
+
+        cfg = {'LOCAL_RAW_PATH': local_raw, 'SHARED_RAW_PATH': shared_raw}
+        with unittest.mock.patch("shutil.copy2", side_effect=OSError("NFS write failed")):
+            with pytest.raises(OSError, match="NFS write failed"):
+                _move_to_shared_storage(cfg, "movie")
 
 
 class TestTranscoderNotify:


### PR DESCRIPTION
## Summary
- Replace `shutil.move()` with per-file `copy2` + verification + `rmtree` for scratch-to-shared storage transfer
- `shutil.move()` nests source inside existing destination dir instead of merging, causing files to be lost in a nested subdirectory the transcoder can't find
- Copy failures now propagate instead of being silently swallowed

## Root cause
Kolchak disc 4 track 5 (The Sentry S01E20) was ripped to scratch but never arrived at shared NFS storage. The destination directory already existed from disc 3, so `shutil.move` nested disc 4's files inside it as a subdirectory. The transcoder found 5 of 6 expected files.

## Test plan
- [x] `test_moves_directory` - basic move works
- [x] `test_merges_into_existing_directory` - THE BUG: files merge into existing dir, not nested
- [x] `test_multiple_files_all_verified` - all files verified at destination
- [x] `test_copy_failure_raises` - OSError propagates (no silent swallowing)
- [x] `test_no_config_does_nothing` - no-op when unconfigured
- [x] `test_no_basename_does_nothing` - no-op when empty basename
- [x] Full suite: 1651 passed