### PR TITLE
fix: disk-usage cache subprocess SyntaxError breaks path checks

### DIFF
--- a/arm/services/disk_usage_cache.py
+++ b/arm/services/disk_usage_cache.py
@@ -40,7 +40,7 @@ def get_disk_usage(path: str) -> dict | None:
     """
     with _cache_lock:
         entry = _cache.get(path)
-    if entry:
+    if entry and "total" in entry:
         return {
             "total": entry["total"],
             "used": entry["used"],
@@ -51,7 +51,7 @@ def get_disk_usage(path: str) -> dict | None:
     _refresh_path(path)
     with _cache_lock:
         entry = _cache.get(path)
-    if entry:
+    if entry and "total" in entry:
         return {
             "total": entry["total"],
             "used": entry["used"],
@@ -74,30 +74,29 @@ def get_path_status(path: str) -> dict | None:
     return None
 
 
+_PROBE_SCRIPT = """\
+import os, json, sys
+p = sys.argv[1]
+e = os.path.exists(p)
+w = os.access(p, os.W_OK) if e else False
+d = {'exists': e, 'writable': w}
+try:
+    s = os.statvfs(p)
+    d['total'] = s.f_frsize * s.f_blocks
+    d['free'] = s.f_frsize * s.f_bavail
+    d['used'] = d['total'] - (s.f_frsize * s.f_bfree)
+    d['percent'] = round(d['used'] / d['total'] * 100, 1) if d['total'] else 0
+except OSError:
+    pass
+json.dump(d, sys.stdout)
+"""
+
+
 def _refresh_path(path: str):
     """Refresh disk usage and path status using a subprocess with timeout."""
     try:
-        # Use a subprocess so D-state statvfs doesn't block our threads.
-        # The subprocess probes existence, writability, and disk usage in one call.
         result = subprocess.run(
-            [
-                "python3", "-c",
-                "import os, json, sys; "
-                "p = sys.argv[1]; "
-                "e = os.path.exists(p); "
-                "w = os.access(p, os.W_OK) if e else False; "
-                "d = {'exists': e, 'writable': w}; "
-                "try:\n"
-                "  s = os.statvfs(p); "
-                "  d['total'] = s.f_frsize * s.f_blocks; "
-                "  d['free'] = s.f_frsize * s.f_bavail; "
-                "  d['used'] = d['total'] - (s.f_frsize * s.f_bfree); "
-                "  d['percent'] = round(d['used'] / d['total'] * 100, 1) if d['total'] else 0\n"
-                "except OSError:\n"
-                "  pass\n"
-                "json.dump(d, sys.stdout)",
-                path,
-            ],
+            ["python3", "-c", _PROBE_SCRIPT, path],
             capture_output=True,
             text=True,
             timeout=SUBPROCESS_TIMEOUT,


### PR DESCRIPTION
## Summary
- The `_refresh_path()` subprocess probe used string concatenation with escaped `\n` to build a `try/except` block in a `python3 -c` argument -- this produced a SyntaxError so the cache never populated
- All 6 paths (RAW_PATH, COMPLETED_PATH, TRANSCODE_PATH, LOGPATH, DBFILE, INSTALLPATH) showed "Missing" in Settings > System even though they exist and are writable
- Fix: use a proper multiline `_PROBE_SCRIPT` string constant and guard `get_disk_usage()` against empty cache entries left by `register_paths()`

## Test plan
- [x] All 174 existing API tests pass
- [x] Hotfix deployed and verified on hifi-server -- all paths now show OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)