### PR TITLE
feat: orphaned job cleanup on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY ./scripts/docker/runsv/armui.sh /etc/service/armui/run
 
 # Startup scripts
 COPY ./scripts/docker/runit/arm_user_files_setup.sh /etc/my_init.d/arm_user_files_setup.sh
+COPY ./scripts/docker/runit/cleanup_orphaned_jobs.sh /etc/my_init.d/cleanup_orphaned_jobs.sh
 COPY ./scripts/docker/runit/start_udev.sh /etc/my_init.d/start_udev.sh
 
 # Modified udev for container

--- a/arm/services/job_cleanup.py
+++ b/arm/services/job_cleanup.py
@@ -1,0 +1,58 @@
+"""Orphaned job cleanup — runs once on container startup.
+
+Detects ARM-owned jobs stuck in intermediate states (identifying, ripping,
+waiting, etc.) after a container restart and marks them as failed. Transcoder-
+owned states (transcoding, waiting_transcode) are left untouched.
+
+Uses the existing clean_old_jobs() for PID-based detection first, then
+sweeps for any remaining orphans (e.g. folder imports with no PID).
+"""
+
+import logging
+
+from arm.database import db
+from arm.models.job import Job, JobState, JOB_STATUS_FINISHED, JOB_STATUS_TRANSCODING
+from arm.ripper.utils import clean_old_jobs
+
+logger = logging.getLogger(__name__)
+
+RESTART_ERROR = "ARM restarted \u2014 process lost. Re-insert disc to retry."
+
+
+def cleanup_orphaned_jobs() -> int:
+    """Fail ARM-owned jobs left in intermediate states after a restart.
+
+    Returns the number of jobs cleaned up.
+    """
+    # Phase 1: PID-based cleanup for jobs that have a PID recorded
+    clean_old_jobs()
+
+    # Phase 2: Catch-all for remaining ARM-owned intermediate jobs
+    # (covers folder imports with no PID, or jobs where PID was never set)
+    skip_states = {s.value for s in JOB_STATUS_FINISHED | JOB_STATUS_TRANSCODING}
+    orphans = (
+        db.session.query(Job)
+        .filter(Job.status.notin_(skip_states))
+        .all()
+    )
+
+    count = 0
+    for job in orphans:
+        logger.info(
+            "Orphaned job %d (%s) in state '%s' — marking as failed",
+            job.job_id, job.title, job.status,
+        )
+        job.status = JobState.FAILURE.value
+        job.errors = RESTART_ERROR
+        if job.drive is not None:
+            try:
+                job.drive.release_current_job()
+            except Exception:
+                logger.warning("Failed to release drive for job %d", job.job_id, exc_info=True)
+        count += 1
+
+    if count:
+        db.session.commit()
+        logger.info("Cleaned up %d orphaned job(s)", count)
+
+    return count

--- a/arm/services/job_cleanup.py
+++ b/arm/services/job_cleanup.py
@@ -12,7 +12,7 @@ import logging
 
 from arm.database import db
 from arm.models.job import Job, JobState, JOB_STATUS_FINISHED, JOB_STATUS_TRANSCODING
-from arm.ripper.utils import clean_old_jobs
+from arm.ripper.utils import clean_old_jobs, notify
 
 logger = logging.getLogger(__name__)
 
@@ -54,5 +54,16 @@ def cleanup_orphaned_jobs() -> int:
     if count:
         db.session.commit()
         logger.info("Cleaned up %d orphaned job(s)", count)
+
+        # Send summary notification
+        titles = ", ".join(j.title or f"Job {j.job_id}" for j in orphans)
+        try:
+            notify(
+                None,
+                f"ARM Startup: {count} orphaned job(s) cleaned up",
+                f"Failed jobs: {titles}",
+            )
+        except Exception:
+            logger.warning("Could not send orphan cleanup notification", exc_info=True)
 
     return count

--- a/scripts/docker/runit/cleanup_orphaned_jobs.sh
+++ b/scripts/docker/runit/cleanup_orphaned_jobs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# One-shot cleanup of orphaned jobs on container startup.
+# Runs after arm_user_files_setup.sh, before start_udev.sh (alphabetical order).
+# Must NOT block container startup — a failed cleanup is logged and skipped.
+
+echo "[ARM] Cleaning up orphaned jobs from previous run..."
+
+cd /opt/arm
+
+# Run cleanup as the arm user with the same Python environment.
+# Errors are caught so the container always boots even if the DB is missing.
+if /sbin/setuser arm /bin/python3 -c "
+import logging
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+import arm.config.config as cfg
+from arm.database import db
+db.init_engine('sqlite:///' + cfg.arm_config['DBFILE'])
+
+from arm.services.job_cleanup import cleanup_orphaned_jobs
+count = cleanup_orphaned_jobs()
+if count:
+    print(f'[ARM] Cleaned up {count} orphaned job(s)')
+else:
+    print('[ARM] No orphaned jobs found')
+"; then
+    echo "[ARM] Orphaned job cleanup complete"
+else
+    echo "[ARM] WARNING: Orphaned job cleanup failed — continuing startup"
+fi

--- a/test/test_orphan_cleanup.py
+++ b/test/test_orphan_cleanup.py
@@ -170,6 +170,27 @@ class TestCleanupOrphanedJobs:
         count = cleanup_orphaned_jobs()
         assert count == 0
 
+    @patch("arm.services.job_cleanup.notify")
+    def test_notification_sent_when_orphans_found(self, mock_notify, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.IDENTIFYING.value
+        sample_job.title = "Test Movie"
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        cleanup_orphaned_jobs()
+
+        mock_notify.assert_called_once()
+        call_args = mock_notify.call_args
+        assert "1 orphaned" in call_args[0][1]
+        assert "Test Movie" in call_args[0][2]
+
+    @patch("arm.services.job_cleanup.notify")
+    def test_no_notification_when_no_orphans(self, mock_notify, mock_clean, app_context):
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        cleanup_orphaned_jobs()
+
+        mock_notify.assert_not_called()
+
     def test_multiple_orphans(self, mock_clean, app_context):
         from arm.services.job_cleanup import cleanup_orphaned_jobs
 

--- a/test/test_orphan_cleanup.py
+++ b/test/test_orphan_cleanup.py
@@ -1,0 +1,197 @@
+"""Tests for orphaned job cleanup on container startup."""
+
+import unittest.mock
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from arm.models.job import Job, JobState
+from arm.database import db
+
+
+@patch("arm.services.job_cleanup.clean_old_jobs")
+class TestCleanupOrphanedJobs:
+    """Test cleanup_orphaned_jobs() marks ARM-owned stuck jobs as failed."""
+
+    def test_identifying_job_gets_failed(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.IDENTIFYING.value
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.status == JobState.FAILURE.value
+        assert "ARM restarted" in sample_job.errors
+        assert count == 1
+
+    def test_ripping_job_gets_failed(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.VIDEO_RIPPING.value
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.status == JobState.FAILURE.value
+        assert count == 1
+
+    def test_waiting_job_gets_failed(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.MANUAL_WAIT_STARTED.value
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.status == JobState.FAILURE.value
+        assert count == 1
+
+    def test_ready_job_gets_failed(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.IDLE.value
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.status == JobState.FAILURE.value
+        assert count == 1
+
+    def test_ejecting_job_gets_failed(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.EJECTING.value
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.status == JobState.FAILURE.value
+        assert count == 1
+
+    def test_copying_job_gets_failed(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.COPYING.value
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.status == JobState.FAILURE.value
+        assert count == 1
+
+    def test_info_job_gets_failed(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.VIDEO_INFO.value
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.status == JobState.FAILURE.value
+        assert count == 1
+
+    def test_transcoding_job_not_touched(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.TRANSCODE_ACTIVE.value
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.status == JobState.TRANSCODE_ACTIVE.value
+        assert count == 0
+
+    def test_waiting_transcode_job_not_touched(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.TRANSCODE_WAITING.value
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.status == JobState.TRANSCODE_WAITING.value
+        assert count == 0
+
+    def test_success_job_not_touched(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.SUCCESS.value
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.status == JobState.SUCCESS.value
+        assert count == 0
+
+    def test_failed_job_not_touched(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.FAILURE.value
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.status == JobState.FAILURE.value
+        assert count == 0
+
+    def test_error_message_set(self, mock_clean, app_context, sample_job):
+        sample_job.status = JobState.IDENTIFYING.value
+        sample_job.errors = None
+        db.session.commit()
+
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        cleanup_orphaned_jobs()
+
+        db.session.refresh(sample_job)
+        assert sample_job.errors == "ARM restarted \u2014 process lost. Re-insert disc to retry."
+
+    def test_drive_released(self, mock_clean, app_context, sample_job):
+        mock_drive = MagicMock()
+        sample_job.status = JobState.VIDEO_RIPPING.value
+        db.session.commit()
+
+        # Patch the drive attribute after commit to avoid SQLAlchemy
+        # trying to persist the MagicMock as a relationship object.
+        with patch.object(type(sample_job), 'drive',
+                          new_callable=lambda: property(lambda self: mock_drive)):
+            from arm.services.job_cleanup import cleanup_orphaned_jobs
+            cleanup_orphaned_jobs()
+
+        mock_drive.release_current_job.assert_called_once()
+
+    def test_clean_old_jobs_called(self, mock_clean, app_context):
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        cleanup_orphaned_jobs()
+        mock_clean.assert_called_once()
+
+    def test_no_orphans_returns_zero(self, mock_clean, app_context):
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+        count = cleanup_orphaned_jobs()
+        assert count == 0
+
+    def test_multiple_orphans(self, mock_clean, app_context):
+        from arm.services.job_cleanup import cleanup_orphaned_jobs
+
+        with unittest.mock.patch.object(Job, 'parse_udev'), \
+             unittest.mock.patch.object(Job, 'get_pid'):
+            job1 = Job('/dev/sr0')
+        job1.status = JobState.IDENTIFYING.value
+        job1.title = "Movie A"
+        db.session.add(job1)
+
+        with unittest.mock.patch.object(Job, 'parse_udev'), \
+             unittest.mock.patch.object(Job, 'get_pid'):
+            job2 = Job('/dev/sr1')
+        job2.status = JobState.VIDEO_RIPPING.value
+        job2.title = "Movie B"
+        db.session.add(job2)
+        db.session.commit()
+
+        count = cleanup_orphaned_jobs()
+        assert count == 2
+
+        db.session.refresh(job1)
+        db.session.refresh(job2)
+        assert job1.status == JobState.FAILURE.value
+        assert job2.status == JobState.FAILURE.value


### PR DESCRIPTION
## Summary
- Detect ARM-owned jobs stuck in intermediate states after container restart
- Mark them as failed with descriptive error message ("ARM restarted — process lost")
- Release associated drive locks
- Send summary notification listing cleaned-up jobs
- Init script runs before UI starts (phusion baseimage `/etc/my_init.d/` pattern)
- Graceful error handling — cleanup failure never blocks container boot

## Changes
- `arm/services/job_cleanup.py` — two-phase cleanup: PID-based (`clean_old_jobs()`) then catch-all sweep
- `scripts/docker/runit/cleanup_orphaned_jobs.sh` — one-shot init script
- `Dockerfile` — COPY for init script
- `test/test_orphan_cleanup.py` — 18 tests

## Test plan
- [x] All 18 new tests pass (ARM-owned states failed, transcoder/finished states skipped)
- [x] Full test suite (1777 tests) passes with no regressions
- [x] Notification sent only when orphans found
- [x] Drive released for orphaned jobs
- [x] `clean_old_jobs()` called in Phase 1
- [ ] Docker build succeeds (CI)
- [ ] Deploy to hifi-server and verify startup log shows cleanup message