### PR TITLE
feat: separate scanning status from ripping on dashboard

### DIFF
--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -71,11 +71,13 @@ JOB_STATUS_FINISHED = {
     JobState.SUCCESS,
     JobState.FAILURE,
 }
-JOB_STATUS_RIPPING = {
+JOB_STATUS_SCANNING = {
     JobState.IDENTIFYING,
+}
+JOB_STATUS_RIPPING = {
     JobState.AUDIO_RIPPING,
     JobState.VIDEO_RIPPING,
-    JobState.MANUAL_WAIT_STARTED,  # <-- not ripping, but undistinguishable
+    JobState.MANUAL_WAIT_STARTED,
     JobState.VIDEO_WAITING,
     JobState.VIDEO_INFO,
     JobState.COPYING,

--- a/test/test_job_status_groups.py
+++ b/test/test_job_status_groups.py
@@ -1,0 +1,42 @@
+"""Tests for job status group definitions."""
+from arm.models.job import (
+    JobState,
+    JOB_STATUS_RIPPING,
+    JOB_STATUS_SCANNING,
+    JOB_STATUS_FINISHED,
+    JOB_STATUS_TRANSCODING,
+)
+
+
+class TestJobStatusGroups:
+    def test_identifying_not_in_ripping(self):
+        """IDENTIFYING should not be in the ripping group."""
+        assert JobState.IDENTIFYING not in JOB_STATUS_RIPPING
+
+    def test_identifying_in_scanning(self):
+        """IDENTIFYING should be in the scanning group."""
+        assert JobState.IDENTIFYING in JOB_STATUS_SCANNING
+
+    def test_scanning_group_exists(self):
+        """JOB_STATUS_SCANNING should be a non-empty set."""
+        assert len(JOB_STATUS_SCANNING) > 0
+
+    def test_no_overlap_scanning_ripping(self):
+        """Scanning and ripping groups must not overlap."""
+        assert JOB_STATUS_SCANNING.isdisjoint(JOB_STATUS_RIPPING)
+
+    def test_no_overlap_scanning_finished(self):
+        """Scanning and finished groups must not overlap."""
+        assert JOB_STATUS_SCANNING.isdisjoint(JOB_STATUS_FINISHED)
+
+    def test_no_overlap_scanning_transcoding(self):
+        """Scanning and transcoding groups must not overlap."""
+        assert JOB_STATUS_SCANNING.isdisjoint(JOB_STATUS_TRANSCODING)
+
+    def test_ripping_still_contains_video_ripping(self):
+        """VIDEO_RIPPING must remain in the ripping group."""
+        assert JobState.VIDEO_RIPPING in JOB_STATUS_RIPPING
+
+    def test_ripping_still_contains_audio_ripping(self):
+        """AUDIO_RIPPING must remain in the ripping group."""
+        assert JobState.AUDIO_RIPPING in JOB_STATUS_RIPPING


### PR DESCRIPTION
## Summary

- Move `IDENTIFYING` out of `JOB_STATUS_RIPPING` into new `JOB_STATUS_SCANNING` group
- Jobs in prescan/identification phase no longer appear as "Ripping"
- No new status values — just regrouping the existing `IDENTIFYING` status

## Test plan

- [x] 8 unit tests for status group membership (no overlap, correct grouping)
- [x] Full suite: 1759 passed, 0 failed