### PR TITLE
ci: pre-release Docker images on release-please PRs

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,0 +1,88 @@
+name: Publish Pre-release Docker Image
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+    paths:
+      - "arm/**"
+      - "docker/**"
+      - "scripts/**"
+      - "setup/**"
+      - "Dockerfile"
+      - "requirements*.txt"
+      - "VERSION"
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
+concurrency:
+  group: prerelease-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  DOCKERHUB_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/automatic-ripping-machine
+  GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/automatic-ripping-machine-neu
+
+jobs:
+  prerelease:
+    if: startsWith(github.head_ref, 'release-please')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Read VERSION file
+        id: version
+        run: echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.version }}-rc
+            ${{ env.GHCR_IMAGE }}:${{ steps.version.outputs.version }}-rc
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}-rc
+
+      - name: Find existing pre-release comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: Pre-release image published
+
+      - name: Comment on PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            Pre-release image published:
+            - `${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.version }}-rc`
+            - `${{ env.GHCR_IMAGE }}:${{ steps.version.outputs.version }}-rc`

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "pull-request-header": "New release created",
   "packages": {
     ".": {
       "version-file": "VERSION"


### PR DESCRIPTION
## Summary
- Add `publish-prerelease.yml` workflow that builds and pushes `-rc` tagged Docker images when release-please opens or updates a PR targeting main
- Only triggers on release-please branches and when container-relevant files change (`arm/`, `docker/`, `scripts/`, `setup/`, `Dockerfile`, `requirements*.txt`, `VERSION`)
- Updates `release-please-config.json` with custom `pull-request-header`

## How it works
1. Release-please creates a PR bumping VERSION
2. The new workflow detects the PR from a `release-please` branch
3. It reads the VERSION file, builds the image, and pushes with a `-rc` tag
4. A comment is posted (or updated) on the PR with the image tags

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Confirm workflow only triggers on `release-please` branches
- [ ] Confirm `-rc` tag is applied correctly
- [ ] Verify PR comment is created and updated on subsequent pushes