### PR TITLE
fix: improve MakeMKV and rsync log levels for production visibility

### DIFF
--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -1617,15 +1617,28 @@ def run(options, select):
         logging.debug(f"PID {proc.pid}: command: '{' '.join(cmd)}'")
         for line in proc.stdout:
             line = line.rstrip(os.linesep)
-            logging.debug(line)  # Maybe write the raw output to a separate log
+            logging.debug(line)
             if proc.returncode:
                 buffer.append(line)
                 continue
             try:
                 msg_type, data = parse_line(line)
             except MakeMkvParserError:
-                continue  # Skip unrecognized lines (already logged at debug)
-            logging.debug(data)
+                continue
+            # Log key events at INFO so they appear in production logs.
+            # PRGV/PRGC/PRGT/SINFO/DRV stay at DEBUG (progress goes to
+            # the separate progress file, stream/drive details are noisy).
+            if msg_type == OutputType.TCOUNT:
+                logging.info(f"Found {data.count} titles")
+            elif msg_type == OutputType.TINFO:
+                if hasattr(data, 'id') and data.id == TrackID.FILENAME:
+                    logging.info(f"Title {data.tid}: {data.value}")
+            elif msg_type == OutputType.MSG:
+                logging.info(f"MakeMKV: {data.message}")
+            elif msg_type == OutputType.CINFO:
+                logging.debug(data)
+            else:
+                logging.debug(data)
             if msg_type in select:
                 yield data
     if proc.returncode:

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -173,14 +173,15 @@ def _move_to_shared_storage(cfg, raw_basename, job=None):
                 logging.error(f"rsync failed (exit {result.returncode}): {result.stderr}")
                 raise OSError(f"rsync failed: {result.stderr[:200]}")
 
-            # Log transferred files from rsync output
-            for line in result.stdout.strip().splitlines():
-                if line.strip():
-                    logging.info(f"rsync: {line.strip()}")
+            # Log individual transfer lines at DEBUG to avoid flooding
+            # the structured log with progress data
+            lines = [l.strip() for l in result.stdout.strip().splitlines() if l.strip()]
+            for line in lines:
+                logging.debug(f"rsync: {line}")
 
             # rsync --remove-source-files removes files but leaves empty dirs
             shutil.rmtree(src, ignore_errors=True)
-            logging.info(f"rsync complete: {src} -> {dst}")
+            logging.info(f"rsync complete: {src} -> {dst} ({len(lines)} files transferred)")
         except OSError as e:
             logging.error(f"Failed to move {src} -> {dst}: {e}")
             raise

--- a/test/test_logging_levels.py
+++ b/test/test_logging_levels.py
@@ -1,0 +1,202 @@
+"""Tests for logging level correctness.
+
+Verifies that key MakeMKV events are logged at INFO (visible in production)
+and that rsync progress lines are logged at DEBUG (not flooding structured logs).
+"""
+import logging
+import os
+import subprocess
+import unittest.mock
+
+import pytest
+
+
+class TestMakeMKVLogLevels:
+    """Verify MakeMKV output is logged at appropriate levels."""
+
+    def test_tcount_logged_at_info(self, caplog):
+        """Title count (TCOUNT) should be logged at INFO."""
+        from arm.ripper.makemkv import run, OutputType
+
+        # Mock makemkvcon to emit a TCOUNT line
+        mock_stdout = "TCOUNT:3\n"
+        mock_proc = unittest.mock.MagicMock()
+        mock_proc.stdout = iter(mock_stdout.splitlines(keepends=True))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+        mock_proc.__enter__ = lambda s: s
+        mock_proc.__exit__ = lambda s, *a: None
+
+        with (
+            unittest.mock.patch("subprocess.Popen", return_value=mock_proc),
+            unittest.mock.patch("shutil.which", return_value="/usr/bin/makemkvcon"),
+            caplog.at_level(logging.DEBUG),
+        ):
+            list(run(["info"], OutputType.TCOUNT))
+
+        info_messages = [r.message for r in caplog.records if r.levelno == logging.INFO]
+        assert any("Found 3 titles" in m for m in info_messages), (
+            f"TCOUNT should produce an INFO log. Got: {info_messages}"
+        )
+
+    def test_msg_logged_at_info(self, caplog):
+        """MakeMKV MSG output should be logged at INFO."""
+        from arm.ripper.makemkv import run, OutputType
+
+        mock_stdout = 'MSG:5010,0,0,"Copy complete - 1 titles saved.","%1 titles saved.","1"\n'
+        mock_proc = unittest.mock.MagicMock()
+        mock_proc.stdout = iter(mock_stdout.splitlines(keepends=True))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+        mock_proc.__enter__ = lambda s: s
+        mock_proc.__exit__ = lambda s, *a: None
+
+        with (
+            unittest.mock.patch("subprocess.Popen", return_value=mock_proc),
+            unittest.mock.patch("shutil.which", return_value="/usr/bin/makemkvcon"),
+            caplog.at_level(logging.DEBUG),
+        ):
+            list(run(["info"], OutputType.MSG))
+
+        info_messages = [r.message for r in caplog.records if r.levelno == logging.INFO]
+        assert any("MakeMKV:" in m for m in info_messages), (
+            f"MSG should produce an INFO log. Got: {info_messages}"
+        )
+
+    def test_prgv_stays_at_debug(self, caplog):
+        """Progress values (PRGV) should stay at DEBUG."""
+        from arm.ripper.makemkv import run, OutputType
+
+        mock_stdout = "PRGV:100,200,65536\n"
+        mock_proc = unittest.mock.MagicMock()
+        mock_proc.stdout = iter(mock_stdout.splitlines(keepends=True))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+        mock_proc.__enter__ = lambda s: s
+        mock_proc.__exit__ = lambda s, *a: None
+
+        with (
+            unittest.mock.patch("subprocess.Popen", return_value=mock_proc),
+            unittest.mock.patch("shutil.which", return_value="/usr/bin/makemkvcon"),
+            caplog.at_level(logging.DEBUG),
+        ):
+            list(run(["info"], OutputType.PRGV))
+
+        info_messages = [r.message for r in caplog.records if r.levelno == logging.INFO]
+        # PRGV should NOT appear in INFO logs (only in DEBUG)
+        prgv_in_info = [m for m in info_messages if "PRGV" in m or "100" in m and "200" in m]
+        assert not prgv_in_info, (
+            f"PRGV progress should NOT be logged at INFO. Found: {prgv_in_info}"
+        )
+
+    def test_sinfo_stays_at_debug(self, caplog):
+        """Stream info (SINFO) should stay at DEBUG."""
+        from arm.ripper.makemkv import run, OutputType
+
+        mock_stdout = 'SINFO:0,0,1,6201,"Video"\n'
+        mock_proc = unittest.mock.MagicMock()
+        mock_proc.stdout = iter(mock_stdout.splitlines(keepends=True))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+        mock_proc.__enter__ = lambda s: s
+        mock_proc.__exit__ = lambda s, *a: None
+
+        with (
+            unittest.mock.patch("subprocess.Popen", return_value=mock_proc),
+            unittest.mock.patch("shutil.which", return_value="/usr/bin/makemkvcon"),
+            caplog.at_level(logging.DEBUG),
+        ):
+            list(run(["info"], OutputType.SINFO))
+
+        info_messages = [r.message for r in caplog.records if r.levelno == logging.INFO]
+        sinfo_in_info = [m for m in info_messages if "SINFO" in m or "Video" in m]
+        assert not sinfo_in_info, (
+            f"SINFO should NOT be logged at INFO. Found: {sinfo_in_info}"
+        )
+
+
+class TestRsyncLogLevels:
+    """Verify rsync progress uses DEBUG, summaries use INFO."""
+
+    def test_rsync_progress_at_debug(self, tmp_path, caplog):
+        """Individual rsync transfer lines should be logged at DEBUG."""
+        from arm.ripper.utils import _move_to_shared_storage
+
+        local_raw = tmp_path / "local"
+        shared_raw = tmp_path / "shared"
+        local_raw.mkdir()
+        shared_raw.mkdir()
+        src_dir = local_raw / "test_movie"
+        src_dir.mkdir()
+        (src_dir / "title.mkv").write_bytes(b"\x00" * 100)
+
+        cfg = {
+            "LOCAL_RAW_PATH": str(local_raw),
+            "SHARED_RAW_PATH": str(shared_raw),
+        }
+
+        # Mock subprocess.run to simulate rsync output
+        mock_result = unittest.mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "title.mkv\n  100,000 100%  50.00MB/s    0:00:00\n"
+        mock_result.stderr = ""
+
+        with (
+            unittest.mock.patch("subprocess.run", return_value=mock_result),
+            unittest.mock.patch("shutil.rmtree"),
+            caplog.at_level(logging.DEBUG),
+        ):
+            _move_to_shared_storage(cfg, "test_movie")
+
+        debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        info_messages = [r.message for r in caplog.records if r.levelno == logging.INFO]
+
+        # Progress lines should be at DEBUG
+        rsync_debug = [m for m in debug_messages if "rsync:" in m]
+        assert len(rsync_debug) > 0, "rsync transfer lines should be at DEBUG"
+
+        # Progress lines should NOT be at INFO
+        rsync_info_progress = [m for m in info_messages if "rsync:" in m and "MB/s" in m]
+        assert not rsync_info_progress, (
+            f"rsync progress should NOT be at INFO. Found: {rsync_info_progress}"
+        )
+
+    def test_rsync_summary_at_info(self, tmp_path, caplog):
+        """rsync start and completion should be logged at INFO."""
+        from arm.ripper.utils import _move_to_shared_storage
+
+        local_raw = tmp_path / "local"
+        shared_raw = tmp_path / "shared"
+        local_raw.mkdir()
+        shared_raw.mkdir()
+        src_dir = local_raw / "test_movie"
+        src_dir.mkdir()
+        (src_dir / "title.mkv").write_bytes(b"\x00" * 100)
+
+        cfg = {
+            "LOCAL_RAW_PATH": str(local_raw),
+            "SHARED_RAW_PATH": str(shared_raw),
+        }
+
+        mock_result = unittest.mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "title.mkv\n"
+        mock_result.stderr = ""
+
+        with (
+            unittest.mock.patch("subprocess.run", return_value=mock_result),
+            unittest.mock.patch("shutil.rmtree"),
+            caplog.at_level(logging.DEBUG),
+        ):
+            _move_to_shared_storage(cfg, "test_movie")
+
+        info_messages = [r.message for r in caplog.records if r.levelno == logging.INFO]
+
+        # Start message
+        assert any("rsync" in m and "->" in m for m in info_messages), (
+            f"rsync start should be at INFO. Got: {info_messages}"
+        )
+        # Completion with file count
+        assert any("rsync complete" in m and "transferred" in m for m in info_messages), (
+            f"rsync complete with file count should be at INFO. Got: {info_messages}"
+        )


### PR DESCRIPTION
## Problem

MakeMKV output was entirely logged at DEBUG level - invisible in production logs (LOGLEVEL=INFO). Users couldn't see what MakeMKV was doing during a rip without switching to DEBUG, which floods logs with noise.

rsync file transfer progress was logged at INFO, flooding structured logs with dozens of per-file progress lines during shared storage copy.

## Changes

### MakeMKV (arm/ripper/makemkv.py)

Selectively promote key events in the run() generator:
- **INFO:** Title count (TCOUNT), per-title filenames (TINFO), MakeMKV messages (MSG)
- **DEBUG (unchanged):** Progress values (PRGV/PRGC/PRGT), stream info (SINFO), drive status (DRV), disc info (CINFO)

### rsync (arm/ripper/utils.py)

- **DEBUG:** Individual rsync transfer lines (file names, progress percentages)
- **INFO:** Start message and completion summary with file count

## Tests

6 new tests in test/test_logging_levels.py:
- TCOUNT logged at INFO
- MSG logged at INFO
- PRGV stays at DEBUG
- SINFO stays at DEBUG
- rsync progress at DEBUG
- rsync summary at INFO

All 1697 tests pass.