### PR TITLE
feat: auto-disable tracks shorter than MINLENGTH after prescan

### DIFF
--- a/arm/api/v1/folder.py
+++ b/arm/api/v1/folder.py
@@ -179,6 +179,20 @@ def _prescan_and_wait(job_id: int):
         try:
             prep_mkv()
             prescan_track_info(job)
+
+            # Auto-disable tracks shorter than MakeMKV's minlength threshold.
+            # MakeMKV silently skips these during rip regardless of the
+            # checkbox state, so disabling them prevents misleading UI.
+            minlength = int(cfg.arm_config.get("MINLENGTH", 120))
+            disabled_count = 0
+            for track in job.tracks:
+                if track.length is not None and track.length < minlength:
+                    track.enabled = False
+                    disabled_count += 1
+            if disabled_count:
+                log.info("Auto-disabled %d tracks shorter than %ds",
+                         disabled_count, minlength)
+
             job.status = JobState.MANUAL_WAIT_STARTED.value
             db.session.commit()
             log.info("Prescan complete for job %s — %d tracks found, waiting for review",

--- a/test/test_folder_api.py
+++ b/test/test_folder_api.py
@@ -262,7 +262,9 @@ class TestPrescanAndWait:
 
         mock_job = MagicMock()
         mock_job.job_id = 10
-        mock_job.tracks = [MagicMock(), MagicMock()]
+        track1 = MagicMock(length=3000, enabled=True)
+        track2 = MagicMock(length=3000, enabled=True)
+        mock_job.tracks = [track1, track2]
         mock_job_cls.query.get.return_value = mock_job
 
         with patch("arm.ripper.makemkv.prep_mkv") as mock_prep, \
@@ -271,10 +273,31 @@ class TestPrescanAndWait:
 
         mock_prep.assert_called_once()
         mock_prescan.assert_called_once_with(mock_job)
-        # Session must be cleaned up to prevent pool exhaustion
         mock_db.session.remove.assert_called_once()
         assert mock_job.status == "waiting"
         mock_db.session.commit.assert_called()
+
+    @patch("arm.api.v1.folder.db")
+    @patch("arm.api.v1.folder.Job")
+    def test_prescan_auto_disables_short_tracks(self, mock_job_cls, mock_db):
+        """Tracks shorter than MINLENGTH are auto-disabled after prescan."""
+        from arm.api.v1.folder import _prescan_and_wait
+
+        mock_job = MagicMock()
+        mock_job.job_id = 13
+        episode = MagicMock(length=3012, enabled=True)
+        short_extra = MagicMock(length=22, enabled=True)
+        medium_extra = MagicMock(length=49, enabled=True)
+        mock_job.tracks = [episode, short_extra, medium_extra]
+        mock_job_cls.query.get.return_value = mock_job
+
+        with patch("arm.ripper.makemkv.prep_mkv"), \
+             patch("arm.ripper.makemkv.prescan_track_info"):
+            _prescan_and_wait(13)
+
+        assert episode.enabled is True, "Episode track should stay enabled"
+        assert short_extra.enabled is False, "22s track should be auto-disabled"
+        assert medium_extra.enabled is False, "49s track should be auto-disabled (< 120s default)"
 
     @patch("arm.api.v1.folder.db")
     @patch("arm.api.v1.folder.Job")


### PR DESCRIPTION
## Summary
Auto-disable tracks shorter than MINLENGTH after prescan so the review UI accurately reflects what MakeMKV will actually rip.

## Why
MakeMKV silently skips titles below its minlength threshold during ripping, regardless of checkbox state. Users see tracks checked but they never get ripped - confusing UX that also causes track reconciliation issues.

## Test plan
- [x] `test_prescan_auto_disables_short_tracks` - 22s and 49s tracks disabled, episodes kept
- [x] Full suite: 1665 passed