### PR TITLE
feat: add pagination to metadata search

### DIFF
--- a/arm/api/v1/metadata.py
+++ b/arm/api/v1/metadata.py
@@ -89,11 +89,12 @@ async def crc_lookup_endpoint(crc64: str):
 async def search_metadata(
     q: str = Query(..., min_length=1),
     year: str | None = None,
+    page: int = Query(1, ge=1),
 ):
     """Search OMDb/TMDb for titles matching the query."""
-    log.debug("GET /metadata/search q=%r year=%s", q, year)
+    log.debug("GET /metadata/search q=%r year=%s page=%d", q, year, page)
     try:
-        return await search(q, year)
+        return await search(q, year, page=page)
     except MetadataConfigError as exc:
         log.warning("Metadata search failed (config): %s", exc)
         raise HTTPException(status_code=503, detail=str(exc))

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -129,9 +129,9 @@ async def test_configured_key(override_key: str | None = None, override_provider
         return {"success": False, "message": f"Test failed: {type(exc).__name__}", "provider": provider}
 
 
-async def search(query: str, year: str | None = None) -> list[dict[str, Any]]:
+async def search(query: str, year: str | None = None, page: int = 1) -> list[dict[str, Any]]:
     """Search for titles. Returns normalized list of SearchResult dicts."""
-    log.debug("Metadata search: query=%r year=%s", query, year)
+    log.debug("Metadata search: query=%r year=%s page=%d", query, year, page)
     keys = _get_keys()
     if keys["provider"] == "tmdb" and keys["tmdb_key"]:
         return await _tmdb_search(query, year, keys["tmdb_key"])
@@ -143,7 +143,7 @@ async def search(query: str, year: str | None = None) -> list[dict[str, Any]]:
                 "METADATA_PROVIDER is 'tmdb' but TMDB_API_KEY is not set and no OMDB_API_KEY fallback."
             )
     if keys["omdb_key"]:
-        return await _omdb_search(query, year, keys["omdb_key"])
+        return await _omdb_search(query, year, keys["omdb_key"], page=page)
     raise MetadataConfigError(
         f"No API key configured for metadata provider '{keys['provider']}'. "
         "Set OMDB_API_KEY or TMDB_API_KEY in arm.yaml."
@@ -408,10 +408,12 @@ def _extract_format(media: list[dict]) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-async def _omdb_search(query: str, year: str | None, api_key: str) -> list[dict[str, Any]]:
+async def _omdb_search(query: str, year: str | None, api_key: str, page: int = 1) -> list[dict[str, Any]]:
     params: dict[str, str] = {"s": query, "r": "json", "apikey": api_key}
     if year:
         params["y"] = year
+    if page > 1:
+        params["page"] = str(page)
     async with _http_client() as client:
         resp = await client.get(_OMDB_URL, params=params)
         if resp.status_code in (401, 403):

--- a/test/test_metadata_api.py
+++ b/test/test_metadata_api.py
@@ -42,7 +42,7 @@ class TestSearchEndpoint:
         with unittest.mock.patch('arm.api.v1.metadata.search', return_value=[]) as mock_fn:
             resp = client.get("/api/v1/metadata/search?q=Matrix&year=1999")
         assert resp.status_code == 200
-        mock_fn.assert_called_once_with("Matrix", "1999")
+        mock_fn.assert_called_once_with("Matrix", "1999", page=1)
 
     def test_missing_query(self, client):
         resp = client.get("/api/v1/metadata/search")

--- a/test/test_metadata_service.py
+++ b/test/test_metadata_service.py
@@ -272,7 +272,7 @@ class TestSearch:
         with unittest.mock.patch('arm.services.metadata._omdb_search',
                                  return_value=[{"title": "Test"}]) as mock_omdb:
             result = _run(search("Matrix", "1999"))
-            mock_omdb.assert_called_once_with("Matrix", "1999", "key123")
+            mock_omdb.assert_called_once_with("Matrix", "1999", "key123", page=1)
         assert result == [{"title": "Test"}]
 
     @unittest.mock.patch.dict('arm.config.config.arm_config', {
@@ -294,7 +294,7 @@ class TestSearch:
         with unittest.mock.patch('arm.services.metadata._omdb_search',
                                  return_value=[]) as mock_omdb:
             _run(search("Matrix"))
-            mock_omdb.assert_called_once_with("Matrix", None, "omdb_fallback")
+            mock_omdb.assert_called_once_with("Matrix", None, "omdb_fallback", page=1)
 
     @pytest.mark.parametrize("config", [
         {'METADATA_PROVIDER': 'tmdb', 'TMDB_API_KEY': '', 'OMDB_API_KEY': ''},


### PR DESCRIPTION
## Summary

- Add `page` query param to `GET /api/v1/metadata/search`
- Pass through to OMDb API `page` parameter
- Enables UI to paginate beyond the first 10 results

## Changes

- `arm/api/v1/metadata.py` — new `page` param (default 1)
- `arm/services/metadata.py` — thread `page` through `search()` and `_omdb_search()`