### PR TITLE
fix: cross-disc filter excludes re-runs of the same disc number

### DIFF
--- a/arm/services/matching/cross_disc.py
+++ b/arm/services/matching/cross_disc.py
@@ -42,6 +42,17 @@ def get_excluded_episodes(job, season: int | None = None) -> set[int]:
                 Track.episode_number.isnot(None),
             )
         )
+        # Only exclude from jobs on DIFFERENT disc numbers.
+        # Re-runs of the same disc (same disc_number) should not
+        # exclude their own episodes from matching.
+        disc_number = getattr(job, "disc_number", None)
+        if disc_number is not None:
+            query = query.filter(
+                db.or_(
+                    Job.disc_number != disc_number,
+                    Job.disc_number.is_(None),
+                )
+            )
         # Filter by season when known — episode numbers restart each season
         if season is not None:
             query = query.filter(


### PR DESCRIPTION
## Summary
Cross-disc episode exclusion now only excludes episodes from jobs with a different disc_number. Re-runs of the same disc can re-match their episodes.

## Root cause
When disc 4 was re-imported multiple times (jobs 75, 76, 77), earlier runs had matched E16-E20. The cross-disc filter excluded ALL episodes matched by sibling jobs (including previous disc 4 runs), leaving nothing to match. The episode matching panel showed "Failed".

## Fix
Filter the exclusion query to only include jobs where `disc_number != current_disc_number`. Jobs with the same disc number are re-runs, not siblings.

## Test plan
- [x] 79 matching tests pass
- [x] Full suite: 1665 passed