### PR TITLE
fix: resolve first-run permission failures and audio CD rip crash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,9 +35,8 @@ ARM_CPUSET=2,3,4,5,6,7
 # Set to false to disable the ~22 MB background download at container startup.
 ARM_COMMUNITY_KEYDB=true
 
-# Optical drives (uncomment and adjust)
-# ARM_DEVICE_0=/dev/sr0
-# ARM_DEVICE_1=/dev/sr1
+# Optical drives: the compose file mounts /dev:/dev so ALL drives are
+# visible automatically. No per-device configuration is needed.
 
 # --- Transcoder ---
 LOG_LEVEL=INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,18 @@ services:
       arm-hb-presets:
         condition: service_completed_successfully
 
+  # Fix ownership on the transcoder work directory before it starts.
+  # Docker creates bind-mount targets as root; the transcoder entrypoint
+  # does a shallow chown but cannot fix a root-owned top-level dir it
+  # doesn't own.  This one-shot container ensures the work dir is usable.
+  arm-transcoder-init:
+    image: alpine
+    container_name: arm-transcoder-init
+    volumes:
+      - ${TRANSCODER_WORK_PATH:-./work}:/data/work
+    command: chown -R ${ARM_UID:-1000}:${ARM_GID:-1000} /data/work
+    restart: "no"
+
   # GPU-accelerated transcoding service
   arm-transcoder:
     image: uprightbass360/arm-transcoder:${TRANSCODER_VERSION:-latest}
@@ -115,6 +127,9 @@ services:
     environment:
       - TZ=${TZ}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      # Match ARM's UID/GID so the transcoder can read raw files and write completed
+      - TRANSCODER_UID=${ARM_UID:-1000}
+      - TRANSCODER_GID=${ARM_GID:-1000}
       # Paths inside container
       - RAW_PATH=/data/raw
       - COMPLETED_PATH=/data/completed
@@ -161,6 +176,9 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+    depends_on:
+      arm-transcoder-init:
+        condition: service_completed_successfully
 
 volumes:
   arm-db:

--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -109,12 +109,14 @@ if [[ -h /home/arm/Music ]]; then
 fi
 
 ##### Setup ARM-specific config files if not found
-# Create config dir if missing, then verify ownership
+# Create config dir if missing, then fix ownership.
+# Docker bind-mounts create the target directory as root if it doesn't
+# exist on the host, so we always attempt chown before checking.
 if [[ ! -d /etc/arm/config ]]; then
   echo "Creating dir: /etc/arm/config"
   mkdir -p /etc/arm/config
-  chown arm:arm /etc/arm/config
 fi
+chown arm:arm /etc/arm/config 2>/dev/null || true
 check_folder_ownership "/etc/arm/config"
 CONFS="arm.yaml apprise.yaml"
 for conf in $CONFS; do

--- a/setup/.abcde.conf
+++ b/setup/.abcde.conf
@@ -544,10 +544,14 @@ mungefilename ()
 # Adjust albumname to not overwrite "Unkown Album" folders
 # for subsequent unknown discs.
 # 
-ID_SUFFIX=$(cd-discid $CDROM | cut -f1 -d ' ')
 mungealbumname ()
 {
-        mungefilename $(echo "$@" | sed s,'Unknown Album','Unknown Album_'$ID_SUFFIX,g)
+        # Defer cd-discid until abcde has set $CDROM from the -d argument.
+        # Running it at config load time hits the default /dev/cdrom which
+        # may not exist or may be a different drive.
+        local id_suffix
+        id_suffix=$(cd-discid "$CDROM" 2>/dev/null | cut -f1 -d ' ')
+        mungefilename $(echo "$@" | sed s,'Unknown Album','Unknown Album_'${id_suffix:-unknown},g)
 }
 
 # Custom genre munging:


### PR DESCRIPTION
## Summary
- Fix `/etc/arm/config` permission crash on first startup (chown before ownership check)
- Add `arm-transcoder-init` container to fix `/data/work` permission denied errors
- Pass `TRANSCODER_UID/GID` from `ARM_UID/GID` so transcoder runs as same user as ARM
- Fix audio CD rip crash (`cd-discid: /dev/cdrom: No medium found`) by deferring `cd-discid` call in abcde config until `$CDROM` is set from `-d` argument
- Remove dead `ARM_DEVICE_0`/`ARM_DEVICE_1` vars from `.env.example` (compose mounts `/dev:/dev`)

Companion PR: uprightbass360/automatic-ripping-machine-transcoder#XX (default UID alignment)

## Test plan
- [ ] Clean `docker compose down -v && docker compose up -d` starts without permission errors
- [ ] Transcoder work dir is writable (no `Permission denied: '/data/work/job-1'`)
- [ ] Audio CD rip completes on non-primary drive (e.g. `/dev/sr2`)
- [ ] Existing installs with custom abcde.conf are unaffected (setup script only copies if missing)