### PR TITLE
feat: setup wizard readiness check and settings health panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,9 +35,8 @@ ARM_CPUSET=2,3,4,5,6,7
 # Set to false to disable the ~22 MB background download at container startup.
 ARM_COMMUNITY_KEYDB=true
 
-# Optical drives (uncomment and adjust)
-# ARM_DEVICE_0=/dev/sr0
-# ARM_DEVICE_1=/dev/sr1
+# Optical drives: the compose file mounts /dev:/dev so ALL drives are
+# visible automatically. No per-device configuration is needed.
 
 # --- Transcoder ---
 LOG_LEVEL=INFO

--- a/arm/api/v1/system.py
+++ b/arm/api/v1/system.py
@@ -270,6 +270,26 @@ def check_makemkv_key():
     }
 
 
+@router.post('/system/preflight')
+async def preflight():
+    """Run all preflight checks: API keys, MakeMKV key, path permissions."""
+    from arm.services.preflight import run_checks
+    return await run_checks()
+
+
+@router.post('/system/preflight/fix')
+async def preflight_fix(body: dict):
+    """Attempt to fix specified issues, then re-run all checks."""
+    from arm.services.preflight import run_fixes
+    items = body.get("fix", [])
+    if not isinstance(items, list):
+        return JSONResponse(
+            {"success": False, "error": "'fix' must be a list"},
+            status_code=400,
+        )
+    return await run_fixes(items)
+
+
 @router.get('/system/stats/jobs')
 def get_job_stats():
     """Return job counts grouped by status and video type."""

--- a/arm/services/preflight.py
+++ b/arm/services/preflight.py
@@ -1,0 +1,346 @@
+"""Preflight readiness checks - API keys, MakeMKV key, path permissions.
+
+Orchestrates all startup checks and returns a unified response for the
+setup wizard and system health dashboard.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import arm.config.config as cfg
+
+log = logging.getLogger(__name__)
+
+# Env var fallback map: container prefix -> env var name
+_ENV_PATH_MAP: dict[str, str] = {
+    "/home/arm/media": "ARM_MEDIA_PATH",
+    "/etc/arm/config": "ARM_CONFIG_PATH",
+    "/home/arm/logs": "ARM_LOGS_PATH",
+    "/home/arm/music": "ARM_MUSIC_PATH",
+}
+
+
+def resolve_host_path(container_path: str) -> str | None:
+    """Resolve a container path to its host-side path.
+
+    Parses ``/proc/self/mountinfo`` to find the bind-mount source for
+    *container_path*.  Falls back to env var mapping when mountinfo is
+    unavailable or the path is not a direct mount point.
+
+    Returns ``None`` when no mapping can be determined.
+    """
+    if not container_path:
+        return None
+
+    # Strategy 1: parse /proc/self/mountinfo for bind-mount sources
+    try:
+        host = _parse_mountinfo(container_path)
+        if host is not None:
+            return host
+    except OSError:
+        pass
+
+    # Strategy 2: env var fallback
+    for prefix, env_var in _ENV_PATH_MAP.items():
+        if container_path == prefix or container_path.startswith(prefix + "/"):
+            host_base = os.environ.get(env_var)
+            if host_base:
+                suffix = container_path[len(prefix):]
+                return host_base + suffix
+    return None
+
+
+def _parse_mountinfo(container_path: str) -> str | None:
+    """Search /proc/self/mountinfo for bind-mount source of *container_path*.
+
+    Each line has the format (space-separated fields):
+      mount_id parent_id major:minor root mount_point ... - fs_type source ...
+
+    We look for lines where mount_point matches *container_path* (or is a
+    parent of it) and the source looks like an absolute host path.
+    """
+    best_mount = ""
+    best_source = None
+
+    with open("/proc/self/mountinfo") as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) < 5:
+                continue
+            mount_point = parts[4]
+            # Find the separator '-' to locate fs_type and source
+            try:
+                sep_idx = parts.index("-")
+            except ValueError:
+                continue
+            if sep_idx + 2 >= len(parts):
+                continue
+            source = parts[sep_idx + 2]
+
+            # Check if this mount_point is a prefix of container_path
+            if container_path == mount_point or container_path.startswith(
+                mount_point + "/"
+            ):
+                # Prefer the longest (most specific) mount point match
+                if len(mount_point) > len(best_mount) and source.startswith("/"):
+                    best_mount = mount_point
+                    best_source = source
+
+    if best_source is not None:
+        suffix = container_path[len(best_mount):]
+        return best_source + suffix
+    return None
+
+
+def check_path(
+    name: str,
+    path: str,
+    expected_uid: int,
+    expected_gid: int,
+) -> dict:
+    """Check a single path for existence, writability, and UID/GID ownership.
+
+    Returns a dict with all relevant status fields.
+    """
+    result: dict = {
+        "name": name,
+        "container_path": path,
+        "host_path": resolve_host_path(path),
+        "exists": False,
+        "writable": False,
+        "owner_uid": None,
+        "owner_gid": None,
+        "expected_uid": expected_uid,
+        "expected_gid": expected_gid,
+        "match": False,
+        "fixable": False,
+    }
+
+    if not path:
+        return result
+
+    try:
+        st = os.stat(path)
+    except OSError:
+        # Path does not exist - check if parent is fixable
+        result["fixable"] = _is_fixable(path)
+        return result
+
+    result["exists"] = True
+    result["writable"] = os.access(path, os.W_OK)
+    result["owner_uid"] = st.st_uid
+    result["owner_gid"] = st.st_gid
+    result["match"] = st.st_uid == expected_uid and st.st_gid == expected_gid
+
+    if not result["match"]:
+        result["fixable"] = _is_fixable(path)
+
+    return result
+
+
+def _is_fixable(path: str) -> bool:
+    """Determine whether we could fix ownership on *path*.
+
+    True when running as root, or when we own the parent directory.
+    """
+    if os.getuid() == 0:
+        return True
+    try:
+        parent = str(Path(path).parent)
+        parent_stat = os.stat(parent)
+        return parent_stat.st_uid == os.getuid()
+    except OSError:
+        return False
+
+
+# -------------------------------------------------------------------
+# Internal check helpers
+# -------------------------------------------------------------------
+
+
+async def _check_omdb_key() -> dict:
+    """Check the OMDB API key."""
+    key = cfg.arm_config.get("OMDB_API_KEY", "")
+    if not key or not str(key).strip():
+        return {"name": "omdb_key", "success": False, "message": "Not configured", "fixable": False}
+    from arm.services.metadata import test_configured_key
+    result = await test_configured_key(override_key=str(key).strip(), override_provider="omdb")
+    return {
+        "name": "omdb_key",
+        "success": result.get("success", False),
+        "message": result.get("message", "Unknown"),
+        "fixable": False,
+    }
+
+
+async def _check_tmdb_key() -> dict:
+    """Check the TMDB API key."""
+    key = cfg.arm_config.get("TMDB_API_KEY", "")
+    if not key or not str(key).strip():
+        return {"name": "tmdb_key", "success": False, "message": "Not configured", "fixable": False}
+    from arm.services.metadata import test_configured_key
+    result = await test_configured_key(override_key=str(key).strip(), override_provider="tmdb")
+    return {
+        "name": "tmdb_key",
+        "success": result.get("success", False),
+        "message": result.get("message", "Unknown"),
+        "fixable": False,
+    }
+
+
+async def _check_tvdb_key() -> dict:
+    """Check the TVDB API key."""
+    key = cfg.arm_config.get("TVDB_API_KEY", "")
+    if not key or not str(key).strip():
+        return {"name": "tvdb_key", "success": False, "message": "Not configured", "fixable": False}
+    from arm.services.tvdb import validate_tvdb_key
+    result = await validate_tvdb_key(str(key).strip())
+    return {
+        "name": "tvdb_key",
+        "success": result.get("success", False),
+        "message": result.get("message", "Unknown"),
+        "fixable": False,
+    }
+
+
+async def _check_makemkv_key() -> dict:
+    """Check the MakeMKV key via prep_mkv()."""
+    from arm.ripper.makemkv import UpdateKeyRunTimeError, UpdateKeyErrorCodes, prep_mkv
+
+    try:
+        prep_mkv()
+        return {
+            "name": "makemkv_key",
+            "success": True,
+            "message": "MakeMKV key is valid",
+            "fixable": True,
+        }
+    except UpdateKeyRunTimeError as exc:
+        code = UpdateKeyErrorCodes(exc.returncode)
+        messages = {
+            UpdateKeyErrorCodes.URL_ERROR: (
+                "Could not reach forum.makemkv.com - set MAKEMKV_PERMA_KEY "
+                "in arm.yaml to use a purchased key"
+            ),
+            UpdateKeyErrorCodes.PARSE_ERROR: "MakeMKV settings file is corrupt",
+            UpdateKeyErrorCodes.INTERNAL_ERROR: "Key update script produced invalid output",
+            UpdateKeyErrorCodes.INVALID_MAKEMKV_SERIAL: (
+                "Invalid MakeMKV serial key format - should match M-XXXX-..."
+            ),
+        }
+        return {
+            "name": "makemkv_key",
+            "success": False,
+            "message": messages.get(code, f"Key update failed (error {code.name})"),
+            "fixable": True,
+        }
+    except Exception as exc:
+        log.warning("MakeMKV key check failed unexpectedly: %s", exc)
+        return {
+            "name": "makemkv_key",
+            "success": False,
+            "message": f"Key check failed: {type(exc).__name__}",
+            "fixable": True,
+        }
+
+
+def _get_path_checks() -> list[dict]:
+    """Run ownership/permission checks on all configured paths."""
+    expected_uid = os.getuid()
+    expected_gid = os.getgid()
+
+    path_entries = [
+        ("RAW_PATH", cfg.arm_config.get("RAW_PATH", "")),
+        ("COMPLETED_PATH", cfg.arm_config.get("COMPLETED_PATH", "")),
+        ("TRANSCODE_PATH", cfg.arm_config.get("TRANSCODE_PATH", "")),
+        ("LOGPATH", cfg.arm_config.get("LOGPATH", "")),
+        ("DBFILE", cfg.arm_config.get("DBFILE", "")),
+        ("ARM_CONFIG", "/etc/arm/config"),
+    ]
+
+    results = []
+    for name, path in path_entries:
+        if not path:
+            continue
+        results.append(check_path(name, path, expected_uid, expected_gid))
+    return results
+
+
+# -------------------------------------------------------------------
+# Public API
+# -------------------------------------------------------------------
+
+
+async def run_checks() -> dict:
+    """Run all preflight checks and return a unified response.
+
+    Returns a dict with arm_uid, arm_gid, checks (API key statuses),
+    and paths (ownership/permission statuses).
+    """
+    checks = [
+        await _check_omdb_key(),
+        await _check_tmdb_key(),
+        await _check_tvdb_key(),
+        await _check_makemkv_key(),
+    ]
+
+    paths = _get_path_checks()
+
+    return {
+        "arm_uid": os.getuid(),
+        "arm_gid": os.getgid(),
+        "checks": checks,
+        "paths": paths,
+    }
+
+
+async def run_fixes(items: list[str]) -> dict:
+    """Attempt to fix specified items, then re-run all checks.
+
+    Supported item names:
+    - ``makemkv_key``: re-run prep_mkv() to fetch/update the key
+    - Any path name from _get_path_checks(): attempt chown to expected UID/GID
+
+    Returns the full run_checks() response after fixes are applied.
+    """
+    from arm.ripper.makemkv import prep_mkv
+
+    expected_uid = os.getuid()
+    expected_gid = os.getgid()
+    path_names = {
+        "RAW_PATH", "COMPLETED_PATH", "TRANSCODE_PATH",
+        "LOGPATH", "DBFILE", "ARM_CONFIG",
+    }
+
+    for item in items:
+        if item == "makemkv_key":
+            try:
+                prep_mkv()
+                log.info("MakeMKV key fix: prep_mkv() succeeded")
+            except Exception as exc:
+                log.warning("MakeMKV key fix failed: %s", exc)
+
+        elif item in path_names:
+            # Find the actual path for this name
+            path_map = {
+                "RAW_PATH": cfg.arm_config.get("RAW_PATH", ""),
+                "COMPLETED_PATH": cfg.arm_config.get("COMPLETED_PATH", ""),
+                "TRANSCODE_PATH": cfg.arm_config.get("TRANSCODE_PATH", ""),
+                "LOGPATH": cfg.arm_config.get("LOGPATH", ""),
+                "DBFILE": cfg.arm_config.get("DBFILE", ""),
+                "ARM_CONFIG": "/etc/arm/config",
+            }
+            path = path_map.get(item, "")
+            if path:
+                try:
+                    os.chown(path, expected_uid, expected_gid)
+                    log.info("Fixed ownership on %s (%s)", item, path)
+                except OSError as exc:
+                    log.warning("Cannot fix ownership on %s (%s): %s", item, path, exc)
+        else:
+            log.warning("Unknown fix item: %s", item)
+
+    return await run_checks()

--- a/arm/services/tvdb.py
+++ b/arm/services/tvdb.py
@@ -48,6 +48,31 @@ async def _ensure_token() -> str:
         return _TOKEN
 
 
+async def validate_tvdb_key(api_key: str) -> dict[str, str]:
+    """Test a TVDB API key by attempting login. Returns {success, message}."""
+    if not api_key or not api_key.strip():
+        return {"success": False, "message": "TVDB_API_KEY is empty"}
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(f"{_BASE}/login", json={"apikey": api_key.strip()})
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("data", {}).get("token"):
+                return {"success": True, "message": "TVDB API key is valid"}
+            return {"success": False, "message": "TVDB login returned no token"}
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            return {"success": False, "message": "Invalid TVDB API key"}
+        return {"success": False, "message": f"TVDB returned HTTP {exc.response.status_code}"}
+    except httpx.TimeoutException:
+        return {"success": False, "message": "TVDB request timed out - check network"}
+    except httpx.ConnectError:
+        return {"success": False, "message": "Cannot connect to TVDB - check network/DNS"}
+    except Exception as exc:
+        log.warning("TVDB key test failed: %s", exc)
+        return {"success": False, "message": f"Test failed: {type(exc).__name__}"}
+
+
 async def _get(path: str, params: dict | None = None) -> dict:
     """Authenticated GET request to TVDB v4 API."""
     token = await _ensure_token()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,11 @@ services:
       # Local SSD scratch for ripping (moved to shared storage after rip)
       - ARM_LOCAL_RAW_PATH=${ARM_LOCAL_RAW_PATH:-}
       - ARM_SHARED_RAW_PATH=${ARM_SHARED_RAW_PATH:-}
+      # Host path mapping for preflight health checks
+      - ARM_MEDIA_PATH=${ARM_MEDIA_PATH}
+      - ARM_CONFIG_PATH=${ARM_CONFIG_PATH}
+      - ARM_LOGS_PATH=${ARM_LOGS_PATH}
+      - ARM_MUSIC_PATH=${ARM_MUSIC_PATH}
     volumes:
       - ${ARM_MUSIC_PATH}:/home/arm/music
       - ${ARM_LOGS_PATH}:/home/arm/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,18 @@ services:
       arm-hb-presets:
         condition: service_completed_successfully
 
+  # Fix ownership on the transcoder work directory before it starts.
+  # Docker creates bind-mount targets as root; the transcoder entrypoint
+  # does a shallow chown but cannot fix a root-owned top-level dir it
+  # doesn't own.  This one-shot container ensures the work dir is usable.
+  arm-transcoder-init:
+    image: alpine
+    container_name: arm-transcoder-init
+    volumes:
+      - ${TRANSCODER_WORK_PATH:-./work}:/data/work
+    command: chown -R ${ARM_UID:-1000}:${ARM_GID:-1000} /data/work
+    restart: "no"
+
   # GPU-accelerated transcoding service
   arm-transcoder:
     image: uprightbass360/arm-transcoder:${TRANSCODER_VERSION:-latest}
@@ -115,6 +127,9 @@ services:
     environment:
       - TZ=${TZ}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      # Match ARM's UID/GID so the transcoder can read raw files and write completed
+      - TRANSCODER_UID=${ARM_UID:-1000}
+      - TRANSCODER_GID=${ARM_GID:-1000}
       # Paths inside container
       - RAW_PATH=/data/raw
       - COMPLETED_PATH=/data/completed
@@ -161,6 +176,9 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+    depends_on:
+      arm-transcoder-init:
+        condition: service_completed_successfully
 
 volumes:
   arm-db:

--- a/docs/superpowers/specs/2026-04-05-setup-wizard-health-panel-design.md
+++ b/docs/superpowers/specs/2026-04-05-setup-wizard-health-panel-design.md
@@ -1,0 +1,211 @@
+# Setup Wizard Readiness Check + Settings Health Panel
+
+## Goal
+
+Help first-time users reach a working state by validating API keys, MakeMKV registration, and path permissions before the first rip. Surface the same checks as an always-accessible health panel in Settings.
+
+## Context
+
+A first-time user deploying published images hit multiple issues that could have been caught at setup time: missing TVDB key, transcoder work dir owned by root (UID mismatch), and no feedback about what was wrong until reading container logs. The existing setup wizard (Welcome, Drives, Settings Review) skips over these validations.
+
+## Architecture
+
+### Backend (ARM-neu)
+
+One new endpoint, one extended endpoint, one new service function.
+
+#### `POST /api/v1/system/preflight`
+
+Unified check that validates all keys and paths in one call. Returns a consistent shape the UI can render directly.
+
+Response:
+
+```json
+{
+  "arm_uid": 1000,
+  "arm_gid": 1000,
+  "checks": [
+    { "name": "omdb_key",    "success": true,  "message": "OMDb API key is valid",          "fixable": false },
+    { "name": "tmdb_key",    "success": false, "message": "Not configured",                 "fixable": false },
+    { "name": "tvdb_key",    "success": false, "message": "TVDB login failed: unauthorized", "fixable": false },
+    { "name": "makemkv_key", "success": true,  "message": "MakeMKV key is valid",           "fixable": true  }
+  ],
+  "paths": [
+    {
+      "name": "RAW_PATH",
+      "container_path": "/home/arm/media/raw",
+      "host_path": "/home/arm/media/raw",
+      "exists": true,
+      "writable": true,
+      "owner_uid": 1000,
+      "owner_gid": 1000,
+      "expected_uid": 1000,
+      "expected_gid": 1000,
+      "match": true,
+      "fixable": false
+    }
+  ]
+}
+```
+
+Field notes:
+- `checks[].name` is a stable key the UI can use for icons and labels.
+- `checks[].fixable` indicates whether `POST /system/preflight/fix` can resolve it (see below).
+- `paths[].host_path` is resolved from `/proc/self/mountinfo` (bind-mounts) or falls back to env vars (`ARM_MEDIA_PATH`, `ARM_CONFIG_PATH`, etc.) passed via docker-compose. For named Docker volumes, shows the volume name.
+- `paths[].fixable` is true when ARM can chown the path from inside the container.
+- Unconfigured keys return `success: false` with message "Not configured" - these render as amber warnings, not red errors.
+- Each metadata key check only runs if a value is configured. Empty keys skip the API call.
+
+#### `POST /api/v1/system/preflight/fix`
+
+Attempts to fix issues ARM can resolve from inside the container.
+
+Request:
+
+```json
+{ "fix": ["makemkv_key", "TRANSCODE_PATH"] }
+```
+
+Response: same shape as preflight (re-runs all checks after fixes).
+
+Fixable items:
+- `makemkv_key` - calls existing `prep_mkv()` to fetch the current beta key.
+- Any path where ARM has ownership of the parent - runs `chown arm:arm <path>`.
+- Non-fixable items in the request array are silently skipped.
+
+#### TVDB key validation
+
+New function in `arm/services/tvdb.py`:
+
+```python
+async def test_tvdb_key(api_key: str) -> dict:
+    """Test a TVDB API key by attempting login. Returns {success, message}."""
+```
+
+Calls the existing `POST /v4/login` endpoint with the provided key. Returns success/failure with a human-readable message. The preflight endpoint calls this when `TVDB_API_KEY` is configured.
+
+#### Host path resolution
+
+New utility function in `arm/services/` (or `arm/api/v1/system.py` inline):
+
+```python
+def resolve_host_path(container_path: str) -> str | None:
+    """Resolve a container path to its host bind-mount source.
+
+    Parses /proc/self/mountinfo to find the host path for bind-mounts.
+    Falls back to known env var mappings (ARM_MEDIA_PATH, etc.).
+    Returns None for named Docker volumes (no meaningful host path).
+    """
+```
+
+Env var fallback mapping:
+- `/home/arm/media` -> `ARM_MEDIA_PATH` (already in compose env)
+- `/etc/arm/config` -> `ARM_CONFIG_PATH` (needs to be added to compose env)
+- `/home/arm/logs` -> `ARM_LOGS_PATH` (needs to be added to compose env)
+- `/home/arm/music` -> `ARM_MUSIC_PATH` (needs to be added to compose env)
+
+The compose file needs to pass these as env vars so the fallback works:
+```yaml
+- ARM_MEDIA_PATH=${ARM_MEDIA_PATH}
+- ARM_CONFIG_PATH=${ARM_CONFIG_PATH}
+- ARM_LOGS_PATH=${ARM_LOGS_PATH}
+- ARM_MUSIC_PATH=${ARM_MUSIC_PATH}
+```
+
+### Frontend (ARM-UI)
+
+#### Wizard Step: ReadinessCheck (new)
+
+New component: `frontend/src/lib/components/setup/ReadinessCheckStep.svelte`
+
+Inserted as step 3 of 4 (Welcome, Drives, **Readiness Check**, Settings Review).
+
+Behavior:
+- On mount, calls `POST /api/system/preflight` (proxied through UI backend).
+- Shows loading spinner during check.
+- Renders results in three sections: ARM Identity, API Keys, Paths & Permissions.
+- Each result row is green (pass), amber (not configured / warning), or red (failed / mismatch).
+- Red path rows show the exact `chown` command if not fixable, or a "Fix" button if fixable.
+- Amber API key rows show an inline input field + "Test" button + link to the provider's signup page.
+- "Re-run Checks" button re-calls preflight.
+- "Fix All" button appears when any items are fixable - calls `POST /system/preflight/fix` with all fixable items, then re-runs checks.
+- "Next" button is always enabled - warnings and errors do not block setup completion.
+
+Signup links:
+- OMDb: `https://www.omdbapi.com/apikey.aspx`
+- TMDb: `https://www.themoviedb.org/settings/api`
+- TVDB: `https://thetvdb.com/api-information`
+
+#### Settings Health Panel (new)
+
+New component: `frontend/src/lib/components/settings/SystemHealth.svelte`
+
+Added as the first section on the Settings page, above Metadata.
+
+Behavior:
+- **Not auto-run on page load.** Shows a "Run Checks" button in a neutral card.
+- After clicking, calls preflight and renders results.
+- **Collapsed when all pass:** single green summary line: "All checks passed - 4 keys valid, 5 paths writable, ARM running as 1000:1000 - Last checked 2 min ago". Expand arrow to see details.
+- **Auto-expanded when issues found:** problems at top (amber/red), passing checks dimmed below.
+- Failed path rows show host path + container path + owner UID:GID + expected UID:GID.
+- Failed path rows show copy-able `chown` command for host-level fixes, "Fix" button for container-fixable issues.
+- Failed/missing API key rows show inline input + "Test" button + signup link.
+- MakeMKV key failure shows "Update Key" button (calls preflight/fix).
+- "Fix All" button when fixable items exist.
+
+#### UI Backend Proxy
+
+New route in `backend/routers/system.py` (or existing settings router):
+- `POST /api/system/preflight` -> proxies to `http://arm-rippers:8080/api/v1/system/preflight`
+- `POST /api/system/preflight/fix` -> proxies to `http://arm-rippers:8080/api/v1/system/preflight/fix`
+
+#### API Key Inline Editing
+
+When a user enters a key in the health panel's inline input and clicks "Test":
+1. Call `GET /api/settings/test-metadata?key=<value>&provider=<provider>` (existing) for OMDB/TMDB.
+2. For TVDB, call the new test endpoint via preflight or a dedicated route.
+3. On success, save the key to config via `PUT /api/settings/arm` (existing).
+4. Re-run preflight to refresh all statuses.
+
+This reuses existing endpoints - no new config persistence logic needed.
+
+## Graceful Degradation
+
+- **Transcoder offline/absent:** Preflight does not probe the transcoder. Transcoder-related paths (TRANSCODE_PATH) are checked for local writability only. No transcoder-specific checks in the health panel. If transcoder becomes optional in the future, these path checks simply become irrelevant.
+- **DB not initialized:** Preflight works before the DB exists (key checks use arm.yaml, path checks use filesystem). MakeMKV key check writes to AppState but gracefully handles missing table.
+- **Network unreachable:** API key checks return `"Cannot connect to API"` messages, not exceptions. The UI shows these as red failures with a retry button.
+
+## Files Changed
+
+### ARM-neu (automatic-ripping-machine-neu)
+
+| Action | File | Change |
+|--------|------|--------|
+| New | `arm/api/v1/system.py` | Add `preflight` and `preflight/fix` endpoints |
+| New | `arm/services/preflight.py` | Preflight check orchestration, host path resolution |
+| Modify | `arm/services/tvdb.py` | Add `test_tvdb_key()` function |
+| Modify | `docker-compose.yml` | Pass `ARM_MEDIA_PATH`, `ARM_CONFIG_PATH`, `ARM_LOGS_PATH`, `ARM_MUSIC_PATH` as env vars to arm-rippers |
+
+### ARM-UI (automatic-ripping-machine-ui)
+
+| Action | File | Change |
+|--------|------|--------|
+| New | `frontend/src/lib/components/setup/ReadinessCheckStep.svelte` | Wizard step component |
+| Modify | `frontend/src/lib/components/setup/SetupWizard.svelte` | Add step 3, update step count |
+| New | `frontend/src/lib/components/settings/SystemHealth.svelte` | Health panel component |
+| Modify | `frontend/src/routes/settings/+page.svelte` | Import and render SystemHealth at top |
+| Modify | `frontend/src/lib/api/system.ts` | Add `runPreflight()` and `fixPreflight()` API calls |
+| Modify | `backend/routers/system.py` | Add preflight proxy routes |
+
+## Testing
+
+### Backend
+- Unit test `preflight.py`: mock key checks and path stats, verify response shape.
+- Unit test `test_tvdb_key()`: mock httpx to simulate login success, 401, timeout.
+- Unit test `resolve_host_path()`: mock `/proc/self/mountinfo` parsing, env var fallback.
+- Unit test fix endpoint: mock chown calls, verify re-check after fix.
+
+### Frontend
+- Component test `ReadinessCheckStep`: mock preflight response, verify green/amber/red rendering.
+- Component test `SystemHealth`: mock preflight, verify collapsed/expanded states.
+- Test inline key input: mock test-metadata call, verify save-on-success flow.

--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -109,12 +109,14 @@ if [[ -h /home/arm/Music ]]; then
 fi
 
 ##### Setup ARM-specific config files if not found
-# Create config dir if missing, then verify ownership
+# Create config dir if missing, then fix ownership.
+# Docker bind-mounts create the target directory as root if it doesn't
+# exist on the host, so we always attempt chown before checking.
 if [[ ! -d /etc/arm/config ]]; then
   echo "Creating dir: /etc/arm/config"
   mkdir -p /etc/arm/config
-  chown arm:arm /etc/arm/config
 fi
+chown arm:arm /etc/arm/config 2>/dev/null || true
 check_folder_ownership "/etc/arm/config"
 CONFS="arm.yaml apprise.yaml"
 for conf in $CONFS; do

--- a/setup/.abcde.conf
+++ b/setup/.abcde.conf
@@ -544,10 +544,14 @@ mungefilename ()
 # Adjust albumname to not overwrite "Unkown Album" folders
 # for subsequent unknown discs.
 # 
-ID_SUFFIX=$(cd-discid $CDROM | cut -f1 -d ' ')
 mungealbumname ()
 {
-        mungefilename $(echo "$@" | sed s,'Unknown Album','Unknown Album_'$ID_SUFFIX,g)
+        # Defer cd-discid until abcde has set $CDROM from the -d argument.
+        # Running it at config load time hits the default /dev/cdrom which
+        # may not exist or may be a different drive.
+        local id_suffix
+        id_suffix=$(cd-discid "$CDROM" 2>/dev/null | cut -f1 -d ' ')
+        mungefilename $(echo "$@" | sed s,'Unknown Album','Unknown Album_'${id_suffix:-unknown},g)
 }
 
 # Custom genre munging:

--- a/test/test_preflight.py
+++ b/test/test_preflight.py
@@ -1,0 +1,177 @@
+"""Tests for preflight readiness checks."""
+
+import asyncio
+import unittest.mock
+
+import httpx
+import pytest
+
+from arm.services.tvdb import validate_tvdb_key
+
+
+class TestTvdbKeyValidation:
+    """Test validate_tvdb_key() API key validation."""
+
+    def test_validate_tvdb_key_valid(self):
+        """Successful TVDB login returns success=True."""
+        mock_response = unittest.mock.MagicMock()
+        mock_response.json.return_value = {"data": {"token": "tok_abc123"}}
+        mock_response.raise_for_status = unittest.mock.MagicMock()
+
+        async def mock_post(url, json=None):
+            return mock_response
+
+        mock_client = unittest.mock.MagicMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__ = unittest.mock.AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+
+        with unittest.mock.patch("arm.services.tvdb.httpx.AsyncClient",
+                                 return_value=mock_client):
+            result = asyncio.run(validate_tvdb_key("valid-api-key-123"))
+
+        assert result["success"] is True
+        assert "valid" in result["message"].lower()
+
+    def test_validate_tvdb_key_invalid(self):
+        """401 response returns success=False with 'Invalid' message."""
+        mock_request = unittest.mock.MagicMock()
+        mock_resp = unittest.mock.MagicMock()
+        mock_resp.status_code = 401
+
+        async def mock_post(url, json=None):
+            raise httpx.HTTPStatusError(
+                "Unauthorized", request=mock_request, response=mock_resp
+            )
+
+        mock_client = unittest.mock.MagicMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__ = unittest.mock.AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+
+        with unittest.mock.patch("arm.services.tvdb.httpx.AsyncClient",
+                                 return_value=mock_client):
+            result = asyncio.run(validate_tvdb_key("bad-key"))
+
+        assert result["success"] is False
+        assert "Invalid" in result["message"]
+
+    def test_validate_tvdb_key_timeout(self):
+        """Timeout returns success=False with 'timeout' in message."""
+        async def mock_post(url, json=None):
+            raise httpx.ReadTimeout("timed out")
+
+        mock_client = unittest.mock.MagicMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__ = unittest.mock.AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+
+        with unittest.mock.patch("arm.services.tvdb.httpx.AsyncClient",
+                                 return_value=mock_client):
+            result = asyncio.run(validate_tvdb_key("some-key"))
+
+        assert result["success"] is False
+        assert "timed out" in result["message"].lower()
+
+    def test_validate_tvdb_key_empty(self):
+        """Empty API key returns failure without making a network call."""
+        result = asyncio.run(validate_tvdb_key(""))
+        assert result["success"] is False
+        assert "empty" in result["message"].lower()
+
+    def test_validate_tvdb_key_whitespace_only(self):
+        """Whitespace-only API key is treated as empty."""
+        result = asyncio.run(validate_tvdb_key("   "))
+        assert result["success"] is False
+        assert "empty" in result["message"].lower()
+
+    def test_validate_tvdb_key_none(self):
+        """None API key returns failure."""
+        result = asyncio.run(validate_tvdb_key(None))
+        assert result["success"] is False
+        assert "empty" in result["message"].lower()
+
+    def test_validate_tvdb_key_no_token_in_response(self):
+        """Login succeeds but response lacks a token."""
+        mock_response = unittest.mock.MagicMock()
+        mock_response.json.return_value = {"data": {}}
+        mock_response.raise_for_status = unittest.mock.MagicMock()
+
+        async def mock_post(url, json=None):
+            return mock_response
+
+        mock_client = unittest.mock.MagicMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__ = unittest.mock.AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+
+        with unittest.mock.patch("arm.services.tvdb.httpx.AsyncClient",
+                                 return_value=mock_client):
+            result = asyncio.run(validate_tvdb_key("some-key"))
+
+        assert result["success"] is False
+        assert "no token" in result["message"].lower()
+
+    def test_validate_tvdb_key_connect_error(self):
+        """Connection error returns failure with network message."""
+        async def mock_post(url, json=None):
+            raise httpx.ConnectError("DNS resolution failed")
+
+        mock_client = unittest.mock.MagicMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__ = unittest.mock.AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+
+        with unittest.mock.patch("arm.services.tvdb.httpx.AsyncClient",
+                                 return_value=mock_client):
+            result = asyncio.run(validate_tvdb_key("some-key"))
+
+        assert result["success"] is False
+        assert "connect" in result["message"].lower()
+
+    def test_validate_tvdb_key_server_error(self):
+        """Non-401 HTTP error returns the status code."""
+        mock_request = unittest.mock.MagicMock()
+        mock_resp = unittest.mock.MagicMock()
+        mock_resp.status_code = 500
+
+        async def mock_post(url, json=None):
+            raise httpx.HTTPStatusError(
+                "Internal Server Error", request=mock_request, response=mock_resp
+            )
+
+        mock_client = unittest.mock.MagicMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__ = unittest.mock.AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+
+        with unittest.mock.patch("arm.services.tvdb.httpx.AsyncClient",
+                                 return_value=mock_client):
+            result = asyncio.run(validate_tvdb_key("some-key"))
+
+        assert result["success"] is False
+        assert "500" in result["message"]
+
+    def test_validate_tvdb_key_strips_whitespace(self):
+        """API key with leading/trailing whitespace is stripped before use."""
+        mock_response = unittest.mock.MagicMock()
+        mock_response.json.return_value = {"data": {"token": "tok_abc"}}
+        mock_response.raise_for_status = unittest.mock.MagicMock()
+
+        posted_payloads = []
+
+        async def mock_post(url, json=None):
+            posted_payloads.append(json)
+            return mock_response
+
+        mock_client = unittest.mock.MagicMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__ = unittest.mock.AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+
+        with unittest.mock.patch("arm.services.tvdb.httpx.AsyncClient",
+                                 return_value=mock_client):
+            result = asyncio.run(validate_tvdb_key("  my-key  "))
+
+        assert result["success"] is True
+        assert posted_payloads[0]["apikey"] == "my-key"

--- a/test/test_preflight.py
+++ b/test/test_preflight.py
@@ -1,6 +1,7 @@
 """Tests for preflight readiness checks."""
 
 import asyncio
+import os
 import unittest.mock
 
 import httpx
@@ -175,3 +176,211 @@ class TestTvdbKeyValidation:
 
         assert result["success"] is True
         assert posted_payloads[0]["apikey"] == "my-key"
+
+
+# -------------------------------------------------------------------
+# Preflight service tests
+# -------------------------------------------------------------------
+
+from arm.services.preflight import resolve_host_path, check_path, run_checks
+
+
+class TestResolveHostPath:
+    """Test resolve_host_path() bind-mount parsing and env var fallback."""
+
+    def test_mountinfo_parsing(self, tmp_path):
+        """Finds host path from a /proc/self/mountinfo-style line."""
+        fake_mountinfo = (
+            "36 1 8:1 / /mnt rw - ext4 /dev/sda1 rw\n"
+            "100 36 0:50 / /home/arm/media rw - ext4 /host/media rw\n"
+        )
+        with unittest.mock.patch(
+            "builtins.open", unittest.mock.mock_open(read_data=fake_mountinfo)
+        ):
+            result = resolve_host_path("/home/arm/media")
+        assert result == "/host/media"
+
+    def test_mountinfo_subpath(self):
+        """Subpath under a bind mount resolves correctly."""
+        fake_mountinfo = (
+            "100 36 0:50 / /home/arm/media rw - ext4 /host/media rw\n"
+        )
+        with unittest.mock.patch(
+            "builtins.open", unittest.mock.mock_open(read_data=fake_mountinfo)
+        ):
+            result = resolve_host_path("/home/arm/media/raw/movie.mkv")
+        assert result == "/host/media/raw/movie.mkv"
+
+    def test_env_var_fallback(self):
+        """Falls back to env var when mountinfo is not available."""
+        with unittest.mock.patch(
+            "builtins.open", side_effect=OSError("no mountinfo")
+        ):
+            with unittest.mock.patch.dict(
+                os.environ, {"ARM_MEDIA_PATH": "/mnt/nas/media"}
+            ):
+                result = resolve_host_path("/home/arm/media")
+        assert result == "/mnt/nas/media"
+
+    def test_env_var_subpath(self):
+        """Env var fallback preserves the path suffix."""
+        with unittest.mock.patch(
+            "builtins.open", side_effect=OSError("no mountinfo")
+        ):
+            with unittest.mock.patch.dict(
+                os.environ, {"ARM_MEDIA_PATH": "/mnt/nas/media"}
+            ):
+                result = resolve_host_path("/home/arm/media/raw")
+        assert result == "/mnt/nas/media/raw"
+
+    def test_unknown_path_returns_none(self):
+        """Unknown path with no mountinfo and no env var returns None."""
+        with unittest.mock.patch(
+            "builtins.open", side_effect=OSError("no mountinfo")
+        ):
+            with unittest.mock.patch.dict(os.environ, {}, clear=False):
+                # Remove any ARM env vars that might interfere
+                env_clean = {
+                    k: v for k, v in os.environ.items()
+                    if k not in ("ARM_MEDIA_PATH", "ARM_CONFIG_PATH",
+                                 "ARM_LOGS_PATH", "ARM_MUSIC_PATH")
+                }
+                with unittest.mock.patch.dict(os.environ, env_clean, clear=True):
+                    result = resolve_host_path("/some/random/path")
+        assert result is None
+
+    def test_empty_path_returns_none(self):
+        """Empty container path returns None."""
+        result = resolve_host_path("")
+        assert result is None
+
+
+class TestCheckPath:
+    """Test check_path() existence, writability, and UID/GID checks."""
+
+    def test_existing_writable_path(self, tmp_path):
+        """Existing path with correct ownership passes all checks."""
+        uid = os.getuid()
+        gid = os.getgid()
+
+        with unittest.mock.patch(
+            "arm.services.preflight.resolve_host_path", return_value=None
+        ):
+            result = check_path("test_dir", str(tmp_path), uid, gid)
+
+        assert result["name"] == "test_dir"
+        assert result["exists"] is True
+        assert result["writable"] is True
+        assert result["owner_uid"] == uid
+        assert result["owner_gid"] == gid
+        assert result["match"] is True
+
+    def test_nonexistent_path(self):
+        """Non-existent path reports exists=False."""
+        with unittest.mock.patch(
+            "arm.services.preflight.resolve_host_path", return_value=None
+        ):
+            result = check_path(
+                "missing", "/nonexistent/path/xyz", os.getuid(), os.getgid()
+            )
+
+        assert result["exists"] is False
+        assert result["writable"] is False
+        assert result["owner_uid"] is None
+
+    def test_uid_mismatch(self, tmp_path):
+        """Path owned by a different UID reports match=False."""
+        uid = os.getuid()
+        gid = os.getgid()
+        wrong_uid = uid + 999
+
+        with unittest.mock.patch(
+            "arm.services.preflight.resolve_host_path", return_value=None
+        ):
+            result = check_path("test_dir", str(tmp_path), wrong_uid, gid)
+
+        assert result["exists"] is True
+        assert result["match"] is False
+        assert result["expected_uid"] == wrong_uid
+        assert result["owner_uid"] == uid
+
+
+class TestRunChecks:
+    """Test run_checks() response shape and content."""
+
+    def test_response_shape(self):
+        """run_checks() returns arm_uid, arm_gid, checks (4 items), paths."""
+        omdb_check = {"name": "omdb_key", "success": True, "message": "OK", "fixable": False}
+        tmdb_check = {"name": "tmdb_key", "success": False, "message": "Not configured", "fixable": False}
+        tvdb_check = {"name": "tvdb_key", "success": False, "message": "Not configured", "fixable": False}
+        makemkv_check = {"name": "makemkv_key", "success": True, "message": "Valid", "fixable": True}
+
+        mock_paths = [
+            {
+                "name": "RAW_PATH",
+                "container_path": "/home/arm/media/raw",
+                "host_path": None,
+                "exists": True,
+                "writable": True,
+                "owner_uid": 1000,
+                "owner_gid": 1000,
+                "expected_uid": 1000,
+                "expected_gid": 1000,
+                "match": True,
+                "fixable": False,
+            }
+        ]
+
+        async def fake_omdb():
+            return omdb_check
+
+        async def fake_tmdb():
+            return tmdb_check
+
+        async def fake_tvdb():
+            return tvdb_check
+
+        async def fake_makemkv():
+            return makemkv_check
+
+        with unittest.mock.patch("arm.services.preflight._check_omdb_key", fake_omdb), \
+             unittest.mock.patch("arm.services.preflight._check_tmdb_key", fake_tmdb), \
+             unittest.mock.patch("arm.services.preflight._check_tvdb_key", fake_tvdb), \
+             unittest.mock.patch("arm.services.preflight._check_makemkv_key", fake_makemkv), \
+             unittest.mock.patch("arm.services.preflight._get_path_checks", return_value=mock_paths):
+            result = asyncio.run(run_checks())
+
+        assert "arm_uid" in result
+        assert "arm_gid" in result
+        assert isinstance(result["arm_uid"], int)
+        assert isinstance(result["arm_gid"], int)
+
+        assert "checks" in result
+        assert len(result["checks"]) == 4
+        check_names = [c["name"] for c in result["checks"]]
+        assert check_names == ["omdb_key", "tmdb_key", "tvdb_key", "makemkv_key"]
+
+        assert "paths" in result
+        assert isinstance(result["paths"], list)
+        assert len(result["paths"]) == 1
+        assert result["paths"][0]["name"] == "RAW_PATH"
+
+    def test_checks_have_required_fields(self):
+        """Each check in the response has name, success, message, fixable."""
+        async def fake_check():
+            return {"name": "test", "success": True, "message": "OK", "fixable": False}
+
+        mock_paths = []
+
+        with unittest.mock.patch("arm.services.preflight._check_omdb_key", fake_check), \
+             unittest.mock.patch("arm.services.preflight._check_tmdb_key", fake_check), \
+             unittest.mock.patch("arm.services.preflight._check_tvdb_key", fake_check), \
+             unittest.mock.patch("arm.services.preflight._check_makemkv_key", fake_check), \
+             unittest.mock.patch("arm.services.preflight._get_path_checks", return_value=mock_paths):
+            result = asyncio.run(run_checks())
+
+        for check in result["checks"]:
+            assert "name" in check
+            assert "success" in check
+            assert "message" in check
+            assert "fixable" in check


### PR DESCRIPTION
## Summary
- Add `POST /system/preflight` endpoint that validates all API keys (OMDB, TMDB, TVDB, MakeMKV) and checks path permissions with UID/GID ownership in one call
- Add `POST /system/preflight/fix` endpoint to auto-fix issues ARM can resolve (MakeMKV key refresh, chown on owned paths)
- Add `validate_tvdb_key()` function (TVDB had no test endpoint)
- Resolve container paths to host paths via `/proc/self/mountinfo` with env var fallback
- Pass host path env vars to arm-rippers in docker-compose for path resolution

Depends on #180 (first-run permissions fixes). Companion UI PR: uprightbass360/automatic-ripping-machine-ui#XX

## Test plan
- [ ] `python3 -m pytest test/test_preflight.py` - 21 tests pass
- [ ] `POST /system/preflight` returns checks (4 items) + paths with host_path populated
- [ ] `POST /system/preflight/fix` with `{"fix": ["makemkv_key"]}` refreshes key and re-checks
- [ ] Integration test with UI wizard and settings panel after UI PR merges