### PR TITLE
fix: mountinfo parser uses root field for bind-mount host paths

### DIFF
--- a/arm/services/preflight.py
+++ b/arm/services/preflight.py
@@ -59,39 +59,37 @@ def _parse_mountinfo(container_path: str) -> str | None:
     Each line has the format (space-separated fields):
       mount_id parent_id major:minor root mount_point ... - fs_type source ...
 
-    We look for lines where mount_point matches *container_path* (or is a
-    parent of it) and the source looks like an absolute host path.
+    For Docker bind mounts, ``root`` (field 3) contains the host-side path
+    and ``mount_point`` (field 4) is the container-side path. When ``root``
+    is ``/`` the entry is a full filesystem mount (not a bind), so we skip it.
     """
     best_mount = ""
-    best_source = None
+    best_root = None
 
     with open("/proc/self/mountinfo") as f:
         for line in f:
             parts = line.split()
             if len(parts) < 5:
                 continue
+            root = parts[3]
             mount_point = parts[4]
-            # Find the separator '-' to locate fs_type and source
-            try:
-                sep_idx = parts.index("-")
-            except ValueError:
+
+            # Skip non-bind mounts (root is "/" for full filesystem mounts)
+            if root == "/":
                 continue
-            if sep_idx + 2 >= len(parts):
-                continue
-            source = parts[sep_idx + 2]
 
             # Check if this mount_point is a prefix of container_path
             if container_path == mount_point or container_path.startswith(
                 mount_point + "/"
             ):
                 # Prefer the longest (most specific) mount point match
-                if len(mount_point) > len(best_mount) and source.startswith("/"):
+                if len(mount_point) > len(best_mount):
                     best_mount = mount_point
-                    best_source = source
+                    best_root = root
 
-    if best_source is not None:
+    if best_root is not None:
         suffix = container_path[len(best_mount):]
-        return best_source + suffix
+        return best_root + suffix
     return None
 
 

--- a/test/test_preflight.py
+++ b/test/test_preflight.py
@@ -189,27 +189,28 @@ class TestResolveHostPath:
     """Test resolve_host_path() bind-mount parsing and env var fallback."""
 
     def test_mountinfo_parsing(self, tmp_path):
-        """Finds host path from a /proc/self/mountinfo-style line."""
+        """Finds host path from a Docker bind-mount mountinfo line."""
+        # Docker bind mounts have the host path in the root field (field 3)
         fake_mountinfo = (
-            "36 1 8:1 / /mnt rw - ext4 /dev/sda1 rw\n"
-            "100 36 0:50 / /home/arm/media rw - ext4 /host/media rw\n"
+            "36 1 8:1 / / rw - ext4 /dev/sda1 rw\n"
+            "100 36 8:1 /home/arm/media /home/arm/media rw,relatime - ext4 /dev/sda1 rw\n"
         )
         with unittest.mock.patch(
             "builtins.open", unittest.mock.mock_open(read_data=fake_mountinfo)
         ):
             result = resolve_host_path("/home/arm/media")
-        assert result == "/host/media"
+        assert result == "/home/arm/media"
 
     def test_mountinfo_subpath(self):
         """Subpath under a bind mount resolves correctly."""
         fake_mountinfo = (
-            "100 36 0:50 / /home/arm/media rw - ext4 /host/media rw\n"
+            "100 36 8:1 /nfs/shared/media /home/arm/media rw,relatime - ext4 /dev/sda1 rw\n"
         )
         with unittest.mock.patch(
             "builtins.open", unittest.mock.mock_open(read_data=fake_mountinfo)
         ):
             result = resolve_host_path("/home/arm/media/raw/movie.mkv")
-        assert result == "/host/media/raw/movie.mkv"
+        assert result == "/nfs/shared/media/raw/movie.mkv"
 
     def test_env_var_fallback(self):
         """Falls back to env var when mountinfo is not available."""


### PR DESCRIPTION
## Summary
- Fix `resolve_host_path()` in preflight service to use the mountinfo `root` field (column 3) instead of the `source` field for bind-mount host path resolution
- The old parser matched device paths like `/dev/sdd` which are not meaningful host paths
- Update tests to use realistic Docker bind-mount mountinfo format

Found during live testing of the preflight endpoint on WSL2.

## Test plan
- [ ] `python3 -m pytest test/test_preflight.py` - 21 tests pass
- [ ] `POST /system/preflight` returns correct host paths (not `/dev/sdX` paths)