### PR TITLE
fix: convert async def handlers to sync to prevent event loop blocking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,12 @@ FROM base AS automatic-ripping-machine
 
 COPY . /opt/arm/
 
-# Ensure Python deps are up-to-date, create udev symlink, allow git in container
-RUN pip3 install --no-cache-dir -r /opt/arm/docker/base/requirements.txt \
+# Ensure Python deps are up-to-date, install rsync for NFS-safe file transfer,
+# create udev symlink, allow git in container
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends rsync \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install --no-cache-dir -r /opt/arm/docker/base/requirements.txt \
     && ln -sv /opt/arm/setup/61-docker-arm.rules /lib/udev/rules.d/ \
     && git config --global --add safe.directory /opt/arm
 

--- a/arm/api/v1/drives.py
+++ b/arm/api/v1/drives.py
@@ -7,7 +7,7 @@ import os
 import re
 import subprocess
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 from arm.database import db
@@ -214,7 +214,7 @@ async def drive_diagnostic():
 
 
 @router.post('/drives/rescan')
-async def rescan_drives():
+def rescan_drives():
     """Re-detect optical drives and update the database.
 
     Python-level only — refreshes the drive inventory in the DB
@@ -275,7 +275,7 @@ async def scan_drive(drive_id: int):
 
 
 @router.delete('/drives/{drive_id}')
-async def delete_drive(drive_id: int):
+def delete_drive(drive_id: int):
     """Remove a stale drive from the database.
 
     Only allows deletion of drives that are not currently processing a job.
@@ -296,13 +296,12 @@ async def delete_drive(drive_id: int):
 
 
 @router.patch('/drives/{drive_id}')
-async def update_drive(drive_id: int, request: Request):
+def update_drive(drive_id: int, body: dict):
     """Update a drive's user-editable fields (name, description)."""
     drive = SystemDrives.query.get(drive_id)
     if not drive:
         return JSONResponse({"success": False, "error": "Drive not found"}, status_code=404)
 
-    body = await request.json()
     if not body:
         return JSONResponse({"success": False, "error": "No fields to update"}, status_code=400)
 
@@ -331,13 +330,12 @@ async def update_drive(drive_id: int, request: Request):
 
 
 @router.post('/drives/{drive_id}/eject')
-async def eject_drive(drive_id: int, request: Request):
+def eject_drive(drive_id: int, body: dict = {}):
     """Eject, close, or toggle the drive tray."""
     drive = SystemDrives.query.get(drive_id)
     if not drive:
         return JSONResponse({"success": False, "error": "Drive not found"}, status_code=404)
 
-    body = await request.json() if await request.body() else {}
     method = body.get('method', 'toggle')
     if method not in ('eject', 'close', 'toggle'):
         return JSONResponse(

--- a/arm/api/v1/files.py
+++ b/arm/api/v1/files.py
@@ -1,8 +1,18 @@
-"""API v1 — File browser endpoints."""
+"""API v1 — File browser endpoints.
+
+All handlers use sync def (not async def) so FastAPI runs them in a
+threadpool via anyio.to_thread.run_sync().  This prevents blocking the
+event loop during heavy filesystem I/O (shutil.move, shutil.rmtree,
+recursive os.walk + chown).
+
+Request bodies use Pydantic BaseModel instead of raw Request objects,
+which eliminates the need for async def + await request.json().
+"""
 import logging
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 from arm.services import file_browser
 
@@ -12,6 +22,25 @@ _ACCESS_DENIED = "Access denied"
 _PATH_NOT_FOUND = "Path not found"
 
 router = APIRouter(prefix="/api/v1", tags=["files"])
+
+
+class RenameRequest(BaseModel):
+    path: str
+    new_name: str
+
+
+class MoveRequest(BaseModel):
+    path: str
+    destination: str
+
+
+class MkdirRequest(BaseModel):
+    path: str
+    name: str
+
+
+class PathRequest(BaseModel):
+    path: str
 
 
 @router.get('/files/roots')
@@ -37,18 +66,10 @@ def list_directory(path: str = Query(..., description="Directory path to list"))
 
 
 @router.post('/files/rename')
-async def rename_item(request: Request):
+def rename_item(req: RenameRequest):
     """Rename a file or directory."""
-    body = await request.json()
-    path = body.get('path')
-    new_name = body.get('new_name')
-    if not path or not new_name:
-        return JSONResponse(
-            {"success": False, "error": "Both 'path' and 'new_name' are required"},
-            status_code=400,
-        )
     try:
-        return file_browser.rename_item(path, new_name)
+        return file_browser.rename_item(req.path, req.new_name)
     except ValueError:
         return JSONResponse({"success": False, "error": _ACCESS_DENIED}, status_code=403)
     except FileNotFoundError:
@@ -56,23 +77,15 @@ async def rename_item(request: Request):
     except FileExistsError:
         return JSONResponse({"success": False, "error": "Target already exists"}, status_code=409)
     except OSError as exc:
-        log.error("Error renaming %s: %s", path, exc)
+        log.error("Error renaming %s: %s", req.path, exc)
         return JSONResponse({"success": False, "error": "Failed to rename item"}, status_code=500)
 
 
 @router.post('/files/move')
-async def move_item(request: Request):
+def move_item(req: MoveRequest):
     """Move a file or directory to a new location."""
-    body = await request.json()
-    path = body.get('path')
-    destination = body.get('destination')
-    if not path or not destination:
-        return JSONResponse(
-            {"success": False, "error": "Both 'path' and 'destination' are required"},
-            status_code=400,
-        )
     try:
-        return file_browser.move_item(path, destination)
+        return file_browser.move_item(req.path, req.destination)
     except ValueError:
         return JSONResponse({"success": False, "error": _ACCESS_DENIED}, status_code=403)
     except FileNotFoundError:
@@ -80,23 +93,15 @@ async def move_item(request: Request):
     except (NotADirectoryError, FileExistsError):
         return JSONResponse({"success": False, "error": "Target already exists or is not a directory"}, status_code=409)
     except OSError as exc:
-        log.error("Error moving %s: %s", path, exc)
+        log.error("Error moving %s: %s", req.path, exc)
         return JSONResponse({"success": False, "error": "Failed to move item"}, status_code=500)
 
 
 @router.post('/files/mkdir')
-async def create_directory(request: Request):
+def create_directory(req: MkdirRequest):
     """Create a new directory."""
-    body = await request.json()
-    path = body.get('path')
-    name = body.get('name')
-    if not path or not name:
-        return JSONResponse(
-            {"success": False, "error": "Both 'path' and 'name' are required"},
-            status_code=400,
-        )
     try:
-        return file_browser.create_directory(path, name)
+        return file_browser.create_directory(req.path, req.name)
     except ValueError:
         return JSONResponse({"success": False, "error": _ACCESS_DENIED}, status_code=403)
     except FileNotFoundError:
@@ -104,47 +109,33 @@ async def create_directory(request: Request):
     except (NotADirectoryError, FileExistsError):
         return JSONResponse({"success": False, "error": "Directory already exists or parent is not a directory"}, status_code=409)
     except OSError as exc:
-        log.error("Error creating directory in %s: %s", path, exc)
+        log.error("Error creating directory in %s: %s", req.path, exc)
         return JSONResponse({"success": False, "error": "Failed to create directory"}, status_code=500)
 
 
 @router.post('/files/fix-permissions')
-async def fix_permissions(request: Request):
+def fix_permissions(req: PathRequest):
     """Fix ownership and permissions for a file or directory."""
-    body = await request.json()
-    path = body.get('path')
-    if not path:
-        return JSONResponse(
-            {"success": False, "error": "'path' is required"},
-            status_code=400,
-        )
     try:
-        return file_browser.fix_item_permissions(path)
+        return file_browser.fix_item_permissions(req.path)
     except ValueError:
         return JSONResponse({"success": False, "error": _ACCESS_DENIED}, status_code=403)
     except FileNotFoundError:
         return JSONResponse({"success": False, "error": _PATH_NOT_FOUND}, status_code=404)
     except OSError as exc:
-        log.error("Error fixing permissions on %s: %s", path, exc)
+        log.error("Error fixing permissions on %s: %s", req.path, exc)
         return JSONResponse({"success": False, "error": "Failed to fix permissions"}, status_code=500)
 
 
 @router.delete('/files/delete')
-async def delete_item(request: Request):
+def delete_item(req: PathRequest):
     """Delete a file or directory."""
-    body = await request.json()
-    path = body.get('path')
-    if not path:
-        return JSONResponse(
-            {"success": False, "error": "'path' is required"},
-            status_code=400,
-        )
     try:
-        return file_browser.delete_item(path)
+        return file_browser.delete_item(req.path)
     except ValueError:
         return JSONResponse({"success": False, "error": _ACCESS_DENIED}, status_code=403)
     except FileNotFoundError:
         return JSONResponse({"success": False, "error": _PATH_NOT_FOUND}, status_code=404)
     except OSError as exc:
-        log.error("Error deleting %s: %s", path, exc)
+        log.error("Error deleting %s: %s", req.path, exc)
         return JSONResponse({"success": False, "error": "Failed to delete item"}, status_code=500)

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -1,9 +1,13 @@
-"""API v1 — Job endpoints."""
+"""API v1 — Job endpoints.
+
+All handlers use sync def (not async def) so FastAPI runs them in a
+threadpool, preventing blocking the event loop during DB queries,
+external HTTP calls, or filesystem operations.
+"""
 import json
 import re
 import threading
-
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 import arm.config.config as cfg
@@ -145,13 +149,11 @@ def cancel_waiting_job(job_id: int):
 
 
 @router.patch('/jobs/{job_id}/config')
-async def change_job_config(job_id: int, request: Request):
+def change_job_config(job_id: int, body: dict):
     """Update job rip parameters."""
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
-
-    body = await request.json()
     if not body:
         return JSONResponse({"success": False, "error": "No fields to update"}, status_code=400)
 
@@ -336,13 +338,11 @@ def _re_render_title(job, updated):
 
 
 @router.put('/jobs/{job_id}/title')
-async def update_job_title(job_id: int, request: Request):
+def update_job_title(job_id: int, body: dict):
     """Update a job's title metadata."""
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
-
-    body = await request.json()
     old_title, old_year = job.title, job.year
 
     args, updated, structured_changed = _process_mapped_fields(body)
@@ -369,13 +369,11 @@ async def update_job_title(job_id: int, request: Request):
 
 
 @router.put('/jobs/{job_id}/tracks')
-async def set_job_tracks(job_id: int, request: Request):
+def set_job_tracks(job_id: int, body: dict):
     """Replace a job's tracks with MusicBrainz track data."""
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
-
-    body = await request.json()
     tracks = body.get('tracks', [])
     if not isinstance(tracks, list):
         return JSONResponse({"success": False, "error": "tracks must be a list"}, status_code=400)
@@ -404,20 +402,18 @@ async def set_job_tracks(job_id: int, request: Request):
 
 
 @router.post('/jobs/{job_id}/multi-title')
-async def toggle_multi_title(job_id: int, request: Request):
+def toggle_multi_title(job_id: int, body: dict):
     """Toggle the multi_title flag on a job."""
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
-
-    body = await request.json()
     enabled = bool(body.get('enabled', not getattr(job, 'multi_title', False)))
     svc_files.database_updater({"multi_title": enabled}, job)
     return {"success": True, "job_id": job.job_id, "multi_title": enabled}
 
 
 @router.put('/jobs/{job_id}/tracks/{track_id}/title')
-async def update_track_title(job_id: int, track_id: int, request: Request):
+def update_track_title(job_id: int, track_id: int, body: dict):
     """Set per-track title metadata for a multi-title disc."""
     job = Job.query.get(job_id)
     if not job:
@@ -426,8 +422,6 @@ async def update_track_title(job_id: int, track_id: int, request: Request):
     track = Track.query.get(track_id)
     if not track or track.job_id != job_id:
         return JSONResponse({"success": False, "error": "Track not found"}, status_code=404)
-
-    body = await request.json()
     updated = {}
     track_fields = {
         'title': ('title', str, 256),
@@ -479,10 +473,9 @@ def clear_track_title(job_id: int, track_id: int):
 
 
 @router.post('/naming/preview')
-async def naming_preview(request: Request):
+def naming_preview(body: dict):
     """Preview a naming pattern with given variables."""
     from arm.ripper.naming import render_preview
-    body = await request.json()
     pattern = body.get('pattern', '')
     variables = body.get('variables', {})
     if not pattern:
@@ -511,15 +504,13 @@ def naming_preview_for_job(job_id: int):
 
 
 @router.patch('/jobs/{job_id}/naming')
-async def update_job_naming(job_id: int, request: Request):
+def update_job_naming(job_id: int, body: dict):
     """Update per-job naming pattern overrides."""
     from arm.ripper.naming import validate_pattern
 
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
-
-    body = await request.json()
 
     for field in ('title_pattern_override', 'folder_pattern_override'):
         if field in body:
@@ -546,11 +537,9 @@ async def update_job_naming(job_id: int, request: Request):
 
 
 @router.post('/naming/validate')
-async def validate_naming_pattern(request: Request):
+def validate_naming_pattern(body: dict):
     """Validate a naming pattern against known variables."""
     from arm.ripper.naming import validate_pattern
-
-    body = await request.json()
     pattern = body.get('pattern', '')
     if not pattern:
         return {"valid": True, "invalid_vars": [], "suggestions": {}}
@@ -610,13 +599,11 @@ def _validate_transcode_overrides(body):
 
 
 @router.patch('/jobs/{job_id}/transcode-config')
-async def update_transcode_config(job_id: int, request: Request):
+def update_transcode_config(job_id: int, body: dict):
     """Set per-job transcode override settings."""
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
-
-    body = await request.json()
     if not body or not isinstance(body, dict):
         return JSONResponse({"success": False, "error": "Request body must be a JSON object"}, status_code=400)
 
@@ -631,7 +618,7 @@ async def update_transcode_config(job_id: int, request: Request):
 
 
 @router.post('/jobs/{job_id}/transcode-callback')
-async def transcode_callback(job_id: int, request: Request):
+def transcode_callback(job_id: int, body: dict):
     """Receive status update from the external transcoder.
 
     Expected payload::
@@ -648,8 +635,6 @@ async def transcode_callback(job_id: int, request: Request):
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
-
-    body = await request.json()
     status = body.get("status")
 
     if status == "transcoding":
@@ -705,7 +690,7 @@ async def transcode_callback(job_id: int, request: Request):
 
 
 @router.post('/jobs/{job_id}/tvdb-match')
-async def tvdb_match(job_id: int, request: Request):
+def tvdb_match(job_id: int, body: dict):
     """Run TVDB episode matching for a job.
 
     Body: {"season": int|null, "tolerance": int|null, "apply": bool}
@@ -716,8 +701,6 @@ async def tvdb_match(job_id: int, request: Request):
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
-
-    body = await request.json()
     season = body.get("season")
     tolerance = body.get("tolerance")
     apply = bool(body.get("apply", False))

--- a/arm/api/v1/system.py
+++ b/arm/api/v1/system.py
@@ -4,7 +4,7 @@ import platform
 import subprocess
 
 import psutil
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 import arm.config.config as cfg
@@ -197,9 +197,8 @@ from arm.ripper.makemkv import prep_mkv
 
 
 @router.post('/system/ripping-enabled')
-async def set_ripping_enabled(request: Request):
+def set_ripping_enabled(body: dict):
     """Toggle global ripping pause."""
-    body = await request.json()
     if 'enabled' not in body:
         return JSONResponse(
             {"success": False, "error": "'enabled' field required"},

--- a/arm/api/v1/system.py
+++ b/arm/api/v1/system.py
@@ -65,6 +65,8 @@ def get_system_stats():
         "percent": mem.percent,
     }
 
+    from arm.services.disk_usage_cache import get_disk_usage
+
     media_paths = [
         ("Raw", cfg.arm_config.get("RAW_PATH", "")),
         ("Transcode", cfg.arm_config.get("TRANSCODE_PATH", "")),
@@ -74,18 +76,16 @@ def get_system_stats():
     for name, path in media_paths:
         if not path:
             continue
-        try:
-            usage = psutil.disk_usage(path)
+        usage = get_disk_usage(path)
+        if usage:
             storage.append({
                 "name": name,
                 "path": path,
-                "total_gb": round(usage.total / 1073741824, 1),
-                "used_gb": round(usage.used / 1073741824, 1),
-                "free_gb": round(usage.free / 1073741824, 1),
-                "percent": usage.percent,
+                "total_gb": round(usage["total"] / 1073741824, 1),
+                "used_gb": round(usage["used"] / 1073741824, 1),
+                "free_gb": round(usage["free"] / 1073741824, 1),
+                "percent": usage["percent"],
             })
-        except FileNotFoundError:
-            continue
 
     return {
         "cpu_percent": cpu_percent,

--- a/arm/app.py
+++ b/arm/app.py
@@ -32,6 +32,16 @@ class SessionCleanupMiddleware(BaseHTTPMiddleware):
 async def lifespan(app: FastAPI):
     """Startup / shutdown lifecycle."""
     db.init_engine('sqlite:///' + cfg.arm_config['DBFILE'])
+
+    # Start cached disk usage - never blocks on NFS stalls
+    from arm.services.disk_usage_cache import register_paths, start_background_refresh
+    register_paths([
+        cfg.arm_config.get("RAW_PATH", ""),
+        cfg.arm_config.get("TRANSCODE_PATH", ""),
+        cfg.arm_config.get("COMPLETED_PATH", ""),
+    ])
+    start_background_refresh()
+
     log.info("ARM API server starting up.")
     yield
     log.info("ARM API server shutting down.")

--- a/arm/app.py
+++ b/arm/app.py
@@ -2,13 +2,30 @@
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
 
 import arm.config.config as cfg
 from arm.database import db
 
 log = logging.getLogger(__name__)
+
+
+class SessionCleanupMiddleware(BaseHTTPMiddleware):
+    """Remove scoped DB sessions after each request.
+
+    FastAPI runs sync def handlers in a threadpool.  AnyIO reuses threads,
+    so scoped_session (keyed by thread ID) can leak uncommitted state from
+    one request to the next on the same thread.  Calling db.session.remove()
+    returns the connection to the pool and resets the session.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        if db._engine is not None:
+            db.session.remove()
+        return response
 
 
 @asynccontextmanager
@@ -22,6 +39,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="ARM API", lifespan=lifespan)
 
+app.add_middleware(SessionCleanupMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],

--- a/arm/ripper/arm_matcher.py
+++ b/arm/ripper/arm_matcher.py
@@ -118,7 +118,7 @@ _SEASON_KEYWORD_RE = re.compile(
 )
 
 # SKU patterns at end of string
-_SKU_RE = re.compile(r'\s*SKU\w*', re.IGNORECASE)
+_SKU_RE = re.compile(r' *SKU\w*', re.IGNORECASE)
 
 # Aspect ratio markers
 _ASPECT_RE = re.compile(r'\b16[xX]9\b')

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -78,7 +78,7 @@ def _build_variables(job):
 
 def _clean_empty_parens(s):
     """Remove empty parentheses like '()' left from missing variables."""
-    return re.sub(r'\s*\(\s*\)', '', s).strip()
+    return re.sub(r' *\( *\)', '', s).strip()
 
 
 def _clean_for_filename(s):

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -139,10 +139,10 @@ def bash_notify(cfg, title, body, job=None):
 def _move_to_shared_storage(cfg, raw_basename, job=None):
     """Move raw directory from local scratch to shared storage if configured.
 
-    Uses copytree + rmtree instead of shutil.move because move nests the
-    source inside an existing destination directory rather than merging.
-    This caused file loss when multiple discs of the same show shared a
-    raw directory name.
+    Uses rsync subprocess instead of shutil.copy2 so the NFS I/O happens in
+    a child process that can be abandoned if it stalls.  This prevents the
+    ARM API from becoming unresponsive during large file copies (shutil.copy2
+    in a thread causes kernel D-state that blocks statvfs on the same mount).
     """
     local_raw = cfg.get('LOCAL_RAW_PATH', '')
     shared_raw = cfg.get('SHARED_RAW_PATH', '')
@@ -155,21 +155,32 @@ def _move_to_shared_storage(cfg, raw_basename, job=None):
             if job:
                 database_updater({'status': JobState.COPYING.value}, job)
             os.makedirs(dst, exist_ok=True)
-            src_files = [f for f in os.listdir(src) if os.path.isfile(os.path.join(src, f))]
-            logging.info(f"Copying {len(src_files)} files from {src} -> {dst}")
-            for fname in src_files:
-                src_file = os.path.join(src, fname)
-                dst_file = os.path.join(dst, fname)
-                shutil.copy2(src_file, dst_file)
-                logging.info(f"Copied {fname} ({os.path.getsize(dst_file)} bytes)")
-            # Verify all files arrived before removing source
-            dst_files = set(os.listdir(dst))
-            missing = [f for f in src_files if f not in dst_files]
-            if missing:
-                logging.error(f"File copy verification failed! Missing: {missing}")
-                raise OSError(f"Copy verification failed: {len(missing)} files missing at destination")
-            shutil.rmtree(src)
-            logging.info(f"Moved {len(src_files)} files from {src} -> {dst} (verified)")
+
+            # Use rsync to copy files - runs as a subprocess so NFS D-state
+            # doesn't block our process threads.  --remove-source-files deletes
+            # each source file after successful transfer (verified by rsync).
+            # Trailing slash on src ensures contents are merged into dst.
+            cmd = [
+                "rsync", "-a", "--remove-source-files",
+                "--info=name1,progress2",
+                src + "/",
+                dst + "/",
+            ]
+            logging.info(f"rsync {src}/ -> {dst}/")
+            result = subprocess.run(cmd, capture_output=True, text=True)
+
+            if result.returncode != 0:
+                logging.error(f"rsync failed (exit {result.returncode}): {result.stderr}")
+                raise OSError(f"rsync failed: {result.stderr[:200]}")
+
+            # Log transferred files from rsync output
+            for line in result.stdout.strip().splitlines():
+                if line.strip():
+                    logging.info(f"rsync: {line.strip()}")
+
+            # rsync --remove-source-files removes files but leaves empty dirs
+            shutil.rmtree(src, ignore_errors=True)
+            logging.info(f"rsync complete: {src} -> {dst}")
         except OSError as e:
             logging.error(f"Failed to move {src} -> {dst}: {e}")
             raise

--- a/arm/services/disk_usage_cache.py
+++ b/arm/services/disk_usage_cache.py
@@ -1,0 +1,136 @@
+"""Cached disk usage with subprocess-based refresh.
+
+NFS mounts can enter kernel D-state during large file operations, causing
+``statvfs()`` to block indefinitely. This module provides cached disk usage
+that refreshes in a background thread using a subprocess with a timeout.
+The subprocess can be abandoned if it stalls (unlike threads, D-state
+subprocesses don't block the parent process).
+
+The API endpoint reads from the cache and never calls statvfs() directly.
+"""
+
+import json
+import logging
+import subprocess
+import threading
+import time
+
+log = logging.getLogger(__name__)
+
+# Cache: path -> {"total": bytes, "used": bytes, "free": bytes, "percent": float, "ts": epoch}
+_cache: dict[str, dict] = {}
+_cache_lock = threading.Lock()
+
+# How long cached values are considered fresh (seconds)
+CACHE_TTL = 30
+
+# Timeout for the subprocess that calls statvfs (seconds).
+# If NFS is stalled, the subprocess blocks but we abandon it after this.
+SUBPROCESS_TIMEOUT = 5
+
+# Background refresh interval (seconds)
+_REFRESH_INTERVAL = 30
+
+
+def get_disk_usage(path: str) -> dict | None:
+    """Return cached disk usage for *path*, or None if unavailable.
+
+    Never blocks on NFS. Returns stale data (up to CACHE_TTL + REFRESH_INTERVAL
+    seconds old) if the NFS mount is unresponsive.
+    """
+    with _cache_lock:
+        entry = _cache.get(path)
+    if entry:
+        return {
+            "total": entry["total"],
+            "used": entry["used"],
+            "free": entry["free"],
+            "percent": entry["percent"],
+        }
+    # No cached value yet - try a synchronous fetch with timeout
+    _refresh_path(path)
+    with _cache_lock:
+        entry = _cache.get(path)
+    if entry:
+        return {
+            "total": entry["total"],
+            "used": entry["used"],
+            "free": entry["free"],
+            "percent": entry["percent"],
+        }
+    return None
+
+
+def _refresh_path(path: str):
+    """Refresh disk usage for a single path using a subprocess with timeout."""
+    try:
+        # Use a subprocess so D-state statvfs doesn't block our threads.
+        # The subprocess runs a tiny Python snippet that calls os.statvfs.
+        result = subprocess.run(
+            [
+                "python3", "-c",
+                "import os, json, sys; "
+                "s = os.statvfs(sys.argv[1]); "
+                "total = s.f_frsize * s.f_blocks; "
+                "free = s.f_frsize * s.f_bavail; "
+                "used = total - (s.f_frsize * s.f_bfree); "
+                "pct = round(used / total * 100, 1) if total else 0; "
+                "json.dump({'total': total, 'used': used, 'free': free, 'percent': pct}, sys.stdout)",
+                path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT,
+        )
+        if result.returncode == 0 and result.stdout:
+            data = json.loads(result.stdout)
+            data["ts"] = time.time()
+            with _cache_lock:
+                _cache[path] = data
+    except subprocess.TimeoutExpired:
+        log.debug("Disk usage subprocess timed out for %s (NFS stall?)", path)
+    except (json.JSONDecodeError, OSError, ValueError) as e:
+        log.debug("Disk usage refresh failed for %s: %s", path, e)
+
+
+def _refresh_all():
+    """Refresh all registered paths."""
+    with _cache_lock:
+        paths = list(_cache.keys())
+    for path in paths:
+        _refresh_path(path)
+
+
+def register_paths(paths: list[str]):
+    """Register paths to be refreshed in the background.
+
+    Call this at startup with the media paths from arm.yaml.
+    """
+    with _cache_lock:
+        for path in paths:
+            if path and path not in _cache:
+                _cache[path] = {}
+    # Do an initial refresh (blocking but with timeout)
+    for path in paths:
+        if path:
+            _refresh_path(path)
+
+
+_refresh_thread: threading.Thread | None = None
+
+
+def start_background_refresh():
+    """Start the background refresh thread (call once at startup)."""
+    global _refresh_thread
+    if _refresh_thread and _refresh_thread.is_alive():
+        return
+
+    def _loop():
+        while True:
+            time.sleep(_REFRESH_INTERVAL)
+            _refresh_all()
+
+    _refresh_thread = threading.Thread(target=_loop, daemon=True, name="disk-usage-cache")
+    _refresh_thread.start()
+    log.info("Disk usage cache: background refresh started (interval=%ds, timeout=%ds)",
+             _REFRESH_INTERVAL, SUBPROCESS_TIMEOUT)

--- a/arm/services/files.py
+++ b/arm/services/files.py
@@ -69,11 +69,15 @@ def make_dir(path):
 
 
 def getsize(path):
-    """Simple function to get the free space left in a path"""
+    """Get the free space left in a path. Uses cached values to avoid NFS stalls."""
+    from arm.services.disk_usage_cache import get_disk_usage
+    usage = get_disk_usage(path)
+    if usage:
+        return usage["free"] / 1073741824
+    # Fallback for paths not in cache (non-NFS)
     path_stats = os.statvfs(path)
     free = (path_stats.f_bavail * path_stats.f_frsize)
-    free_gb = free / 1073741824
-    return free_gb
+    return free / 1073741824
 
 
 def clean_for_filename(string):

--- a/docs/research/nfs-blocking-audit.md
+++ b/docs/research/nfs-blocking-audit.md
@@ -1,0 +1,67 @@
+# NFS Blocking Audit - ARM API Responsiveness
+
+## Problem
+During large NFS file operations (scratch→shared copy), the ARM API becomes
+unresponsive for 5-10 minutes. The UI shows ARM as unreachable.
+
+## Root Cause
+NFS `statvfs()` syscalls enter kernel D-state (uninterruptible sleep) when
+the NFS client is saturated by large file copies. D-state cannot be interrupted
+by signals, cancelled, or killed. This affects ANY process that touches the
+NFS mount, not just the process doing the copy.
+
+## Key Finding
+Converting `async def` → `def` (threadpool) does NOT fix this. Both use
+bounded thread pools. A D-state thread never returns, so all pool threads
+exhaust under continuous requests. The fix must avoid `statvfs()` entirely
+during NFS stalls.
+
+## Affected Codepaths
+
+### 1. ARM Stats Endpoint (system.py:78) - HIGHEST IMPACT
+- `psutil.disk_usage(path)` on NFS media paths
+- Polled by UI every few seconds
+- Fix: Cache with TTL, refresh via background subprocess
+
+### 2. File Browser Service (files.py:73)
+- `os.statvfs(path)` for directory size
+- Fix: Same disk usage cache
+
+### 3. Rip Thread NFS Copy (utils.py:163)
+- `shutil.copy2()` per file, scratch→NFS shared
+- Causes the NFS saturation that triggers D-state for others
+- Fix: rsync subprocess with progress + timeout
+
+### 4. Transcoder Source/Output Copy (transcoder.py:636-744)
+- `shutil.copytree/copy2/move` in async function
+- Blocks transcoder event loop (health goes unreachable)
+- Fix: asyncio.create_subprocess_exec rsync (separate repo)
+
+### 5. File Browser Move/Delete (file_browser.py:317,338)
+- `shutil.move`, `shutil.rmtree`
+- In threadpool (PR #150), acceptable for user-initiated ops
+
+### 6. Maintenance (maintenance.py:185,240)
+- `shutil.rmtree` on media paths
+- Infrequent, acceptable
+
+## Fix Strategy
+
+### Stats/File Browser: Cached Disk Usage
+- Background thread refreshes disk usage every 30s via subprocess
+- Subprocess has a 3s timeout - if NFS stalls, serves stale cache
+- API endpoint reads from cache (never calls statvfs directly)
+- Subprocess can be abandoned (unlike threads, D-state subprocesses
+  don't block the parent)
+
+### Rip Copy: rsync Subprocess
+- Replace `shutil.copy2` loop with `rsync` subprocess
+- Parse rsync progress output for per-file status updates
+- Subprocess can be killed if stalled (timeout)
+- ARM API stays responsive because it's not doing the I/O
+
+### Transcoder: asyncio Subprocess (separate repo)
+- Replace `shutil.copytree/move` with `asyncio.create_subprocess_exec`
+  running rsync
+- Event loop stays responsive
+- Health endpoint stays alive during copies

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1780,7 +1780,7 @@ class TestApiTranscodeConfig:
             f'/api/v1/jobs/{sample_job.job_id}/transcode-config',
             json=""
         )
-        assert response.status_code in (400, 422)
+        assert response.status_code == 422
 
     def test_transcode_config_unknown_key(self, client, sample_job, app_context):
         response = client.patch(

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -763,7 +763,7 @@ class TestApiFilesRename:
 
     def test_rename_missing_fields(self, client, app_context):
         response = client.post('/api/v1/files/rename', json={"path": "/home/arm/media/old.mkv"})
-        assert response.status_code == 400
+        assert response.status_code == 422  # Pydantic validation
 
     def test_rename_access_denied(self, client, app_context):
         with unittest.mock.patch("arm.services.file_browser.rename_item",
@@ -806,7 +806,7 @@ class TestApiFilesMove:
 
     def test_move_missing_fields(self, client, app_context):
         response = client.post('/api/v1/files/move', json={"path": "/home/arm/media/file.mkv"})
-        assert response.status_code == 400
+        assert response.status_code == 422  # Pydantic validation
 
     def test_move_access_denied(self, client, app_context):
         with unittest.mock.patch("arm.services.file_browser.move_item",
@@ -849,7 +849,7 @@ class TestApiFilesMkdir:
 
     def test_mkdir_missing_fields(self, client, app_context):
         response = client.post('/api/v1/files/mkdir', json={"path": "/home/arm/media"})
-        assert response.status_code == 400
+        assert response.status_code == 422  # Pydantic validation
 
     def test_mkdir_access_denied(self, client, app_context):
         with unittest.mock.patch("arm.services.file_browser.create_directory",
@@ -893,7 +893,7 @@ class TestApiFilesFixPermissions:
 
     def test_fix_perms_missing_path(self, client, app_context):
         response = client.post('/api/v1/files/fix-permissions', json={})
-        assert response.status_code == 400
+        assert response.status_code == 422  # Pydantic validation
 
     def test_fix_perms_access_denied(self, client, app_context):
         with unittest.mock.patch("arm.services.file_browser.fix_item_permissions",
@@ -929,7 +929,7 @@ class TestApiFilesDelete:
 
     def test_delete_missing_path(self, client, app_context):
         response = client.request('DELETE', '/api/v1/files/delete', json={})
-        assert response.status_code == 400
+        assert response.status_code == 422  # Pydantic validation
 
     def test_delete_access_denied(self, client, app_context):
         with unittest.mock.patch("arm.services.file_browser.delete_item",

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1780,7 +1780,7 @@ class TestApiTranscodeConfig:
             f'/api/v1/jobs/{sample_job.job_id}/transcode-config',
             json=""
         )
-        assert response.status_code == 400
+        assert response.status_code in (400, 422)
 
     def test_transcode_config_unknown_key(self, client, sample_job, app_context):
         response = client.patch(

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -995,13 +995,14 @@ class TestApiSystemStats:
             "COMPLETED_PATH": "/home/arm/media/completed",
         }
 
+        mock_usage = {"total": 500107862016, "used": 250053931008, "free": 250053931008, "percent": 50.0}
         with unittest.mock.patch("arm.api.v1.system.psutil.cpu_percent", return_value=25.0), \
              unittest.mock.patch("arm.api.v1.system.psutil.sensors_temperatures",
                                  return_value={}), \
              unittest.mock.patch("arm.api.v1.system.psutil.virtual_memory",
                                  return_value=mock_mem), \
-             unittest.mock.patch("arm.api.v1.system.psutil.disk_usage",
-                                 return_value=mock_disk), \
+             unittest.mock.patch("arm.services.disk_usage_cache.get_disk_usage",
+                                 return_value=mock_usage), \
              unittest.mock.patch("arm.api.v1.system.cfg.arm_config", config):
             response = client.get('/api/v1/system/stats')
         assert response.status_code == 200

--- a/test/test_file_browser.py
+++ b/test/test_file_browser.py
@@ -374,9 +374,9 @@ class TestAPIEndpoints:
         assert resp.status_code == 200
         assert resp.json()['success'] is True
 
-    def test_rename_missing_params_400(self, client, media_tree):
+    def test_rename_missing_params_422(self, client, media_tree):
         resp = client.post("/api/v1/files/rename", json={"path": "/some/path"})
-        assert resp.status_code == 400
+        assert resp.status_code == 422  # Pydantic validation error
 
     def test_move_success(self, client, media_tree):
         path = os.path.join(media_tree['roots']['music'], "album.flac")

--- a/test/test_files_api.py
+++ b/test/test_files_api.py
@@ -1,0 +1,289 @@
+"""Tests for arm/api/v1/files.py — file browser API endpoints.
+
+Verifies that file browser endpoints:
+1. Use sync def (not async def) so FastAPI runs them in a threadpool,
+   preventing event loop blocking during heavy I/O operations.
+2. Accept Pydantic request models instead of raw Request objects.
+3. Handle all error cases correctly (403, 404, 409, 500).
+4. Return correct success responses for all operations.
+"""
+import inspect
+import os
+import shutil
+import unittest.mock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def files_client(app_context):
+    from arm.api.v1.files import router
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def tmp_media_tree(tmp_path):
+    """Create a temporary media directory tree for file browser tests."""
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    completed = tmp_path / "completed"
+    completed.mkdir()
+    # Create some files and directories
+    movie_dir = raw / "Test Movie"
+    movie_dir.mkdir()
+    (movie_dir / "title.mkv").write_bytes(b"\x00" * 1024)
+    (raw / "orphan.mkv").write_bytes(b"\x00" * 512)
+    return {
+        "root": str(tmp_path),
+        "raw": str(raw),
+        "completed": str(completed),
+        "movie_dir": str(movie_dir),
+    }
+
+
+class TestHandlersAreSync:
+    """Verify all file browser handlers are sync (def, not async def).
+
+    FastAPI automatically runs sync def handlers in a threadpool via
+    anyio.to_thread.run_sync(). Async def handlers run directly on the
+    event loop — if they call blocking I/O (shutil.move, shutil.rmtree,
+    os.walk + chown), they block ALL other requests.
+
+    This is the root cause of API unresponsiveness during file operations.
+    """
+
+    def test_rename_handler_is_sync(self):
+        from arm.api.v1.files import rename_item
+        assert not inspect.iscoroutinefunction(rename_item), (
+            "rename_item must be sync (def, not async def) to avoid "
+            "blocking the event loop during filesystem operations"
+        )
+
+    def test_move_handler_is_sync(self):
+        from arm.api.v1.files import move_item
+        assert not inspect.iscoroutinefunction(move_item), (
+            "move_item must be sync (def, not async def) to avoid "
+            "blocking the event loop during large file moves"
+        )
+
+    def test_mkdir_handler_is_sync(self):
+        from arm.api.v1.files import create_directory
+        assert not inspect.iscoroutinefunction(create_directory), (
+            "create_directory must be sync (def, not async def) to avoid "
+            "blocking the event loop during directory creation"
+        )
+
+    def test_fix_permissions_handler_is_sync(self):
+        from arm.api.v1.files import fix_permissions
+        assert not inspect.iscoroutinefunction(fix_permissions), (
+            "fix_permissions must be sync (def, not async def) to avoid "
+            "blocking the event loop during recursive permission fixing"
+        )
+
+    def test_delete_handler_is_sync(self):
+        from arm.api.v1.files import delete_item
+        assert not inspect.iscoroutinefunction(delete_item), (
+            "delete_item must be sync (def, not async def) to avoid "
+            "blocking the event loop during directory tree deletion"
+        )
+
+    def test_get_roots_handler_is_sync(self):
+        from arm.api.v1.files import get_roots
+        assert not inspect.iscoroutinefunction(get_roots)
+
+    def test_list_directory_handler_is_sync(self):
+        from arm.api.v1.files import list_directory
+        assert not inspect.iscoroutinefunction(list_directory)
+
+
+class TestHandlersDoNotUseRawRequest:
+    """Verify handlers use Pydantic models, not raw Request objects.
+
+    Using raw Request objects forces async def (to await request.json()).
+    Pydantic models let FastAPI parse the body automatically in sync handlers.
+    """
+
+    def test_rename_does_not_take_request_param(self):
+        from arm.api.v1.files import rename_item
+        sig = inspect.signature(rename_item)
+        param_types = [p.annotation for p in sig.parameters.values()]
+        from fastapi import Request
+        assert Request not in param_types, (
+            "rename_item should use a Pydantic model, not Request"
+        )
+
+    def test_move_does_not_take_request_param(self):
+        from arm.api.v1.files import move_item
+        sig = inspect.signature(move_item)
+        param_types = [p.annotation for p in sig.parameters.values()]
+        from fastapi import Request
+        assert Request not in param_types, (
+            "move_item should use a Pydantic model, not Request"
+        )
+
+    def test_delete_does_not_take_request_param(self):
+        from arm.api.v1.files import delete_item
+        sig = inspect.signature(delete_item)
+        param_types = [p.annotation for p in sig.parameters.values()]
+        from fastapi import Request
+        assert Request not in param_types, (
+            "delete_item should use a Pydantic model, not Request"
+        )
+
+
+class TestFileOperations:
+    """Verify file browser endpoints work correctly end-to-end."""
+
+    def test_get_roots(self, app_context, files_client):
+        with unittest.mock.patch(
+            "arm.config.config.arm_config",
+            {"RAW_PATH": "/media/raw", "COMPLETED_PATH": "/media/completed",
+             "TRANSCODE_PATH": "/media/transcode", "MUSIC_PATH": "/media/music",
+             "INSTALLPATH": "/opt/arm/"},
+        ):
+            resp = files_client.get("/api/v1/files/roots")
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_list_directory(self, app_context, tmp_media_tree, files_client):
+        mock_cfg = {
+            "RAW_PATH": tmp_media_tree["raw"],
+            "COMPLETED_PATH": tmp_media_tree["completed"],
+            "TRANSCODE_PATH": "",
+            "MUSIC_PATH": "",
+        }
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            resp = files_client.get(
+                "/api/v1/files/list",
+                params={"path": tmp_media_tree["raw"]},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "entries" in data
+        names = [e["name"] for e in data["entries"]]
+        assert "Test Movie" in names
+
+    def test_list_directory_access_denied(self, app_context, files_client):
+        mock_cfg = {"RAW_PATH": "/media/raw", "COMPLETED_PATH": "/media/completed",
+                     "TRANSCODE_PATH": "", "MUSIC_PATH": ""}
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            resp = files_client.get(
+                "/api/v1/files/list",
+                params={"path": "/etc/passwd"},
+            )
+        assert resp.status_code == 403
+
+    def test_rename_success(self, app_context, tmp_media_tree, files_client):
+        mock_cfg = {
+            "RAW_PATH": tmp_media_tree["raw"],
+            "COMPLETED_PATH": tmp_media_tree["completed"],
+            "TRANSCODE_PATH": "",
+            "MUSIC_PATH": "",
+        }
+        target = os.path.join(tmp_media_tree["raw"], "orphan.mkv")
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            resp = files_client.post(
+                "/api/v1/files/rename",
+                json={"path": target, "new_name": "renamed.mkv"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_rename_missing_params(self, app_context, files_client):
+        resp = files_client.post("/api/v1/files/rename", json={"path": "/some/path"})
+        assert resp.status_code == 422  # Pydantic validation error
+
+    def test_move_success(self, app_context, tmp_media_tree, files_client):
+        mock_cfg = {
+            "RAW_PATH": tmp_media_tree["raw"],
+            "COMPLETED_PATH": tmp_media_tree["completed"],
+            "TRANSCODE_PATH": "",
+            "MUSIC_PATH": "",
+        }
+        src = os.path.join(tmp_media_tree["raw"], "orphan.mkv")
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            resp = files_client.post(
+                "/api/v1/files/move",
+                json={"path": src, "destination": tmp_media_tree["completed"]},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_mkdir_success(self, app_context, tmp_media_tree, files_client):
+        mock_cfg = {
+            "RAW_PATH": tmp_media_tree["raw"],
+            "COMPLETED_PATH": tmp_media_tree["completed"],
+            "TRANSCODE_PATH": "",
+            "MUSIC_PATH": "",
+        }
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            resp = files_client.post(
+                "/api/v1/files/mkdir",
+                json={"path": tmp_media_tree["raw"], "name": "New Folder"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        assert os.path.isdir(os.path.join(tmp_media_tree["raw"], "New Folder"))
+
+    def test_delete_success(self, app_context, tmp_media_tree, files_client):
+        mock_cfg = {
+            "RAW_PATH": tmp_media_tree["raw"],
+            "COMPLETED_PATH": tmp_media_tree["completed"],
+            "TRANSCODE_PATH": "",
+            "MUSIC_PATH": "",
+        }
+        target = os.path.join(tmp_media_tree["raw"], "orphan.mkv")
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            resp = files_client.request(
+                "DELETE",
+                "/api/v1/files/delete",
+                json={"path": target},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        assert not os.path.exists(target)
+
+    def test_delete_access_denied(self, app_context, files_client):
+        mock_cfg = {"RAW_PATH": "/media/raw", "COMPLETED_PATH": "/media/completed",
+                     "TRANSCODE_PATH": "", "MUSIC_PATH": ""}
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            resp = files_client.request(
+                "DELETE",
+                "/api/v1/files/delete",
+                json={"path": "/etc/passwd"},
+            )
+        assert resp.status_code == 403
+
+    def test_fix_permissions_access_denied(self, app_context, files_client):
+        mock_cfg = {"RAW_PATH": "/media/raw", "COMPLETED_PATH": "/media/completed",
+                     "TRANSCODE_PATH": "", "MUSIC_PATH": ""}
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            resp = files_client.post(
+                "/api/v1/files/fix-permissions",
+                json={"path": "/etc/passwd"},
+            )
+        assert resp.status_code == 403
+
+
+class TestDbSessionMiddleware:
+    """Verify that the app has DB session cleanup middleware."""
+
+    def test_app_has_session_cleanup_middleware(self):
+        """The app must clean up DB sessions after each request to prevent
+        leaked transaction state across recycled threadpool threads."""
+        from arm.app import app, SessionCleanupMiddleware
+        # Check user_middleware list for our middleware class
+        found = any(
+            m.cls is SessionCleanupMiddleware
+            for m in app.user_middleware
+            if hasattr(m, 'cls')
+        )
+        assert found, (
+            "App should have SessionCleanupMiddleware to prevent "
+            "leaked sessions across recycled threadpool threads"
+        )

--- a/test/test_services.py
+++ b/test/test_services.py
@@ -364,7 +364,8 @@ class TestGetsize:
         mock_stats.f_bavail = 1073741824  # 1 GB in blocks of size 1
         mock_stats.f_frsize = 1
 
-        with patch("arm.services.files.os.statvfs", return_value=mock_stats):
+        with patch("arm.services.disk_usage_cache.get_disk_usage", return_value=None), \
+             patch("arm.services.files.os.statvfs", return_value=mock_stats):
             result = getsize("/")
         assert result == pytest.approx(1.0)
 

--- a/test/test_utils_coverage.py
+++ b/test/test_utils_coverage.py
@@ -193,8 +193,9 @@ class TestMoveToSharedStorage:
         (tmp_path / "local" / "movie" / "file.mkv").write_bytes(b"data")
 
         cfg = {'LOCAL_RAW_PATH': local_raw, 'SHARED_RAW_PATH': shared_raw}
-        with unittest.mock.patch("shutil.copy2", side_effect=OSError("NFS write failed")):
-            with pytest.raises(OSError, match="NFS write failed"):
+        mock_result = unittest.mock.MagicMock(returncode=1, stderr="rsync: NFS write failed")
+        with unittest.mock.patch("arm.ripper.utils.subprocess.run", return_value=mock_result):
+            with pytest.raises(OSError, match="rsync failed"):
                 _move_to_shared_storage(cfg, "movie")
 
 


### PR DESCRIPTION
## Summary
16 API handlers were async def but only used await for request.json(). This forced blocking DB queries and service calls onto the event loop thread, freezing all request processing. Converted to sync def with body: dict so FastAPI runs them in a threadpool.

## Changes
- **jobs.py**: 11 handlers converted (config, title, tracks, naming, transcode, tvdb-match, callback)
- **drives.py**: 4 handlers converted (delete, update, eject, rescan)
- **system.py**: 1 handler converted (ripping-enabled)
- **test_api.py**: Updated empty body test to accept 422 (Pydantic validation)

## Not changed (properly async)
- **metadata.py**: 6 handlers - properly await async httpx calls
- **settings.py**: 3 handlers - properly use asyncio.to_thread
- **drives.py diagnostic/scan**: properly use asyncio.to_thread/create_subprocess_exec
- **files.py**: 5 handlers - addressed separately in PR #150

## Companion
PR #150 fixes files.py endpoints with the same pattern plus adds SessionCleanupMiddleware and Pydantic models. This PR can be merged independently or combined.

## Test plan
- [x] Full suite: 1665 passed
- [x] Verified no remaining improper async def handlers