### PR TITLE
fix: async blocking audit — prevent NFS stalls in API

### DIFF
--- a/arm/api/v1/system.py
+++ b/arm/api/v1/system.py
@@ -172,7 +172,14 @@ def get_version():
 
 @router.get('/system/paths')
 def get_paths():
-    """Check existence and writability of configured ARM paths."""
+    """Check existence and writability of configured ARM paths.
+
+    Reads from the disk-usage cache to avoid blocking on stale NFS mounts.
+    Falls back to direct checks only for paths not yet in the cache (e.g.
+    DBFILE, LOGPATH which are local and won't stall).
+    """
+    from arm.services.disk_usage_cache import get_path_status, register_paths as _reg
+
     path_keys = [
         "RAW_PATH", "COMPLETED_PATH", "TRANSCODE_PATH",
         "LOGPATH", "DBFILE", "INSTALLPATH",
@@ -182,8 +189,22 @@ def get_paths():
         value = cfg.arm_config.get(key, "")
         if not value:
             continue
-        exists = os.path.exists(value)
-        writable = os.access(value, os.W_OK) if exists else False
+        status = get_path_status(value)
+        if status:
+            exists = status["exists"]
+            writable = status["writable"]
+        else:
+            # Path not in cache yet — register it and probe (with timeout).
+            # Local paths (DBFILE, LOGPATH) resolve instantly; NFS paths
+            # get a 5s timeout via the subprocess probe.
+            _reg([value])
+            status = get_path_status(value)
+            if status:
+                exists = status["exists"]
+                writable = status["writable"]
+            else:
+                exists = False
+                writable = False
         results.append({
             "setting": key,
             "path": value,

--- a/arm/app.py
+++ b/arm/app.py
@@ -39,6 +39,9 @@ async def lifespan(app: FastAPI):
         cfg.arm_config.get("RAW_PATH", ""),
         cfg.arm_config.get("TRANSCODE_PATH", ""),
         cfg.arm_config.get("COMPLETED_PATH", ""),
+        cfg.arm_config.get("LOGPATH", ""),
+        cfg.arm_config.get("DBFILE", ""),
+        cfg.arm_config.get("INSTALLPATH", ""),
     ])
     start_background_refresh()
 

--- a/arm/services/disk_usage_cache.py
+++ b/arm/services/disk_usage_cache.py
@@ -61,21 +61,41 @@ def get_disk_usage(path: str) -> dict | None:
     return None
 
 
+def get_path_status(path: str) -> dict | None:
+    """Return cached path existence/writability for *path*, or None if unavailable.
+
+    Never blocks on NFS — reads from the same cache populated by the
+    background subprocess probe.
+    """
+    with _cache_lock:
+        entry = _cache.get(path)
+    if entry and "exists" in entry:
+        return {"exists": entry["exists"], "writable": entry["writable"]}
+    return None
+
+
 def _refresh_path(path: str):
-    """Refresh disk usage for a single path using a subprocess with timeout."""
+    """Refresh disk usage and path status using a subprocess with timeout."""
     try:
         # Use a subprocess so D-state statvfs doesn't block our threads.
-        # The subprocess runs a tiny Python snippet that calls os.statvfs.
+        # The subprocess probes existence, writability, and disk usage in one call.
         result = subprocess.run(
             [
                 "python3", "-c",
                 "import os, json, sys; "
-                "s = os.statvfs(sys.argv[1]); "
-                "total = s.f_frsize * s.f_blocks; "
-                "free = s.f_frsize * s.f_bavail; "
-                "used = total - (s.f_frsize * s.f_bfree); "
-                "pct = round(used / total * 100, 1) if total else 0; "
-                "json.dump({'total': total, 'used': used, 'free': free, 'percent': pct}, sys.stdout)",
+                "p = sys.argv[1]; "
+                "e = os.path.exists(p); "
+                "w = os.access(p, os.W_OK) if e else False; "
+                "d = {'exists': e, 'writable': w}; "
+                "try:\n"
+                "  s = os.statvfs(p); "
+                "  d['total'] = s.f_frsize * s.f_blocks; "
+                "  d['free'] = s.f_frsize * s.f_bavail; "
+                "  d['used'] = d['total'] - (s.f_frsize * s.f_bfree); "
+                "  d['percent'] = round(d['used'] / d['total'] * 100, 1) if d['total'] else 0\n"
+                "except OSError:\n"
+                "  pass\n"
+                "json.dump(d, sys.stdout)",
                 path,
             ],
             capture_output=True,


### PR DESCRIPTION
## Summary

- **Convert async handlers to sync** in UI backend to prevent event loop blocking (file browser + other handlers)
- **Cached disk usage via subprocess probe** (`disk_usage_cache.py`) — background refresh every 30s with 5s timeout, so `statvfs()` on stalled NFS never blocks API threads
- **Protect `/system/paths` endpoint** — `os.path.exists()` and `os.access()` now go through the same cached subprocess probe instead of blocking directly
- **Rsync copy** for NFS-safe file transfer during rip completion
- **CodeQL fixes** — replace polynomial regex patterns in `arm_matcher.py`

## Details

NFS mounts can enter kernel D-state during large file operations, causing `statvfs()`, `os.path.exists()`, and `os.access()` to block indefinitely. Threads stuck in D-state cannot be interrupted, eventually exhausting the entire threadpool and making the API unresponsive.

The fix uses subprocess-based probes with timeouts. If a subprocess stalls on NFS, it can be abandoned without consuming a threadpool slot. All 6 configured paths (RAW_PATH, TRANSCODE_PATH, COMPLETED_PATH, LOGPATH, DBFILE, INSTALLPATH) are pre-registered at startup for background refresh.

## Test plan

- [x] All 1686 tests pass
- [ ] Deploy to hifi-server and verify `/system/paths` returns cached results
- [ ] Verify dashboard disk usage stats still update correctly
- [ ] Simulate NFS stall and confirm API remains responsive