### PR TITLE
feat: add per-drive rip speed setting

### DIFF
--- a/arm/api/v1/drives.py
+++ b/arm/api/v1/drives.py
@@ -47,6 +47,7 @@ def _drive_dict(d):
         "capabilities": _drive_capabilities(d),
         "uhd_capable": getattr(d, 'uhd_capable', False),
         "drive_mode": getattr(d, 'drive_mode', 'auto'),
+        "rip_speed": getattr(d, 'rip_speed', None),
         "stale": d.stale,
         "job_id_current": d.job_id_current,
         "job_id_previous": d.job_id_previous,
@@ -405,6 +406,20 @@ def update_drive(drive_id: int, body: dict):
             return JSONResponse({"success": False, "error": "drive_mode must be 'auto' or 'manual'"}, status_code=400)
         drive.drive_mode = mode
         updated['drive_mode'] = drive.drive_mode
+    if 'rip_speed' in body:
+        val = body['rip_speed']
+        if val is None:
+            drive.rip_speed = None
+            updated['rip_speed'] = None
+        else:
+            try:
+                speed = int(val)
+            except (ValueError, TypeError):
+                return JSONResponse({"success": False, "error": "rip_speed must be an integer or null"}, status_code=400)
+            if speed < 1 or speed > 99:
+                return JSONResponse({"success": False, "error": "rip_speed must be 1-99 (or null for max)"}, status_code=400)
+            drive.rip_speed = speed
+            updated['rip_speed'] = speed
 
     if not updated:
         return JSONResponse({"success": False, "error": "No valid fields provided"}, status_code=400)

--- a/arm/migrations/versions/l7m8n9o0p1q2_drive_rip_speed.py
+++ b/arm/migrations/versions/l7m8n9o0p1q2_drive_rip_speed.py
@@ -1,0 +1,23 @@
+"""Add per-drive rip_speed column to system_drives.
+
+Revision ID: l7m8n9o0p1q2
+Revises: k6l7m8n9o0p1
+Create Date: 2026-04-05
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'l7m8n9o0p1q2'
+down_revision = 'k6l7m8n9o0p1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('system_drives') as batch_op:
+        batch_op.add_column(sa.Column('rip_speed', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('system_drives') as batch_op:
+        batch_op.drop_column('rip_speed')

--- a/arm/models/system_drives.py
+++ b/arm/models/system_drives.py
@@ -124,6 +124,7 @@ class SystemDrives(db.Model):  # pylint: disable=too-many-instance-attributes
     name = db.Column(db.String(100))
     description = db.Column(db.Unicode(200))
     uhd_capable = db.Column(db.Boolean)
+    rip_speed = db.Column(db.Integer, nullable=True)  # MakeMKV read speed (None = max)
 
     def __init__(self):
         # mark drive info as outdated

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -1112,6 +1112,45 @@ def _resolve_mdisc(job):
         raise ValueError(f"No MakeMKV disc number for device {job.devpath}")
 
 
+def _apply_drive_rip_speed(job):
+    """Write per-drive rip speed to MakeMKV settings.conf before ripping.
+
+    MakeMKV uses settings.conf entries like:
+        speed_BD-RE_PIONEER_BD-RW__BDR-S12JX_1.01_SERIAL = "0=4"
+    where 0=all titles, value=speed multiplier (99=max).
+
+    If the drive has rip_speed set, find and update the matching speed line.
+    If no matching line exists, the speed stays at MakeMKV's default.
+    """
+    drive = getattr(job, 'drive', None)
+    if not drive:
+        return
+    speed = getattr(drive, 'rip_speed', None)
+    if speed is None:
+        return
+
+    settings_path = os.path.expanduser("~/.MakeMKV/settings.conf")
+    if not os.path.isfile(settings_path):
+        return
+
+    try:
+        with open(settings_path, "r") as f:
+            lines = f.readlines()
+
+        updated = False
+        for i, line in enumerate(lines):
+            if line.startswith("speed_"):
+                lines[i] = re.sub(r'"0=\d+"', f'"0={speed}"', line)
+                updated = True
+
+        if updated:
+            with open(settings_path, "w") as f:
+                f.writelines(lines)
+            logging.info("MakeMKV rip speed set to %d for drive %s", speed, drive.name or drive.mount)
+    except OSError as e:
+        logging.warning("Failed to set MakeMKV rip speed: %s", e)
+
+
 def makemkv(job):
     """
     Rip Blu-rays/DVDs with MakeMKV
@@ -1129,6 +1168,7 @@ def makemkv(job):
             f"Drive {job.devpath} not ready — disc may have been ejected"
         )
 
+    _apply_drive_rip_speed(job)
     prep_mkv()
     logging.info(f"Starting MakeMKV rip. Method is {job.config.RIPMETHOD}")
     _resolve_mdisc(job)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -585,6 +585,114 @@ class TestApiDriveUpdate:
             response = client.patch('/api/v1/drives/1', json={"invalid_field": "value"})
         assert response.status_code == 400
 
+    def test_update_rip_speed(self, client, app_context):
+        mock_drive = unittest.mock.MagicMock()
+        mock_drive.drive_id = 1
+        with unittest.mock.patch("arm.api.v1.drives.SystemDrives") as mock_sd, \
+             unittest.mock.patch("arm.api.v1.drives.db"):
+            mock_sd.query.get.return_value = mock_drive
+            response = client.patch('/api/v1/drives/1', json={"rip_speed": 4})
+        assert response.status_code == 200
+        assert mock_drive.rip_speed == 4
+
+    def test_update_rip_speed_null_clears(self, client, app_context):
+        mock_drive = unittest.mock.MagicMock()
+        mock_drive.drive_id = 1
+        with unittest.mock.patch("arm.api.v1.drives.SystemDrives") as mock_sd, \
+             unittest.mock.patch("arm.api.v1.drives.db"):
+            mock_sd.query.get.return_value = mock_drive
+            response = client.patch('/api/v1/drives/1', json={"rip_speed": None})
+        assert response.status_code == 200
+        assert mock_drive.rip_speed is None
+
+    def test_update_rip_speed_invalid(self, client, app_context):
+        mock_drive = unittest.mock.MagicMock()
+        mock_drive.drive_id = 1
+        with unittest.mock.patch("arm.api.v1.drives.SystemDrives") as mock_sd:
+            mock_sd.query.get.return_value = mock_drive
+            response = client.patch('/api/v1/drives/1', json={"rip_speed": 0})
+        assert response.status_code == 400
+
+    def test_update_rip_speed_too_high(self, client, app_context):
+        mock_drive = unittest.mock.MagicMock()
+        mock_drive.drive_id = 1
+        with unittest.mock.patch("arm.api.v1.drives.SystemDrives") as mock_sd:
+            mock_sd.query.get.return_value = mock_drive
+            response = client.patch('/api/v1/drives/1', json={"rip_speed": 100})
+        assert response.status_code == 400
+
+
+class TestApiDriveRipSpeed:
+    """Test rip_speed in drive listing endpoints."""
+
+    def test_drives_list_includes_rip_speed(self, client, sample_drives, app_context):
+        from arm.database import db
+        sample_drives[0].rip_speed = 4
+        db.session.commit()
+
+        response = client.get('/api/v1/drives')
+        data = response.json()
+        drive = next(d for d in data["drives"] if d["name"] == "Living Room")
+        assert drive["rip_speed"] == 4
+
+    def test_drives_list_null_rip_speed(self, client, sample_drives):
+        response = client.get('/api/v1/drives')
+        data = response.json()
+        drive = next(d for d in data["drives"] if d["name"] == "Living Room")
+        assert drive["rip_speed"] is None
+
+
+class TestApiApplyDriveRipSpeed:
+    """Test _apply_drive_rip_speed writes to settings.conf."""
+
+    def test_applies_speed(self, tmp_path, sample_job, app_context):
+        from arm.ripper.makemkv import _apply_drive_rip_speed
+        from arm.database import db
+        from arm.models.system_drives import SystemDrives
+
+        # Create a drive with rip_speed and assign to job
+        drive = SystemDrives()
+        drive.name = "Test"
+        drive.mount = "/dev/sr0"
+        drive.stale = False
+        drive.rip_speed = 4
+        db.session.add(drive)
+        db.session.flush()
+        sample_job.drive = drive
+        db.session.commit()
+
+        # Create fake settings.conf
+        settings = tmp_path / ".MakeMKV" / "settings.conf"
+        settings.parent.mkdir()
+        settings.write_text('app_Key = "test"\nspeed_DRIVE_ID = "0=99"\n')
+
+        with unittest.mock.patch("os.path.expanduser", return_value=str(settings)):
+            _apply_drive_rip_speed(sample_job)
+
+        content = settings.read_text()
+        assert '"0=4"' in content
+        assert '"0=99"' not in content
+
+    def test_no_speed_set_skips(self, sample_job, app_context):
+        from arm.ripper.makemkv import _apply_drive_rip_speed
+        from arm.database import db
+        from arm.models.system_drives import SystemDrives
+
+        drive = SystemDrives()
+        drive.name = "Test"
+        drive.mount = "/dev/sr0"
+        drive.stale = False
+        drive.rip_speed = None
+        db.session.add(drive)
+        db.session.flush()
+        sample_job.drive = drive
+        db.session.commit()
+
+        # Should not touch settings.conf at all
+        with unittest.mock.patch("builtins.open") as mock_open:
+            _apply_drive_rip_speed(sample_job)
+            mock_open.assert_not_called()
+
 
 class TestApiSettingsConfig:
     """Test GET /api/v1/settings/config endpoint."""


### PR DESCRIPTION
## Summary
- Add `rip_speed` column to SystemDrives model (nullable integer, 1-99, null=max)
- Before each MakeMKV rip, write the drive's speed to `~/.MakeMKV/settings.conf`
- Expose via `PATCH /drives/{id}` (set/clear) and `GET /drives` (read)
- DB migration included

## Why
Pioneer BDR-S12JX over USB 3.0 fails reading 4K UHD dual-layer discs at full speed. The laser can't reliably read the layer transition zone (~37GB) at max RPM. Reducing to 4x fixes it. This setting lets users configure read speed per-drive through the UI without manually editing MakeMKV config files inside the container.

## API Changes

**PATCH /drives/{id}** - new field:
- `rip_speed`: integer 1-99, or null to use max speed

**GET /drives** and **GET /drives/with-jobs** - new field in response:
- `rip_speed`: integer or null

## Implementation
- `_apply_drive_rip_speed(job)` called before `prep_mkv()` in the rip pipeline
- Reads `~/.MakeMKV/settings.conf`, finds `speed_*` lines, updates the value
- If drive has no `rip_speed` set (null), the setting is left unchanged
- Validation: 1-99 range, null to clear, non-integer rejected with 400

## Test plan
- [x] 8 new tests: PATCH validation (set, clear, invalid, too high), listing includes field, settings.conf write, skip when null
- [x] Full suite: 1785 passed