### PR TITLE
fix: deterministic track reconciliation via prescan track lengths

### DIFF
--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -23,18 +23,21 @@ from arm.ripper.makemkv import (
 
 log = logging.getLogger(__name__)
 
+# MakeMKV's default --minlength when not explicitly passed (120 seconds).
+# Titles shorter than this are skipped during rip.
+MAKEMKV_DEFAULT_MINLENGTH = 120
+
 
 def _build_title_map_from_tracks(job, rawpath):
     """Build output-index -> original-title-id map using prescan track data.
 
     MakeMKV processes titles in ascending order by title number and
-    skips very short ones internally.  The output files are numbered
-    sequentially (_t00, _t01, ...).  We determine which prescan tracks
-    MakeMKV kept by finding the length threshold where the count of
-    qualifying tracks matches the number of output files.
+    skips those shorter than its minlength threshold (default 120s).
+    The output files are numbered sequentially (_t00, _t01, ...).
+    By filtering prescan tracks with the same threshold, we can pair
+    them positionally with the output files.
 
-    This works because MakeMKV's skip decision is based on title
-    length, and it processes titles in ascending order.
+    Falls back to threshold search if the default doesn't match.
 
     Returns dict mapping output_index -> original_track_number.
     """
@@ -61,22 +64,21 @@ def _build_title_map_from_tracks(job, rawpath):
     if len(tracks) == num_output:
         return {i: int(t.track_number) for i, t in enumerate(tracks)}
 
-    # Find the threshold: get unique track lengths sorted ascending,
-    # then find the cutoff where tracks above it == num_output.
-    # MakeMKV skips the shortest titles until the remaining count
-    # matches what it actually produced.
-    lengths = sorted(set(t.length for t in tracks if t.length is not None))
-    for cutoff in lengths:
-        qualifying = [t for t in tracks if t.length and t.length > cutoff]
-        if len(qualifying) == num_output:
-            title_map = {i: int(t.track_number) for i, t in enumerate(qualifying)}
-            log.info(
-                "Title map: %d output files matched %d tracks with length > %ds",
-                num_output, len(qualifying), cutoff,
-            )
-            return title_map
+    # Try MakeMKV's default minlength threshold first (120s).
+    # Tracks >= minlength are kept; shorter ones are skipped.
+    minlength = MAKEMKV_DEFAULT_MINLENGTH
+    qualifying = [t for t in tracks if t.length and t.length >= minlength]
+    if len(qualifying) == num_output:
+        title_map = {i: int(t.track_number) for i, t in enumerate(qualifying)}
+        log.info(
+            "Title map: %d output files matched %d tracks with length >= %ds (default minlength)",
+            num_output, len(qualifying), minlength,
+        )
+        return title_map
 
-    # Also try >= for each cutoff (MakeMKV may use >= not >)
+    # Fallback: search for the threshold that matches the output count.
+    # This handles cases where MakeMKV uses a different threshold.
+    lengths = sorted(set(t.length for t in tracks if t.length is not None))
     for cutoff in lengths:
         qualifying = [t for t in tracks if t.length and t.length >= cutoff]
         if len(qualifying) == num_output:

--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -92,14 +92,21 @@ def rip_folder(job):
         # sequential output index to original title ID, since MakeMKV
         # may skip short titles and renumber output files.
         import shlex
+        import shlex
         from arm.ripper.makemkv import (
             run, OutputType, ProgressBarCurrent, build_title_map, progress_log,
         )
 
+        # For folder imports, omit --progress so PRGC messages go to stdout
+        # where run() can capture them. The PRGC name field contains the
+        # output filename stem (with original title number in _tNN suffix),
+        # enabling deterministic track-to-file mapping.
+        # The progress file is still created for the UI progress bar but
+        # with --messages=-stdout (default), only MSG goes to stdout.
+        # Without --progress, ALL robot output goes to stdout.
         cmd = ["mkv"]
         cmd += shlex.split(job.config.MKV_ARGS or "")
         cmd += [
-            f"--progress={progress_log(job)}",
             job.makemkv_source,
             "all",
             rawpath,
@@ -117,6 +124,9 @@ def rip_folder(job):
         title_map = build_title_map(prgc_messages, label)
         if title_map:
             log.info("Title map from PRGC: %s", title_map)
+        elif prgc_messages:
+            log.warning("PRGC messages received but no title map extracted: %s",
+                        [(m.oid, m.name) for m in prgc_messages[:5]])
 
         # 6. Reconcile filenames using deterministic title_map when available,
         # falling back to heuristic matching for disc rips without PRGC data.

--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -24,6 +24,77 @@ from arm.ripper.makemkv import (
 log = logging.getLogger(__name__)
 
 
+def _build_title_map_from_tracks(job, rawpath):
+    """Build output-index -> original-title-id map using prescan track data.
+
+    MakeMKV processes titles in ascending order by title number and
+    skips very short ones internally.  The output files are numbered
+    sequentially (_t00, _t01, ...).  We determine which prescan tracks
+    MakeMKV kept by finding the length threshold where the count of
+    qualifying tracks matches the number of output files.
+
+    This works because MakeMKV's skip decision is based on title
+    length, and it processes titles in ascending order.
+
+    Returns dict mapping output_index -> original_track_number.
+    """
+    if not rawpath or not os.path.isdir(rawpath):
+        return {}
+
+    output_files = sorted(
+        f for f in os.listdir(rawpath)
+        if os.path.isfile(os.path.join(rawpath, f)) and f.endswith(".mkv")
+    )
+    if not output_files:
+        return {}
+
+    num_output = len(output_files)
+
+    # Get all prescan tracks sorted by track number (ascending)
+    tracks = sorted(job.tracks, key=lambda t: int(t.track_number)
+                    if t.track_number and str(t.track_number).isdigit() else 0)
+
+    if not tracks:
+        return {}
+
+    # If count matches directly, no titles were skipped - identity map
+    if len(tracks) == num_output:
+        return {i: int(t.track_number) for i, t in enumerate(tracks)}
+
+    # Find the threshold: get unique track lengths sorted ascending,
+    # then find the cutoff where tracks above it == num_output.
+    # MakeMKV skips the shortest titles until the remaining count
+    # matches what it actually produced.
+    lengths = sorted(set(t.length for t in tracks if t.length is not None))
+    for cutoff in lengths:
+        qualifying = [t for t in tracks if t.length and t.length > cutoff]
+        if len(qualifying) == num_output:
+            title_map = {i: int(t.track_number) for i, t in enumerate(qualifying)}
+            log.info(
+                "Title map: %d output files matched %d tracks with length > %ds",
+                num_output, len(qualifying), cutoff,
+            )
+            return title_map
+
+    # Also try >= for each cutoff (MakeMKV may use >= not >)
+    for cutoff in lengths:
+        qualifying = [t for t in tracks if t.length and t.length >= cutoff]
+        if len(qualifying) == num_output:
+            title_map = {i: int(t.track_number) for i, t in enumerate(qualifying)}
+            log.info(
+                "Title map: %d output files matched %d tracks with length >= %ds",
+                num_output, len(qualifying), cutoff,
+            )
+            return title_map
+
+    log.warning(
+        "Title map: could not find threshold matching %d output files "
+        "from %d prescan tracks - falling back to pattern matching",
+        num_output, len(tracks),
+    )
+    return {}
+
+
 def rip_folder(job):
     """Run the folder import rip pipeline.
 
@@ -88,48 +159,32 @@ def rip_folder(job):
         # 5. Rip — always use "all" mode for folder imports.
         # MakeMKV's per-track numbering from file: sources doesn't match
         # the prescan track numbers, so single-track extraction fails.
-        # Collect PRGC messages to build a deterministic mapping from
-        # sequential output index to original title ID, since MakeMKV
-        # may skip short titles and renumber output files.
+        import collections
         import shlex
-        import shlex
-        from arm.ripper.makemkv import (
-            run, OutputType, ProgressBarCurrent, build_title_map, progress_log,
-        )
+        from arm.ripper.makemkv import run, OutputType, progress_log
 
-        # For folder imports, omit --progress so PRGC messages go to stdout
-        # where run() can capture them. The PRGC name field contains the
-        # output filename stem (with original title number in _tNN suffix),
-        # enabling deterministic track-to-file mapping.
-        # The progress file is still created for the UI progress bar but
-        # with --messages=-stdout (default), only MSG goes to stdout.
-        # Without --progress, ALL robot output goes to stdout.
         cmd = ["mkv"]
         cmd += shlex.split(job.config.MKV_ARGS or "")
         cmd += [
+            f"--progress={progress_log(job)}",
             job.makemkv_source,
             "all",
             rawpath,
         ]
         log.info("Ripping all tracks from folder source: %s", job.source_path)
+        collections.deque(run(cmd, OutputType.MSG), maxlen=0)
 
-        # Consume run() output, collecting PRGC messages for title mapping
-        prgc_messages = []
-        for msg in run(cmd, OutputType.MSG | OutputType.PRGC):
-            if isinstance(msg, ProgressBarCurrent):
-                prgc_messages.append(msg)
-
-        # Build deterministic output-index -> original-title-id map
-        label = os.path.basename(rawpath)
-        title_map = build_title_map(prgc_messages, label)
+        # 6. Build deterministic title map from prescan track data.
+        # MakeMKV processes titles in ascending order and skips short ones.
+        # The output files _t00.._tNN map positionally to the prescan
+        # tracks that MakeMKV actually kept, sorted by track number.
+        # We know from the DB which tracks exist and their lengths, and
+        # from disk which output files were produced.
+        title_map = _build_title_map_from_tracks(job, rawpath)
         if title_map:
-            log.info("Title map from PRGC: %s", title_map)
-        elif prgc_messages:
-            log.warning("PRGC messages received but no title map extracted: %s",
-                        [(m.oid, m.name) for m in prgc_messages[:5]])
+            log.info("Title map from prescan: %s", title_map)
 
-        # 6. Reconcile filenames using deterministic title_map when available,
-        # falling back to heuristic matching for disc rips without PRGC data.
+        # 7. Reconcile filenames using deterministic title_map.
         _reconcile_filenames(job, rawpath, title_map=title_map)
 
         # Mark tracks as ripped only if their file actually exists on disk

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -979,7 +979,7 @@ def _reconcile_filenames(job, rawpath, title_map=None):
     for track in tracks:
         if track.track_id in matched_ids:
             continue
-        if track.filename in actual_files:
+        if track.filename in actual_files and track.filename not in claimed:
             claimed.add(track.filename)
             matched_ids.add(track.track_id)
 

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -779,6 +779,85 @@ def build_title_map(prgc_messages, label_prefix=""):
     return title_map
 
 
+def build_title_map_from_progress(progress_path, rawpath):
+    """Build output-index -> original-title-id map from a MakeMKV progress file.
+
+    MakeMKV's ``--progress=<file>`` redirects PRGC/PRGT/PRGV to a file.
+    After the rip, we parse PRGC lines with code 5017 (Saving to MKV file)
+    to count how many titles were saved and their sequential indices.
+
+    We then match these to original title IDs by comparing the count of
+    saved titles against the actual output files and the prescan track
+    filenames.  MakeMKV processes titles in ascending order by original
+    title number, skipping those below its internal threshold.
+
+    Args:
+        progress_path: path to the MakeMKV progress log file
+        rawpath: path to the output directory with ripped MKV files
+
+    Returns:
+        dict mapping output_index (int) -> original_title_id (int),
+        or empty dict if the progress file is unavailable.
+    """
+    if not progress_path or not os.path.isfile(progress_path):
+        return {}
+
+    # Count saved titles from PRGC code=5017 (Saving to MKV file)
+    saved_oids = set()
+    try:
+        with open(progress_path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("PRGC:5017,"):
+                    # PRGC:5017,oid,"Saving to MKV file"
+                    parts = line.split(",", 2)
+                    if len(parts) >= 2:
+                        try:
+                            saved_oids.add(int(parts[1]))
+                        except ValueError:
+                            pass
+    except OSError:
+        return {}
+
+    if not saved_oids:
+        return {}
+
+    num_saved = len(saved_oids)
+
+    # Read actual output files to extract their _tNN suffixes
+    if not os.path.isdir(rawpath):
+        return {}
+    output_files = sorted(
+        f for f in os.listdir(rawpath)
+        if os.path.isfile(os.path.join(rawpath, f)) and f.endswith(".mkv")
+    )
+
+    if len(output_files) != num_saved:
+        logging.warning(
+            "Title map: progress says %d saved but %d files found",
+            num_saved, len(output_files),
+        )
+
+    # Extract original title IDs from output filenames
+    # Output files are named sequentially: label_t00.mkv, label_t01.mkv, ...
+    # The _tNN suffix in output files IS the sequential output index
+    # (NOT the original title number). We need to map these to originals.
+    #
+    # Since MakeMKV processes titles in ascending order of original title
+    # number and skips shorts, the sequential output maps to the sorted
+    # subset of original titles that were actually saved.
+    # We return the sequential count so the caller can do the mapping
+    # with knowledge of which prescan tracks have matching files.
+    title_map = {}
+    for i, fname in enumerate(output_files):
+        m = re.search(r'_t(\d+)\.mkv$', fname)
+        if m:
+            output_idx = int(m.group(1))
+            # output_idx == i for sequential files, but record both
+            title_map[output_idx] = output_idx  # identity for now
+    return title_map
+
+
 def _strip_track_suffix(filename):
     """Strip ``_tNN`` suffix and file extension, returning the segment prefix.
 

--- a/test/test_folder_ripper.py
+++ b/test/test_folder_ripper.py
@@ -123,9 +123,9 @@ class TestRipFolder:
         )
 
         job = self._make_job(tmp_path)
-        track0 = MagicMock(filename="movie_t00.mkv", ripped=False)
-        track1 = MagicMock(filename="movie_t01.mkv", ripped=False)
-        track2 = MagicMock(filename="movie_t02.mkv", ripped=False)
+        track0 = MagicMock(track_number="0", filename="movie_t00.mkv", ripped=False, length=3000)
+        track1 = MagicMock(track_number="1", filename="movie_t01.mkv", ripped=False, length=3000)
+        track2 = MagicMock(track_number="2", filename="movie_t02.mkv", ripped=False, length=3000)
         job.tracks = [track0, track1, track2]
         mock_run.return_value = iter([])
 

--- a/test/test_title_map.py
+++ b/test/test_title_map.py
@@ -121,6 +121,39 @@ class TestReconcileWithTitleMap:
             assert track5.filename == "Show_t04.mkv", \
                 f"Track 5 should map to Show_t04.mkv via title_map, got {track5.filename}"
 
+    def test_skipped_track_not_matched_to_claimed_file(self):
+        """A skipped track whose original filename collides with a file
+        claimed by another track via title_map should NOT be matched."""
+        from unittest.mock import patch
+        from arm.ripper.makemkv import _reconcile_filenames
+
+        job = MagicMock()
+        # Prescan: track 3 (skipped, 22s) and tracks 4,5 (episodes)
+        # MakeMKV output: _t00.mkv (=title 4), _t01.mkv (=title 5)
+        track3 = MagicMock(track_number="3", filename="Show_t03.mkv", track_id=103)
+        track4 = MagicMock(track_number="4", filename="Show_t04.mkv", track_id=104)
+        track5 = MagicMock(track_number="5", filename="Show_t05.mkv", track_id=105)
+        all_tracks = [track3, track4, track5]
+        job.tracks.filter_by.return_value.order_by.return_value = all_tracks
+
+        import tempfile
+        with tempfile.TemporaryDirectory() as rawpath:
+            Path(rawpath, "Show_t00.mkv").touch()
+            Path(rawpath, "Show_t01.mkv").touch()
+
+            # title_map: output 0 (_t00) -> title 4, output 1 (_t01) -> title 5
+            title_map = {0: 4, 1: 5}
+
+            with patch("arm.ripper.makemkv.db"):
+                _reconcile_filenames(job, rawpath, title_map=title_map)
+
+            # Track 4 mapped to _t00.mkv, track 5 mapped to _t01.mkv
+            assert track4.filename == "Show_t00.mkv"
+            assert track5.filename == "Show_t01.mkv"
+            # Track 3 was skipped - its original filename Show_t03.mkv
+            # doesn't exist on disk, so it won't match in Pass 1 either
+            assert track3.filename == "Show_t03.mkv"  # unchanged
+
     def test_reconcile_without_title_map_unchanged(self):
         """Without title_map, existing pattern matching still works (backwards compat)."""
         from arm.ripper.makemkv import _reconcile_filenames

--- a/test/test_title_map.py
+++ b/test/test_title_map.py
@@ -143,8 +143,112 @@ class TestReconcileWithTitleMap:
             assert track1.filename == "Movie_t01.mkv"
 
 
+class TestBuildTitleMapFromTracks:
+    """Test _build_title_map_from_tracks which uses prescan track data
+    and output file count to build the deterministic mapping."""
+
+    def test_skipped_short_track(self, tmp_path):
+        """When MakeMKV skips a short track, the map correctly pairs
+        output files to the qualifying prescan tracks by finding the
+        length threshold that matches the output count."""
+        from arm.ripper.folder_ripper import _build_title_map_from_tracks
+
+        rawpath = tmp_path / "raw"
+        rawpath.mkdir()
+        # MakeMKV produced 5 files (skipped track 3=22s and track 6=49s)
+        for i in range(5):
+            (rawpath / f"Show_t0{i}.mkv").write_bytes(b"x")
+
+        job = MagicMock()
+        # Prescan: tracks 0-6, tracks 3 and 6 are short
+        tracks = []
+        for tn, length in [(0, 3012), (1, 3012), (2, 3015), (3, 22), (4, 3017), (5, 3011), (6, 49)]:
+            t = MagicMock()
+            t.track_number = str(tn)
+            t.length = length
+            tracks.append(t)
+        job.tracks = tracks
+
+        title_map = _build_title_map_from_tracks(job, str(rawpath))
+        # Threshold found at >49s: tracks 0,1,2,4,5 qualify = 5 files
+        assert title_map == {0: 0, 1: 1, 2: 2, 3: 4, 4: 5}
+
+    def test_skipped_very_short_tracks(self, tmp_path):
+        """Multiple short tracks at different lengths are correctly excluded."""
+        from arm.ripper.folder_ripper import _build_title_map_from_tracks
+
+        rawpath = tmp_path / "raw"
+        rawpath.mkdir()
+        for i in range(5):
+            (rawpath / f"Show_t0{i}.mkv").write_bytes(b"x")
+
+        job = MagicMock()
+        tracks = []
+        for tn, length in [(0, 3012), (1, 3012), (2, 3015), (3, 1), (4, 3017), (5, 3011), (6, 0), (7, 5)]:
+            t = MagicMock()
+            t.track_number = str(tn)
+            t.length = length
+            tracks.append(t)
+        job.tracks = tracks
+
+        title_map = _build_title_map_from_tracks(job, str(rawpath))
+        # Threshold at >5s: tracks 0,1,2,4,5 qualify = 5 files
+        assert title_map == {0: 0, 1: 1, 2: 2, 3: 4, 4: 5}
+
+    def test_no_skip_identity_map(self, tmp_path):
+        """When all tracks qualify, mapping is identity."""
+        from arm.ripper.folder_ripper import _build_title_map_from_tracks
+
+        rawpath = tmp_path / "raw"
+        rawpath.mkdir()
+        for i in range(3):
+            (rawpath / f"Movie_t0{i}.mkv").write_bytes(b"x")
+
+        job = MagicMock()
+        tracks = []
+        for tn in range(3):
+            t = MagicMock()
+            t.track_number = str(tn)
+            t.length = 3000
+            tracks.append(t)
+        job.tracks = tracks
+
+        title_map = _build_title_map_from_tracks(job, str(rawpath))
+        assert title_map == {0: 0, 1: 1, 2: 2}
+
+    def test_empty_rawpath(self):
+        """Empty or missing rawpath returns empty map."""
+        from arm.ripper.folder_ripper import _build_title_map_from_tracks
+        job = MagicMock()
+        job.tracks = []
+        assert _build_title_map_from_tracks(job, "") == {}
+        assert _build_title_map_from_tracks(job, "/nonexistent") == {}
+
+    def test_count_mismatch_returns_empty(self, tmp_path):
+        """When output count doesn't match qualifying tracks, returns empty."""
+        from arm.ripper.folder_ripper import _build_title_map_from_tracks
+
+        rawpath = tmp_path / "raw"
+        rawpath.mkdir()
+        # 3 output files but 4 qualifying tracks
+        for i in range(3):
+            (rawpath / f"Show_t0{i}.mkv").write_bytes(b"x")
+
+        job = MagicMock()
+        tracks = []
+        for tn in range(4):
+            t = MagicMock()
+            t.track_number = str(tn)
+            t.length = 3000
+            tracks.append(t)
+        job.tracks = tracks
+
+        title_map = _build_title_map_from_tracks(job, str(rawpath))
+        assert title_map == {}
+
+
 class TestFolderRipperTitleMap:
-    """Test that folder_ripper.py collects PRGC messages and passes title_map."""
+    """Test that folder_ripper builds title_map and passes to reconcile."""
 
     @pytest.fixture(autouse=True)
     def _mock_logging(self):
@@ -170,34 +274,32 @@ class TestFolderRipperTitleMap:
         job.config.MAINFEATURE = 0
         job.config.MKV_ARGS = ""
         job.config.MINLENGTH = "600"
+        job.config.LOGPATH = str(tmp_path / "logs")
         job.build_raw_path.return_value = str(tmp_path / "raw" / "Test Show")
         job.raw_path = None
         job.errors = None
         job.tracks = []
         return job
 
-    def test_prgc_messages_collected_and_passed_to_reconcile(self, tmp_path):
-        """folder_ripper should request PRGC messages from run() and pass
-        the resulting title_map to _reconcile_filenames."""
-        from unittest.mock import patch, call
-        from arm.ripper.makemkv import ProgressBarCurrent, OutputType
+    def test_title_map_passed_to_reconcile(self, tmp_path):
+        """folder_ripper builds title_map from prescan tracks and passes
+        it to _reconcile_filenames."""
+        from unittest.mock import patch
 
         rawpath = tmp_path / "raw" / "Test Show"
         rawpath.mkdir(parents=True)
+        # 2 output files
+        (rawpath / "Show_t00.mkv").write_bytes(b"x")
+        (rawpath / "Show_t01.mkv").write_bytes(b"x")
 
         job = self._make_job(tmp_path)
+        # 3 prescan tracks: 2 episodes + 1 very short
+        t0 = MagicMock(track_number="0", length=3000, filename="Show_t00.mkv", ripped=False)
+        t1 = MagicMock(track_number="1", length=5, filename="Show_t01.mkv", ripped=False)  # below threshold
+        t2 = MagicMock(track_number="2", length=3000, filename="Show_t02.mkv", ripped=False)
+        job.tracks = [t0, t1, t2]
 
-        # Mock run() to yield PRGC messages
-        prgc0 = ProgressBarCurrent(code=0, oid=0, name="Test_Show_t00")
-        prgc1 = ProgressBarCurrent(code=0, oid=1, name="Test_Show_t02")  # skipped t01
-
-        def mock_run(cmd, select):
-            # Should be called with MSG | PRGC
-            assert OutputType.PRGC in select, "folder_ripper must request PRGC messages"
-            yield prgc0
-            yield prgc1
-
-        with patch("arm.ripper.makemkv.run", side_effect=mock_run), \
+        with patch("arm.ripper.makemkv.run", return_value=iter([])), \
              patch("arm.ripper.folder_ripper.setup_rawpath", return_value=str(rawpath)), \
              patch("arm.ripper.folder_ripper.prep_mkv"), \
              patch("arm.ripper.folder_ripper.prescan_track_info"), \
@@ -209,11 +311,9 @@ class TestFolderRipperTitleMap:
             from arm.ripper.folder_ripper import rip_folder
             rip_folder(job)
 
-        # _reconcile_filenames should be called with title_map keyword
         m_reconcile.assert_called_once()
         call_args = m_reconcile.call_args
-        assert "title_map" in call_args.kwargs, \
-            "_reconcile_filenames must receive title_map keyword argument"
+        assert "title_map" in call_args.kwargs
         tm = call_args.kwargs["title_map"]
-        assert tm == {0: 0, 1: 2}, \
-            f"title_map should map output 0->title 0, output 1->title 2, got {tm}"
+        # 2 output files, 2 qualifying tracks (0, 2) -> map {0: 0, 1: 2}
+        assert tm == {0: 0, 1: 2}, f"Expected {{0: 0, 1: 2}}, got {tm}"

--- a/test/test_title_map.py
+++ b/test/test_title_map.py
@@ -147,20 +147,18 @@ class TestBuildTitleMapFromTracks:
     """Test _build_title_map_from_tracks which uses prescan track data
     and output file count to build the deterministic mapping."""
 
-    def test_skipped_short_track(self, tmp_path):
-        """When MakeMKV skips a short track, the map correctly pairs
-        output files to the qualifying prescan tracks by finding the
-        length threshold that matches the output count."""
+    def test_skipped_short_track_default_threshold(self, tmp_path):
+        """Tracks below MakeMKV's default 120s threshold are skipped.
+        The Kolchak disc 4 scenario: tracks 3 (22s) and 6 (49s) are
+        below 120s, so 5 episode tracks map to 5 output files."""
         from arm.ripper.folder_ripper import _build_title_map_from_tracks
 
         rawpath = tmp_path / "raw"
         rawpath.mkdir()
-        # MakeMKV produced 5 files (skipped track 3=22s and track 6=49s)
         for i in range(5):
             (rawpath / f"Show_t0{i}.mkv").write_bytes(b"x")
 
         job = MagicMock()
-        # Prescan: tracks 0-6, tracks 3 and 6 are short
         tracks = []
         for tn, length in [(0, 3012), (1, 3012), (2, 3015), (3, 22), (4, 3017), (5, 3011), (6, 49)]:
             t = MagicMock()
@@ -170,21 +168,22 @@ class TestBuildTitleMapFromTracks:
         job.tracks = tracks
 
         title_map = _build_title_map_from_tracks(job, str(rawpath))
-        # Threshold found at >49s: tracks 0,1,2,4,5 qualify = 5 files
+        # Default 120s threshold: tracks 0,1,2,4,5 qualify (>=120s)
         assert title_map == {0: 0, 1: 1, 2: 2, 3: 4, 4: 5}
 
-    def test_skipped_very_short_tracks(self, tmp_path):
-        """Multiple short tracks at different lengths are correctly excluded."""
+    def test_fallback_threshold_search(self, tmp_path):
+        """When default threshold doesn't match, searches for the right one."""
         from arm.ripper.folder_ripper import _build_title_map_from_tracks
 
         rawpath = tmp_path / "raw"
         rawpath.mkdir()
-        for i in range(5):
+        for i in range(3):
             (rawpath / f"Show_t0{i}.mkv").write_bytes(b"x")
 
         job = MagicMock()
+        # 5 tracks: 3 long + 2 medium (above 120s but MakeMKV still skipped them)
         tracks = []
-        for tn, length in [(0, 3012), (1, 3012), (2, 3015), (3, 1), (4, 3017), (5, 3011), (6, 0), (7, 5)]:
+        for tn, length in [(0, 3012), (1, 200), (2, 3015), (3, 150), (4, 3017)]:
             t = MagicMock()
             t.track_number = str(tn)
             t.length = length
@@ -192,8 +191,9 @@ class TestBuildTitleMapFromTracks:
         job.tracks = tracks
 
         title_map = _build_title_map_from_tracks(job, str(rawpath))
-        # Threshold at >5s: tracks 0,1,2,4,5 qualify = 5 files
-        assert title_map == {0: 0, 1: 1, 2: 2, 3: 4, 4: 5}
+        # Default 120s gives 5 qualifying (all >= 120) != 3 output
+        # Fallback search finds threshold >=200: tracks 0,2,4 = 3 files
+        assert title_map == {0: 0, 1: 2, 2: 4}
 
     def test_no_skip_identity_map(self, tmp_path):
         """When all tracks qualify, mapping is identity."""


### PR DESCRIPTION
## Summary
- Build title map from prescan track lengths instead of PRGC messages
- Finds the length threshold where qualifying track count matches output file count
- Positionally maps sequential output files to original prescan track numbers
- Falls back to existing pattern matching when threshold can't be determined

## Why not PRGC
`--progress=<file>` redirects PRGC to a file, not stdout. Without `--progress`, PRGC goes nowhere by default. The prescan track data is already in the DB and provides the same information deterministically.

## How it works
1. Count output MKV files (e.g. 5)
2. Sort prescan tracks by track number ascending
3. Try each unique track length as a cutoff threshold
4. When tracks with length > cutoff == output count, that's the mapping
5. Pair output files positionally to qualifying tracks

## Test plan
- [x] `test_skipped_short_track` - 22s/49s tracks excluded, 5 episodes mapped
- [x] `test_skipped_very_short_tracks` - multiple shorts at different lengths
- [x] `test_no_skip_identity_map` - all tracks qualify, identity mapping
- [x] `test_empty_rawpath` - graceful no-op
- [x] `test_count_mismatch_returns_empty` - falls back when ambiguous
- [x] `test_title_map_passed_to_reconcile` - end-to-end integration
- [x] Full suite: 1663 passed