### PR TITLE
fix: gracefully handle read-only config during startup migration

### DIFF
--- a/arm/config/config.py
+++ b/arm/config/config.py
@@ -67,9 +67,11 @@ if len(cur_cfg) != len(new_cfg):
             arm_cfg += config_utils.arm_yaml_test_bool(key, value)
 
     # this handles the truncation
-    with open(arm_config_path, "w") as settings_file:
-        settings_file.write(arm_cfg)
-        settings_file.close()
+    try:
+        with open(arm_config_path, "w") as settings_file:
+            settings_file.write(arm_cfg)
+    except OSError:
+        pass  # config may be read-only (e.g. Docker bind-mount)
 
 arm_config = _load_config(arm_config_path)
 


### PR DESCRIPTION
## Summary
- Wrap arm.yaml write during config migration in `try/except OSError` so startup doesn't crash when config is mounted read-only (e.g. Docker bind-mount)
- The API settings layer already handled this; the startup migration path did not
- Also removes redundant explicit `file.close()` — `with`-statement handles cleanup

## Upstream audit
Reviewed upstream PR automatic-ripping-machine/automatic-ripping-machine#1696 and subsequent commits. Of 4 potential enhancements:

| Upstream PR | Enhancement | Status |
|-------------|------------|--------|
| #1698 | Main feature sort by chapters/filesize | Already surpassed (4-tier sort vs 3) |
| #1699 | Unparsed makemkvcon lines | Already surpassed (prevent buffering vs post-check) |
| #1692 | Mount drive fix | Already surpassed (12-retry with backoff) |
| Read-only config | Graceful read-only config handling | **Adopted here** |

## Test plan
- [ ] 1759 tests pass locally
- [ ] Verify startup with read-only arm.yaml doesn't crash