### PR TITLE
feat: deterministic track-to-file reconciliation via PRGC messages

### DIFF
--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -88,13 +88,13 @@ def rip_folder(job):
         # 5. Rip — always use "all" mode for folder imports.
         # MakeMKV's per-track numbering from file: sources doesn't match
         # the prescan track numbers, so single-track extraction fails.
-        # Do NOT use --minlength here: it causes MakeMKV to renumber output
-        # files sequentially (skipping short titles), breaking the track
-        # number correspondence with the prescan.  The user already selected
-        # tracks in the review UI; short extras are tiny and rip in seconds.
-        import collections
+        # Collect PRGC messages to build a deterministic mapping from
+        # sequential output index to original title ID, since MakeMKV
+        # may skip short titles and renumber output files.
         import shlex
-        from arm.ripper.makemkv import run, OutputType, progress_log
+        from arm.ripper.makemkv import (
+            run, OutputType, ProgressBarCurrent, build_title_map, progress_log,
+        )
 
         cmd = ["mkv"]
         cmd += shlex.split(job.config.MKV_ARGS or "")
@@ -105,10 +105,25 @@ def rip_folder(job):
             rawpath,
         ]
         log.info("Ripping all tracks from folder source: %s", job.source_path)
-        collections.deque(run(cmd, OutputType.MSG), maxlen=0)
 
-        # Mark tracks as ripped only if their file actually exists on disk.
-        # MakeMKV may skip some titles (e.g. zero-length or copy-protected).
+        # Consume run() output, collecting PRGC messages for title mapping
+        prgc_messages = []
+        for msg in run(cmd, OutputType.MSG | OutputType.PRGC):
+            if isinstance(msg, ProgressBarCurrent):
+                prgc_messages.append(msg)
+
+        # Build deterministic output-index -> original-title-id map
+        label = os.path.basename(rawpath)
+        title_map = build_title_map(prgc_messages, label)
+        if title_map:
+            log.info("Title map from PRGC: %s", title_map)
+
+        # 6. Reconcile filenames using deterministic title_map when available,
+        # falling back to heuristic matching for disc rips without PRGC data.
+        _reconcile_filenames(job, rawpath, title_map=title_map)
+
+        # Mark tracks as ripped only if their file actually exists on disk
+        # (after reconciliation so filenames are corrected).
         actual_files = set(os.listdir(rawpath)) if os.path.isdir(rawpath) else set()
         for track in job.tracks:
             if track.filename and track.filename in actual_files:
@@ -119,9 +134,6 @@ def rip_folder(job):
         log.info("Ripped %d of %d tracks to %s",
                  sum(1 for t in job.tracks if t.ripped),
                  len(list(job.tracks)), rawpath)
-
-        # 6. Reconcile filenames
-        _reconcile_filenames(job, rawpath)
 
         # 7. Notify transcoder if configured
         transcoder_url = cfg.arm_config.get("TRANSCODER_URL", "")

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -753,6 +753,32 @@ def makemkv_mkv(job, rawpath):
         process_single_tracks(job, rawpath, 'auto')
 
 
+def build_title_map(prgc_messages, label_prefix=""):
+    """Build a deterministic output-index -> original-title-id map from PRGC messages.
+
+    During ripping, MakeMKV emits ``PRGC:code,oid,name`` messages where
+    ``oid`` is the sequential output index and ``name`` is the output
+    filename stem (e.g. ``Show_Disc_4_t03``).  The ``_tNN`` suffix in
+    the name contains the **original** title number, not the sequential
+    output index.
+
+    Returns a dict mapping output_index (int) -> original_title_id (int).
+    When MakeMKV skips titles, the output indices are contiguous but the
+    original title IDs have gaps.
+    """
+    title_map = {}
+    for msg in prgc_messages:
+        oid = int(msg.oid)
+        if oid in title_map:
+            continue  # skip duplicate PRGC for same output
+        name = msg.name
+        # Extract original title number from _tNN suffix
+        m = re.search(r'_t(\d+)$', name)
+        if m:
+            title_map[oid] = int(m.group(1))
+    return title_map
+
+
 def _strip_track_suffix(filename):
     """Strip ``_tNN`` suffix and file extension, returning the segment prefix.
 
@@ -817,12 +843,16 @@ def _positional_match_pass(tracks, actual_files, matched_ids, claimed):
     return True
 
 
-def _reconcile_filenames(job, rawpath):
+def _reconcile_filenames(job, rawpath, title_map=None):
     """Update track filenames to match actual files on disk after MakeMKV rip.
 
     MakeMKV's scan-time filenames (from 'makemkvcon info') may differ from
     the actual rip-time filenames. This reconciliation ensures the database
     reflects the files that were actually created (#1355, #1281).
+
+    When *title_map* is provided (from PRGC messages during ripping), it
+    gives a deterministic mapping from sequential output index to original
+    title ID, which is used as Pass 0 before any heuristic matching.
     """
     if not rawpath or not os.path.isdir(rawpath):
         return
@@ -837,15 +867,45 @@ def _reconcile_filenames(job, rawpath):
     tracks = list(job.tracks.filter_by(source=SOURCE).order_by(Track.track_number))
     claimed = set()
     matched_ids = set()
+    updated = False
 
-    # Pass 1: Exact match
+    # Pass 0: Deterministic mapping from PRGC messages (folder imports)
+    # title_map: {output_index: original_title_id}
+    # output files are named sequentially (_t00, _t01, ...),
+    # title_map tells us which original title each output corresponds to.
+    if title_map:
+        track_by_number = {str(t.track_number): t for t in tracks}
+        for output_idx, original_tid in sorted(title_map.items()):
+            # Find the output file with this sequential index
+            suffix = f"_t{output_idx:02d}.mkv"
+            output_file = next((f for f in actual_files if f.endswith(suffix)), None)
+            if not output_file:
+                continue
+            # Map to the original prescan track
+            track = track_by_number.get(str(original_tid))
+            if track and track.track_id not in matched_ids:
+                if track.filename != output_file:
+                    logging.info(
+                        "Reconciled track #%s by title_map (output %d -> title %d): "
+                        "'%s' -> '%s'",
+                        track.track_number, output_idx, original_tid,
+                        track.filename, output_file,
+                    )
+                    track.filename = output_file
+                    updated = True
+                claimed.add(output_file)
+                matched_ids.add(track.track_id)
+
+    # Pass 1: Exact match (for tracks not handled by title_map)
     for track in tracks:
+        if track.track_id in matched_ids:
+            continue
         if track.filename in actual_files:
             claimed.add(track.filename)
             matched_ids.add(track.track_id)
 
-    # Pass 2 & 3
-    updated = _prefix_match_pass(tracks, actual_files, claimed, matched_ids)
+    # Pass 2 & 3: Heuristic matching (backwards compat for disc rips)
+    updated = _prefix_match_pass(tracks, actual_files, claimed, matched_ids) or updated
     updated = _positional_match_pass(tracks, actual_files, matched_ids, claimed) or updated
 
     if updated:

--- a/test/test_folder_ripper.py
+++ b/test/test_folder_ripper.py
@@ -63,7 +63,11 @@ class TestRipFolder:
 
         mock_prep.assert_called_once()
         mock_prescan.assert_called_once_with(job)
-        mock_reconcile.assert_called_once_with(job, str(rawpath))
+        mock_reconcile.assert_called_once()
+        args, kwargs = mock_reconcile.call_args
+        assert args[0] is job
+        assert args[1] == str(rawpath)
+        assert "title_map" in kwargs
         mock_notify.assert_not_called()
         assert job.status == "waiting_transcode"
 

--- a/test/test_title_map.py
+++ b/test/test_title_map.py
@@ -1,0 +1,219 @@
+"""Tests for deterministic title-to-file mapping from MakeMKV PRGC messages.
+
+When MakeMKV rips in "all" mode, it may skip short titles and renumber
+output files sequentially. PRGC messages emitted during the rip contain
+the output filename stem which includes the original title number.
+By parsing these, we build a deterministic map from original title_id
+to sequential output file, eliminating the need for heuristic matching.
+"""
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestBuildTitleMap:
+    """Test build_title_map() which extracts title_id -> output_filename
+    from PRGC messages during MakeMKV rip."""
+
+    def test_basic_mapping(self):
+        """PRGC messages map sequential output_id to original title via _tNN suffix."""
+        from arm.ripper.makemkv import build_title_map, ProgressBarCurrent
+
+        # Simulate PRGC messages for a disc with 16 titles, 5 ripped
+        # MakeMKV skips short titles and outputs t00-t04 sequentially
+        # but the PRGC name field contains the ORIGINAL title number
+        prgc_messages = [
+            ProgressBarCurrent(code=0, oid=0, name="Kolchak_The_Night_Stalker_Disc_4_t00"),
+            ProgressBarCurrent(code=0, oid=1, name="Kolchak_The_Night_Stalker_Disc_4_t01"),
+            ProgressBarCurrent(code=0, oid=2, name="Kolchak_The_Night_Stalker_Disc_4_t02"),
+            ProgressBarCurrent(code=0, oid=3, name="Kolchak_The_Night_Stalker_Disc_4_t04"),  # skipped t03
+            ProgressBarCurrent(code=0, oid=4, name="Kolchak_The_Night_Stalker_Disc_4_t05"),
+        ]
+
+        title_map = build_title_map(prgc_messages, "Kolchak The Night Stalker Disc 4")
+        # output_index 0 -> original title 0 -> output file _t00.mkv
+        # output_index 3 -> original title 4 -> output file _t03.mkv (renumbered!)
+        assert title_map[0] == 0   # oid 0 -> original title 0
+        assert title_map[1] == 1   # oid 1 -> original title 1
+        assert title_map[2] == 2   # oid 2 -> original title 2
+        assert title_map[3] == 4   # oid 3 -> original title 4 (t03 was skipped)
+        assert title_map[4] == 5   # oid 4 -> original title 5
+
+    def test_no_skip(self):
+        """When no titles are skipped, mapping is identity."""
+        from arm.ripper.makemkv import build_title_map, ProgressBarCurrent
+
+        prgc_messages = [
+            ProgressBarCurrent(code=0, oid=0, name="Movie_t00"),
+            ProgressBarCurrent(code=0, oid=1, name="Movie_t01"),
+            ProgressBarCurrent(code=0, oid=2, name="Movie_t02"),
+        ]
+
+        title_map = build_title_map(prgc_messages, "Movie")
+        assert title_map == {0: 0, 1: 1, 2: 2}
+
+    def test_empty_messages(self):
+        """No PRGC messages produces empty map."""
+        from arm.ripper.makemkv import build_title_map
+
+        title_map = build_title_map([], "Movie")
+        assert title_map == {}
+
+    def test_duplicate_prgc_for_same_output(self):
+        """MakeMKV may emit multiple PRGC for the same output_id (progress updates).
+        Only the first occurrence should be used."""
+        from arm.ripper.makemkv import build_title_map, ProgressBarCurrent
+
+        prgc_messages = [
+            ProgressBarCurrent(code=0, oid=0, name="Movie_t00"),
+            ProgressBarCurrent(code=0, oid=0, name="Movie_t00"),  # duplicate
+            ProgressBarCurrent(code=0, oid=1, name="Movie_t02"),  # skipped t01
+            ProgressBarCurrent(code=0, oid=1, name="Movie_t02"),  # duplicate
+        ]
+
+        title_map = build_title_map(prgc_messages, "Movie")
+        assert title_map == {0: 0, 1: 2}
+
+
+class TestReconcileWithTitleMap:
+    """Test that _reconcile_filenames uses the title map when provided."""
+
+    def test_reconcile_uses_title_map_over_pattern(self):
+        """When a title_map is provided, it overrides _tNN pattern matching."""
+        from unittest.mock import patch
+        from arm.ripper.makemkv import _reconcile_filenames
+
+        job = MagicMock()
+        track0 = MagicMock(track_number="0", filename="Show_t00.mkv", track_id=100)
+        track1 = MagicMock(track_number="1", filename="Show_t01.mkv", track_id=101)
+        track2 = MagicMock(track_number="2", filename="Show_t02.mkv", track_id=102)
+        track3 = MagicMock(track_number="3", filename="Show_t03.mkv", track_id=103)
+        track4 = MagicMock(track_number="4", filename="Show_t04.mkv", track_id=104)
+        track5 = MagicMock(track_number="5", filename="Show_t05.mkv", track_id=105)
+        all_tracks = [track0, track1, track2, track3, track4, track5]
+        job.tracks.filter_by.return_value.order_by.return_value = all_tracks
+
+        # Actual files on disk: MakeMKV produced t00-t04 (skipped original title 3)
+        import tempfile
+        with tempfile.TemporaryDirectory() as rawpath:
+            for i in range(5):
+                Path(rawpath, f"Show_t0{i}.mkv").touch()
+
+            # title_map: output_index -> original_title_id
+            # output t03 is actually original title 4, output t04 is original title 5
+            title_map = {0: 0, 1: 1, 2: 2, 3: 4, 4: 5}
+
+            with patch("arm.ripper.makemkv.db"):
+                _reconcile_filenames(job, rawpath, title_map=title_map)
+
+            # Track 0-2: files match directly (no renumbering for these)
+            assert track0.filename == "Show_t00.mkv"
+            assert track1.filename == "Show_t01.mkv"
+            assert track2.filename == "Show_t02.mkv"
+            # Track 3 (22s extra): was skipped by MakeMKV, no file
+            # Track 4: should be mapped to output file Show_t03.mkv (output index 3)
+            assert track4.filename == "Show_t03.mkv", \
+                f"Track 4 should map to Show_t03.mkv via title_map, got {track4.filename}"
+            # Track 5: should be mapped to output file Show_t04.mkv (output index 4)
+            assert track5.filename == "Show_t04.mkv", \
+                f"Track 5 should map to Show_t04.mkv via title_map, got {track5.filename}"
+
+    def test_reconcile_without_title_map_unchanged(self):
+        """Without title_map, existing pattern matching still works (backwards compat)."""
+        from arm.ripper.makemkv import _reconcile_filenames
+
+        job = MagicMock()
+        track0 = MagicMock(track_number="0", filename="Movie_t00.mkv", track_id=200)
+        track1 = MagicMock(track_number="1", filename="Movie_t01.mkv", track_id=201)
+        all_tracks = [track0, track1]
+        job.tracks.filter_by.return_value.order_by.return_value = all_tracks
+
+        import tempfile
+        with tempfile.TemporaryDirectory() as rawpath:
+            Path(rawpath, "Movie_t00.mkv").touch()
+            Path(rawpath, "Movie_t01.mkv").touch()
+
+            # No title_map - falls back to existing matching
+            _reconcile_filenames(job, rawpath)
+
+            assert track0.filename == "Movie_t00.mkv"
+            assert track1.filename == "Movie_t01.mkv"
+
+
+class TestFolderRipperTitleMap:
+    """Test that folder_ripper.py collects PRGC messages and passes title_map."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_logging(self):
+        """Mock create_file_handler so tests don't need a real LOGPATH."""
+        import logging
+        from unittest.mock import patch
+        handler = logging.Handler()
+        handler.emit = MagicMock()
+        with patch("arm.ripper.folder_ripper.create_file_handler", return_value=handler):
+            yield
+            logging.getLogger().removeHandler(handler)
+
+    def _make_job(self, tmp_path):
+        source = tmp_path / "disc"
+        source.mkdir()
+        (source / "BDMV").mkdir()
+
+        job = MagicMock()
+        job.job_id = 1
+        job.source_path = str(source)
+        job.title = "Test Show"
+        job.makemkv_source = f"file:{source}"
+        job.config.MAINFEATURE = 0
+        job.config.MKV_ARGS = ""
+        job.config.MINLENGTH = "600"
+        job.build_raw_path.return_value = str(tmp_path / "raw" / "Test Show")
+        job.raw_path = None
+        job.errors = None
+        job.tracks = []
+        return job
+
+    def test_prgc_messages_collected_and_passed_to_reconcile(self, tmp_path):
+        """folder_ripper should request PRGC messages from run() and pass
+        the resulting title_map to _reconcile_filenames."""
+        from unittest.mock import patch, call
+        from arm.ripper.makemkv import ProgressBarCurrent, OutputType
+
+        rawpath = tmp_path / "raw" / "Test Show"
+        rawpath.mkdir(parents=True)
+
+        job = self._make_job(tmp_path)
+
+        # Mock run() to yield PRGC messages
+        prgc0 = ProgressBarCurrent(code=0, oid=0, name="Test_Show_t00")
+        prgc1 = ProgressBarCurrent(code=0, oid=1, name="Test_Show_t02")  # skipped t01
+
+        def mock_run(cmd, select):
+            # Should be called with MSG | PRGC
+            assert OutputType.PRGC in select, "folder_ripper must request PRGC messages"
+            yield prgc0
+            yield prgc1
+
+        with patch("arm.ripper.makemkv.run", side_effect=mock_run), \
+             patch("arm.ripper.folder_ripper.setup_rawpath", return_value=str(rawpath)), \
+             patch("arm.ripper.folder_ripper.prep_mkv"), \
+             patch("arm.ripper.folder_ripper.prescan_track_info"), \
+             patch("arm.ripper.folder_ripper._reconcile_filenames") as m_reconcile, \
+             patch("arm.ripper.folder_ripper.utils.transcoder_notify"), \
+             patch("arm.ripper.folder_ripper.db"), \
+             patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
+            mock_cfg.arm_config = {"TRANSCODER_URL": ""}
+            from arm.ripper.folder_ripper import rip_folder
+            rip_folder(job)
+
+        # _reconcile_filenames should be called with title_map keyword
+        m_reconcile.assert_called_once()
+        call_args = m_reconcile.call_args
+        assert "title_map" in call_args.kwargs, \
+            "_reconcile_filenames must receive title_map keyword argument"
+        tm = call_args.kwargs["title_map"]
+        assert tm == {0: 0, 1: 2}, \
+            f"title_map should map output 0->title 0, output 1->title 2, got {tm}"


### PR DESCRIPTION
## Summary
- Parse MakeMKV PRGC messages during folder rips to build a deterministic output-index -> original-title-id map
- `_reconcile_filenames` uses this map as Pass 0 before heuristic matching, correctly mapping files when MakeMKV renumbers
- Backwards compatible: disc rips without PRGC data fall back to existing pattern matching

## Root cause
MakeMKV skips short titles and renumbers output files sequentially. With 16 prescan tracks and 5 qualifying titles, output `_t03.mkv` maps to prescan track 3 (22s extra) by pattern, but actually contains prescan track 4 (an episode). This caused The Sentry S01E20 to be mislabeled on Kolchak disc 4.

## How it works
1. `folder_ripper.py` requests `OutputType.PRGC` alongside `MSG` from `run()`
2. PRGC messages contain the output filename stem (e.g. `Show_Disc_4_t04`) where the `_tNN` suffix is the **original** title number
3. `build_title_map()` extracts `{output_index: original_title_id}` from these messages
4. `_reconcile_filenames(job, rawpath, title_map=...)` uses the map in Pass 0 to assign correct filenames before heuristic passes
5. Ripped-flag check moved after reconciliation so corrected filenames are used

## Test plan
- [x] `test_basic_mapping` - PRGC with skipped titles correctly maps output -> original
- [x] `test_no_skip` - identity mapping when no titles skipped
- [x] `test_empty_messages` - empty PRGC produces empty map
- [x] `test_duplicate_prgc_for_same_output` - deduplication
- [x] `test_reconcile_uses_title_map_over_pattern` - THE BUG: title_map overrides _tNN pattern
- [x] `test_reconcile_without_title_map_unchanged` - backwards compatibility
- [x] `test_prgc_messages_collected_and_passed_to_reconcile` - end-to-end folder_ripper flow
- [x] Full suite: 1658 passed

## Breaking changes
None. `_reconcile_filenames` accepts optional `title_map` kwarg. Without it, existing behavior is unchanged.