### PR TITLE
chore: add safe defaults and document missing env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # All-in-one deployment: ARM + UI + Transcoder on a single machine
 # Copy to .env and adjust values before running: docker compose up -d
+# For GPU transcoding: docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
 
 # --- Version Pinning ---
 # Pin to a specific release (e.g. 13.0.0) or use "latest"
@@ -12,14 +13,14 @@ ARM_UID=1000
 ARM_GID=1000
 TZ=America/New_York
 
-# Host paths
+# Host paths (must exist and be owned by ARM_UID:ARM_GID)
 ARM_MUSIC_PATH=/home/arm/music
 ARM_LOGS_PATH=/home/arm/logs
 ARM_MEDIA_PATH=/home/arm/media
 ARM_CONFIG_PATH=/etc/arm/config
 ARM_MAKEMKV_PATH=/home/arm/.MakeMKV
 
-# Folder import ingress — host directory containing BDMV/VIDEO_TS folders.
+# Folder import ingress - host directory containing BDMV/VIDEO_TS folders.
 # Mounted read-only into the container. Leave default to use ARM_MEDIA_PATH/ingress.
 # ARM_INGRESS_PATH=/path/to/disc/backups
 
@@ -40,6 +41,8 @@ ARM_COMMUNITY_KEYDB=true
 
 # --- Transcoder ---
 LOG_LEVEL=INFO
+# Library log level (HandBrake, FFmpeg output). Set to DEBUG for troubleshooting.
+LOG_LEVEL_LIBRARIES=WARNING
 
 # Video encoder: x265 (CPU), nvenc_h265 (NVIDIA), vaapi_h265 (AMD), qsv_h265 (Intel)
 VIDEO_ENCODER=x265
@@ -47,10 +50,11 @@ VIDEO_QUALITY=22
 AUDIO_ENCODER=copy
 SUBTITLE_MODE=all
 
-# HandBrake presets (leave empty for software encoding — auto-detected at startup)
+# HandBrake presets (leave empty for software encoding - auto-detected at startup)
 # GPU examples: "H.265 NVENC 1080p", "H.265 NVENC 2160p 4K"
 HANDBRAKE_PRESET=
 HANDBRAKE_PRESET_4K=
+HANDBRAKE_PRESET_DVD=
 HANDBRAKE_PRESET_FILE=
 
 DELETE_SOURCE=true
@@ -72,7 +76,7 @@ MAX_RETRY_COUNT=3
 # ARM_LOCAL_RAW_PATH=/home/arm/scratch/raw/
 # ARM_SHARED_RAW_PATH=/home/arm/media/raw/
 
-# Local scratch for transcoding (fast SSD recommended)
+# Transcoder work directory (fast SSD recommended, relative to compose file)
 TRANSCODER_WORK_PATH=./work
 TRANSCODER_PRESET_PATH=./presets
 
@@ -81,12 +85,12 @@ TRANSCODER_PRESET_PATH=./presets
 # Override for remote transcoder (e.g. http://192.168.0.92:5000/webhook/arm)
 # ARM_TRANSCODER_URL=http://arm-transcoder:5000/webhook/arm
 
-# ARM callback URL — how the transcoder notifies ARM when jobs complete.
+# ARM callback URL - how the transcoder notifies ARM when jobs complete.
 # In all-in-one mode, uses Docker network name. Override for split deployments.
 # ARM_CALLBACK_URL=http://arm-rippers:8080
 
 # --- Authentication ---
-# Shared secret for ARM → transcoder webhook calls.
+# Shared secret for ARM-to-transcoder webhook calls.
 # Generate with: openssl rand -hex 32
 WEBHOOK_SECRET=
 API_KEYS=

--- a/docker-compose.remote-transcoder.yml
+++ b/docker-compose.remote-transcoder.yml
@@ -46,9 +46,9 @@ services:
     ports:
       - "${ARM_PORT:-8080}:8080"
     environment:
-      - ARM_UID=${ARM_UID}
-      - ARM_GID=${ARM_GID}
-      - TZ=${TZ}
+      - ARM_UID=${ARM_UID:-1000}
+      - ARM_GID=${ARM_GID:-1000}
+      - TZ=${TZ:-Etc/UTC}
       # FindVUK community keydb for Blu-ray decryption (true/false, default: true)
       - ARM_COMMUNITY_KEYDB=${ARM_COMMUNITY_KEYDB:-true}
       # Transcoder integration (written to arm.yaml at startup)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,9 +47,9 @@ services:
     ports:
       - "${ARM_PORT:-8080}:8080"
     environment:
-      - ARM_UID=${ARM_UID}
-      - ARM_GID=${ARM_GID}
-      - TZ=${TZ}
+      - ARM_UID=${ARM_UID:-1000}
+      - ARM_GID=${ARM_GID:-1000}
+      - TZ=${TZ:-Etc/UTC}
       # FindVUK community keydb for Blu-ray decryption (true/false, default: true)
       - ARM_COMMUNITY_KEYDB=${ARM_COMMUNITY_KEYDB:-true}
       # Transcoder integration (written to arm.yaml at startup)
@@ -130,7 +130,7 @@ services:
     ports:
       - "${TRANSCODER_PORT:-5000}:5000"
     environment:
-      - TZ=${TZ}
+      - TZ=${TZ:-Etc/UTC}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       # Match ARM's UID/GID so the transcoder can read raw files and write completed
       - TRANSCODER_UID=${ARM_UID:-1000}


### PR DESCRIPTION
## Summary
- Add fallback defaults to ARM_UID, ARM_GID, TZ in all compose files (prevents empty values when .env is incomplete)
- Add HANDBRAKE_PRESET_DVD, LOG_LEVEL_LIBRARIES to .env.example (used in compose but undocumented)
- Add GPU compose usage note to .env.example header
- Clarify host path ownership requirement

## Test plan
- [ ] `docker compose config --quiet` passes on all compose files
- [ ] Fresh deploy without .env still starts (uses defaults)