### PR TITLE
fix: remove --minlength from folder imports to preserve track numbering

### DIFF
--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -88,7 +88,10 @@ def rip_folder(job):
         # 5. Rip — always use "all" mode for folder imports.
         # MakeMKV's per-track numbering from file: sources doesn't match
         # the prescan track numbers, so single-track extraction fails.
-        # "all" with --minlength lets MakeMKV handle track selection.
+        # Do NOT use --minlength here: it causes MakeMKV to renumber output
+        # files sequentially (skipping short titles), breaking the track
+        # number correspondence with the prescan.  The user already selected
+        # tracks in the review UI; short extras are tiny and rip in seconds.
         import collections
         import shlex
         from arm.ripper.makemkv import run, OutputType, progress_log
@@ -100,13 +103,22 @@ def rip_folder(job):
             job.makemkv_source,
             "all",
             rawpath,
-            f"--minlength={job.config.MINLENGTH}",
         ]
         log.info("Ripping all tracks from folder source: %s", job.source_path)
         collections.deque(run(cmd, OutputType.MSG), maxlen=0)
+
+        # Mark tracks as ripped only if their file actually exists on disk.
+        # MakeMKV may skip some titles (e.g. zero-length or copy-protected).
+        actual_files = set(os.listdir(rawpath)) if os.path.isdir(rawpath) else set()
         for track in job.tracks:
-            track.ripped = True
+            if track.filename and track.filename in actual_files:
+                track.ripped = True
+            else:
+                track.ripped = False
         db.session.commit()
+        log.info("Ripped %d of %d tracks to %s",
+                 sum(1 for t in job.tracks if t.ripped),
+                 len(list(job.tracks)), rawpath)
 
         # 6. Reconcile filenames
         _reconcile_filenames(job, rawpath)

--- a/test/test_folder_ripper.py
+++ b/test/test_folder_ripper.py
@@ -43,25 +43,27 @@ class TestRipFolder:
     @patch("arm.ripper.folder_ripper._reconcile_filenames")
     @patch("arm.ripper.makemkv.run")
     @patch("arm.ripper.folder_ripper.prescan_track_info")
-    @patch("arm.ripper.folder_ripper.setup_rawpath", return_value="/tmp/raw/Test Movie")
     @patch("arm.ripper.folder_ripper.prep_mkv")
     def test_happy_path_all_mode(
-        self, mock_prep, mock_setup, mock_prescan, mock_run,
+        self, mock_prep, mock_prescan, mock_run,
         mock_reconcile, mock_notify, mock_db, tmp_path
     ):
         from arm.ripper.folder_ripper import rip_folder
 
+        rawpath = tmp_path / "raw" / "Test Movie"
+        rawpath.mkdir(parents=True)
+
         job = self._make_job(tmp_path)
         mock_run.return_value = iter([])  # MakeMKV yields nothing on success
 
-        with patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
+        with patch("arm.ripper.folder_ripper.setup_rawpath", return_value=str(rawpath)), \
+             patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
             mock_cfg.arm_config = {"TRANSCODER_URL": ""}
             rip_folder(job)
 
         mock_prep.assert_called_once()
-        mock_setup.assert_called_once_with(job, job.build_raw_path())
         mock_prescan.assert_called_once_with(job)
-        mock_reconcile.assert_called_once_with(job, "/tmp/raw/Test Movie")
+        mock_reconcile.assert_called_once_with(job, str(rawpath))
         mock_notify.assert_not_called()
         assert job.status == "waiting_transcode"
 
@@ -70,18 +72,21 @@ class TestRipFolder:
     @patch("arm.ripper.folder_ripper._reconcile_filenames")
     @patch("arm.ripper.makemkv.run")
     @patch("arm.ripper.folder_ripper.prescan_track_info")
-    @patch("arm.ripper.folder_ripper.setup_rawpath", return_value="/tmp/raw/Test Movie")
     @patch("arm.ripper.folder_ripper.prep_mkv")
     def test_happy_path_with_transcoder_notify(
-        self, mock_prep, mock_setup, mock_prescan, mock_run,
+        self, mock_prep, mock_prescan, mock_run,
         mock_reconcile, mock_notify, mock_db, tmp_path
     ):
         from arm.ripper.folder_ripper import rip_folder
 
+        rawpath = tmp_path / "raw" / "Test Movie"
+        rawpath.mkdir(parents=True)
+
         job = self._make_job(tmp_path)
         mock_run.return_value = iter([])
 
-        with patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
+        with patch("arm.ripper.folder_ripper.setup_rawpath", return_value=str(rawpath)), \
+             patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
             mock_cfg.arm_config = {"TRANSCODER_URL": "http://transcoder:8080"}
             rip_folder(job)
 
@@ -93,26 +98,40 @@ class TestRipFolder:
     @patch("arm.ripper.folder_ripper._reconcile_filenames")
     @patch("arm.ripper.makemkv.run")
     @patch("arm.ripper.folder_ripper.prescan_track_info")
-    @patch("arm.ripper.folder_ripper.setup_rawpath", return_value="/tmp/raw/Test Movie")
     @patch("arm.ripper.folder_ripper.prep_mkv")
-    def test_tracks_marked_ripped(
-        self, mock_prep, mock_setup, mock_prescan, mock_run,
+    def test_tracks_marked_ripped_only_if_file_exists(
+        self, mock_prep, mock_prescan, mock_run,
         mock_reconcile, mock_notify, mock_db, tmp_path
     ):
+        """Only tracks whose filename exists on disk should be marked ripped."""
         from arm.ripper.folder_ripper import rip_folder
 
+        # Create raw output dir with 2 of 3 track files
+        rawpath = tmp_path / "raw" / "Test Movie"
+        rawpath.mkdir(parents=True)
+        (rawpath / "movie_t00.mkv").write_bytes(b"data")
+        (rawpath / "movie_t01.mkv").write_bytes(b"data")
+        # movie_t02.mkv intentionally missing (MakeMKV skipped it)
+
+        mock_setup = patch(
+            "arm.ripper.folder_ripper.setup_rawpath",
+            return_value=str(rawpath),
+        )
+
         job = self._make_job(tmp_path)
-        track1 = MagicMock()
-        track2 = MagicMock()
-        job.tracks = [track1, track2]
+        track0 = MagicMock(filename="movie_t00.mkv", ripped=False)
+        track1 = MagicMock(filename="movie_t01.mkv", ripped=False)
+        track2 = MagicMock(filename="movie_t02.mkv", ripped=False)
+        job.tracks = [track0, track1, track2]
         mock_run.return_value = iter([])
 
-        with patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
+        with patch("arm.ripper.folder_ripper.cfg") as mock_cfg, mock_setup:
             mock_cfg.arm_config = {"TRANSCODER_URL": ""}
             rip_folder(job)
 
+        assert track0.ripped is True
         assert track1.ripped is True
-        assert track2.ripped is True
+        assert track2.ripped is False, "Track without file on disk should not be marked ripped"
 
     @patch("arm.ripper.folder_ripper.db")
     def test_missing_source_folder(self, mock_db):


### PR DESCRIPTION
## Summary
- Remove `--minlength` from MakeMKV command for folder imports
- Only mark tracks as `ripped=True` if their file exists on disk

## Root cause
MakeMKV's `--minlength` flag causes sequential renumbering of output files, skipping short titles. With 16 prescan tracks (5 episodes + 11 extras) and `--minlength=600`, MakeMKV produces 5 files named t00-t04. But prescan track 3 is a 22s extra, so MakeMKV's t03 is actually prescan track 4. `_reconcile_filenames` matches by `_tNN` pattern, causing track 5 (The Sentry S01E20) to get no file.

For folder imports the user already selected tracks in the review UI, so `--minlength` filtering is unnecessary. Without it, MakeMKV preserves prescan track numbering.

## Test plan
- [x] `test_tracks_marked_ripped_only_if_file_exists` - NEW: only files on disk get ripped=True
- [x] `test_happy_path_all_mode` - updated to use real tmp dir
- [x] `test_happy_path_with_transcoder_notify` - updated to use real tmp dir
- [x] Full suite: 1651 passed