### PR TITLE
feat: naming lifecycle cleanup - GUID paths, clean titles, single sanitizer

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -419,8 +419,6 @@ def _process_mapped_fields(body):
         if key not in body or body[key] is None:
             continue
         value = str(body[key]).strip()
-        if key == 'title':
-            value = _clean_for_filename(value)
         args[eff] = value
         args[manual] = value
         updated[key] = value
@@ -556,8 +554,6 @@ def update_track_title(job_id: int, track_id: int, body: dict):
     for key, (attr, typ, maxlen) in track_fields.items():
         if key in body and body[key] is not None:
             value = typ(body[key]).strip()[:maxlen]
-            if key == 'title':
-                value = _clean_for_filename(value)
             setattr(track, attr, value)
             updated[key] = value
 
@@ -987,17 +983,6 @@ def tvdb_episodes(job_id: int, season: int = 1):
 
     episodes = _run_async(tvdb.get_season_episodes(tvdb_id, season))
     return {"episodes": episodes, "tvdb_id": tvdb_id, "season": season}
-
-
-def _clean_for_filename(string):
-    """Clean a string for use in filenames."""
-    string = re.sub(r'\s+', ' ', string)
-    string = string.replace(' : ', ' - ')
-    string = string.replace(':', '-')
-    string = string.replace('&', 'and')
-    string = string.replace("\\", " - ")
-    string = re.sub(r"[^\w -]", "", string)
-    return string.strip()
 
 
 # --- Track field updates ---

--- a/arm/migrations/versions/l7m8n9o0p1q2_job_add_guid.py
+++ b/arm/migrations/versions/l7m8n9o0p1q2_job_add_guid.py
@@ -1,0 +1,39 @@
+"""job: add guid column for GUID-based work paths
+
+Revision ID: l7m8n9o0p1q2
+Revises: k6l7m8n9o0p1
+Create Date: 2026-04-06
+
+"""
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'l7m8n9o0p1q2'
+down_revision = 'k6l7m8n9o0p1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('job') as batch_op:
+        batch_op.add_column(sa.Column('guid', sa.String(36), nullable=True))
+
+    conn = op.get_bind()
+    rows = conn.execute(sa.text("SELECT job_id FROM job WHERE guid IS NULL"))
+    for row in rows:
+        conn.execute(
+            sa.text("UPDATE job SET guid = :guid WHERE job_id = :id"),
+            {"guid": str(uuid.uuid4()), "id": row[0]},
+        )
+
+    with op.batch_alter_table('job') as batch_op:
+        batch_op.alter_column('guid', nullable=False)
+        batch_op.create_unique_constraint('uq_job_guid', ['guid'])
+
+
+def downgrade():
+    with op.batch_alter_table('job') as batch_op:
+        batch_op.drop_constraint('uq_job_guid', type_='unique')
+        batch_op.drop_column('guid')

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -454,10 +454,9 @@ class Job(db.Model):
         return f"{title}"
 
     def build_raw_path(self):
-        """Compute the raw rip directory path.
-        Uses title_auto (original auto-detected title) to match the actual
-        directory on disk, even after manual title correction."""
-        return os.path.join(str(self.config.RAW_PATH), str(self.title_auto or self.title))
+        """Compute the raw rip directory path. Uses GUID for uniqueness -
+        no dependency on title fields, no collision handling needed."""
+        return os.path.join(str(self.config.RAW_PATH), str(self.guid))
 
     def build_transcode_path(self):
         """Compute the transcode output directory path, using folder pattern."""

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -4,6 +4,7 @@ import os
 import psutil
 import pyudev
 import time
+import uuid
 
 from datetime import datetime as dt
 from prettytable import PrettyTable
@@ -153,6 +154,7 @@ class Job(db.Model):
     disc_number = db.Column(db.Integer, nullable=True)
     disc_total = db.Column(db.Integer, nullable=True)
     tvdb_id = db.Column(db.Integer, nullable=True)
+    guid = db.Column(db.String(36), nullable=False, unique=True, default=lambda: str(uuid.uuid4()))
     ejected = db.Column(db.Boolean)
     updated = db.Column(db.Boolean)
     pid = db.Column(db.Integer)
@@ -172,6 +174,7 @@ class Job(db.Model):
     def __init__(self, devpath, _skip_hardware=False):
         """Return a disc object"""
         self.devpath = devpath
+        self.guid = str(uuid.uuid4())
         self.mountpoint = ""
         self.hasnicetitle = False
         self.video_type = "unknown"

--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -57,18 +57,30 @@ def rip_visual_media(have_dupes, job, logfile, protection):
 
     # Persist raw_path to DB — this is the actual directory on disk
     utils.database_updater({'raw_path': makemkv_out_path}, job)
-    if job.config.NOTIFY_RIP:
-        # notify() also calls transcoder_notify internally
-        utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete.")
+
+    # Determine whether to hand off to transcoder or finalize locally
+    import arm.config.config as cfg
+    transcoder_url = cfg.arm_config.get('TRANSCODER_URL', '')
+
+    if transcoder_url:
+        if job.config.NOTIFY_RIP:
+            # notify() also calls transcoder_notify internally
+            utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete.")
+        else:
+            # Always notify the transcoder when TRANSCODER_URL is set, even if
+            # NOTIFY_RIP is off.  The transcoder webhook is a pipeline trigger,
+            # not a user notification.
+            utils.transcoder_notify(
+                cfg.arm_config, constants.NOTIFY_TITLE,
+                f"{job.title} rip complete.", job,
+            )
     else:
-        # Always notify the transcoder when TRANSCODER_URL is set, even if
-        # NOTIFY_RIP is off.  The transcoder webhook is a pipeline trigger,
-        # not a user notification.
-        import arm.config.config as cfg
-        utils.transcoder_notify(
-            cfg.arm_config, constants.NOTIFY_TITLE,
-            f"{job.title} rip complete.", job,
-        )
+        # No transcoder - finalize output locally
+        from arm.ripper.naming import finalize_output
+        logging.info("No transcoder configured - finalizing output locally")
+        finalize_output(job)
+        if job.config.NOTIFY_RIP:
+            utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete.")
     logging.info("************* Ripping with MakeMKV completed *************")
 
     # Report errors if any

--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -146,7 +146,7 @@ def rip_folder(job):
         prep_mkv()
 
         # 3. Setup raw output path
-        rawpath = setup_rawpath(job, job.build_raw_path())
+        rawpath = setup_rawpath(job.build_raw_path())
         job.raw_path = rawpath
         db.session.commit()
 

--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -202,7 +202,7 @@ def rip_folder(job):
                  sum(1 for t in job.tracks if t.ripped),
                  len(list(job.tracks)), rawpath)
 
-        # 7. Notify transcoder if configured
+        # 7. Notify transcoder or finalize locally
         transcoder_url = cfg.arm_config.get("TRANSCODER_URL", "")
         if transcoder_url:
             utils.transcoder_notify(
@@ -211,9 +211,13 @@ def rip_folder(job):
                 f"{job.title} folder import rip complete.",
                 job,
             )
+            job.status = JobState.TRANSCODE_WAITING.value
+        else:
+            from arm.ripper.naming import finalize_output
+            log.info("No transcoder configured - finalizing output locally")
+            finalize_output(job)
+            job.status = JobState.SUCCESS.value
 
-        # 8. Set status to TRANSCODE_WAITING
-        job.status = JobState.TRANSCODE_WAITING.value
         db.session.commit()
         log.info("Folder import rip complete for job %s", job.job_id)
 

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -27,7 +27,6 @@ import arm.config.config as cfg
 from arm.models import Job
 
 from arm.ripper import utils
-from arm.ripper.naming import clean_for_filename
 from arm.ripper.ProcessHandler import arm_subprocess
 from arm.ripper.utils import RipperException
 from arm.database import db
@@ -545,7 +544,7 @@ def update_job(job, search_results):
         return None
 
     best = selection.best
-    title = clean_for_filename(best.title)
+    title = best.title
     logging.debug(
         "Matcher selected '%s' (%s) with score %.3f (title=%.3f year=%.3f type=%.3f)",
         best.title, best.imdb_id, best.score,

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -27,6 +27,7 @@ import arm.config.config as cfg
 from arm.models import Job
 
 from arm.ripper import utils
+from arm.ripper.naming import clean_for_filename
 from arm.ripper.ProcessHandler import arm_subprocess
 from arm.ripper.utils import RipperException
 from arm.database import db
@@ -544,7 +545,7 @@ def update_job(job, search_results):
         return None
 
     best = selection.best
-    title = utils.clean_for_filename(best.title)
+    title = clean_for_filename(best.title)
     logging.debug(
         "Matcher selected '%s' (%s) with score %.3f (title=%.3f year=%.3f type=%.3f)",
         best.title, best.imdb_id, best.score,

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -1232,34 +1232,24 @@ def process_single_tracks(job, rawpath, mode: str):
 
 
 def setup_rawpath(job, raw_path):
-    """
-    Checks if we need to create path and does so if needed\n\n
+    """Create the raw rip output directory.
+
+    With GUID-based paths, collision is not possible. If the directory
+    already exists (e.g. retry after partial rip), reuse it.
 
     Parameters:
         job: arm.models.job.Job
-        raw_path
+        raw_path: str - absolute path to create
     Returns:
-        str: modified path
+        str: the raw_path (unchanged)
     """
-
     logging.info(f"Destination is {raw_path}")
-    if not os.path.exists(raw_path):
-        try:
-            os.makedirs(raw_path)
-        except OSError:
-            err = f"Couldn't create the base file path: {raw_path}. Probably a permissions error"
-            logging.error(err)
-    else:
-        import time as _time
-        ts = str(int(_time.time()))
-        logging.info(f"{raw_path} exists.  Adding timestamp {ts}.")
-        raw_path = os.path.join(str(job.config.RAW_PATH), f"{job.title}_{ts}")
-        logging.info(f"raw_path is {raw_path}")
-        try:
-            os.makedirs(raw_path)
-        except OSError:
-            err = f"Couldn't create the base file path: {raw_path}. Probably a permissions error"
-            raise OSError(err) from OSError
+    try:
+        os.makedirs(raw_path, exist_ok=True)
+    except OSError:
+        err = f"Couldn't create the base file path: {raw_path}. Probably a permissions error"
+        logging.error(err)
+        raise
     return raw_path
 
 

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -1134,7 +1134,7 @@ def makemkv(job):
     _resolve_mdisc(job)
     logging.info(f"MakeMKV disc number: {job.drive.mdisc}")
 
-    rawpath = setup_rawpath(job, job.build_raw_path())
+    rawpath = setup_rawpath(job.build_raw_path())
     logging.info(f"Processing files to: {rawpath}")
 
     if (job.config.RIPMETHOD in ("backup", "backup_dvd")) and job.disctype in ("bluray", "bluray4k"):
@@ -1231,14 +1231,13 @@ def process_single_tracks(job, rawpath, mode: str):
             db.session.commit()
 
 
-def setup_rawpath(job, raw_path):
+def setup_rawpath(raw_path):
     """Create the raw rip output directory.
 
     With GUID-based paths, collision is not possible. If the directory
     already exists (e.g. retry after partial rip), reuse it.
 
     Parameters:
-        job: arm.models.job.Job
         raw_path: str - absolute path to create
     Returns:
         str: the raw_path (unchanged)

--- a/arm/ripper/music_brainz.py
+++ b/arm/ripper/music_brainz.py
@@ -9,7 +9,6 @@ from discid import read, Disc
 import arm.config.config as cfg
 from arm.database import db
 from arm.ripper import utils as u
-from arm.ripper.naming import clean_for_filename
 
 
 def main(disc):
@@ -328,7 +327,7 @@ def get_title(discid: str, job) -> str:
 
     This function uses the MusicBrainz API to retrieve the release title and artist name
     for a given disc. If a valid result is found, it updates the job's database entry
-    and returns a sanitized string in the format "Artist-Title". If no valid release is
+    and returns a string in the format "Artist Title". If no valid release is
     found, or an error occurs, it updates the database with a failure and returns
     "not identified".
 
@@ -342,7 +341,7 @@ def get_title(discid: str, job) -> str:
     Returns
     -------
     str
-        The sanitized "Artist-Title" string if the disc is identified,
+        The "Artist Title" string if the disc is identified,
         or "not identified" if no match is found or an error occurs.
 
     Notes
@@ -373,7 +372,7 @@ def get_title(discid: str, job) -> str:
             u.database_updater(False, job)
             return "not identified"
 
-        clean_title = clean_for_filename(artist) + "-" + clean_for_filename(title)
+        clean_title = f"{artist} {title}"
         args = {
             'crc_id': crc_id,
             'title': str(artist + " " + title),

--- a/arm/ripper/music_brainz.py
+++ b/arm/ripper/music_brainz.py
@@ -9,6 +9,7 @@ from discid import read, Disc
 import arm.config.config as cfg
 from arm.database import db
 from arm.ripper import utils as u
+from arm.ripper.naming import clean_for_filename
 
 
 def main(disc):
@@ -372,7 +373,7 @@ def get_title(discid: str, job) -> str:
             u.database_updater(False, job)
             return "not identified"
 
-        clean_title = u.clean_for_filename(artist) + "-" + u.clean_for_filename(title)
+        clean_title = clean_for_filename(artist) + "-" + clean_for_filename(title)
         args = {
             'crc_id': crc_id,
             'title': str(artist + " " + title),

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -81,7 +81,7 @@ def _clean_empty_parens(s):
     return re.sub(r' *\( *\)', '', s).strip()
 
 
-def _clean_for_filename(s):
+def clean_for_filename(s):
     """Sanitize a single path segment for filesystem use."""
     s = s.replace(':', ' - ')
     s = re.sub(r'\s+', ' ', s)
@@ -144,7 +144,7 @@ def render_folder(job, config_dict=None):
     rendered = _clean_empty_parens(rendered)
     # Sanitize each path segment individually
     segments = rendered.split('/')
-    segments = [_clean_for_filename(seg) for seg in segments if seg.strip()]
+    segments = [clean_for_filename(seg) for seg in segments if seg.strip()]
     return os.path.join(*segments) if segments else ''
 
 
@@ -196,7 +196,7 @@ def render_track_title(track, job, config_dict=None):
     """
     # Custom filename takes highest priority
     if getattr(track, 'custom_filename', None):
-        return _clean_for_filename(track.custom_filename)
+        return clean_for_filename(track.custom_filename)
 
     variables = _build_track_variables(track, job)
     video_type = variables.get('video_type', '')
@@ -269,7 +269,7 @@ def render_track_folder(track, job, config_dict=None):
     if variables.get('_disc_fallback'):
         rendered = rendered.replace('Season ', 'Disc ')
     segments = rendered.split('/')
-    segments = [_clean_for_filename(seg) for seg in segments if seg.strip()]
+    segments = [clean_for_filename(seg) for seg in segments if seg.strip()]
     return os.path.join(*segments) if segments else ''
 
 

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -4,6 +4,8 @@ Supports per-type patterns with {variable} placeholders.
 Variables are extracted from Job fields, preferring manual over auto values.
 Per-job pattern overrides and per-track custom filenames are supported.
 """
+import logging
+import os
 import re
 
 _TITLE_YEAR_PATTERN = '{title} ({year})'
@@ -355,3 +357,88 @@ def validate_pattern(pattern):
         if _levenshtein(inv, best) <= 2:
             suggestions[inv] = best
     return {"valid": len(invalid) == 0, "invalid_vars": invalid, "suggestions": suggestions}
+
+
+# ======================================================================
+# File finalization (transcoder-disabled deployments)
+# ======================================================================
+
+
+def finalize_output(job):
+    """Move ripped files from GUID work directory to final named location.
+
+    Used when the transcoder is disabled - ARM handles final naming directly.
+    Renders folder/file names via the naming engine, moves files, updates
+    job.path, and cleans up the empty work directory.
+    """
+    import shutil
+    from arm.database import db
+    import arm.config.config as cfg
+
+    raw_path = getattr(job, 'raw_path', None)
+    if not raw_path or not os.path.isdir(raw_path):
+        logging.debug("finalize_output: no raw_path for job %s, skipping",
+                       getattr(job, 'job_id', '?'))
+        return
+
+    config_dict = cfg.arm_config if hasattr(cfg, 'arm_config') else None
+    final_dir = job.build_final_path()
+    os.makedirs(final_dir, exist_ok=True)
+
+    # Get rendered names for each track
+    rendered = render_all_tracks(job, config_dict)
+    rendered_map = {r["track_number"]: r for r in rendered}
+
+    moved_count = 0
+    for track in job.tracks:
+        if not track.filename:
+            continue
+        src = os.path.join(raw_path, track.filename)
+        if not os.path.isfile(src):
+            continue
+
+        r = rendered_map.get(track.track_number, {})
+        rendered_title = r.get("rendered_title", '')
+        rendered_folder = r.get("rendered_folder", '')
+
+        if rendered_title:
+            ext = os.path.splitext(track.filename)[1]
+            dest_name = _clean_for_filename(rendered_title) + ext
+        else:
+            dest_name = track.filename
+
+        if rendered_folder:
+            dest_dir = os.path.join(final_dir, rendered_folder)
+        else:
+            dest_dir = final_dir
+
+        os.makedirs(dest_dir, exist_ok=True)
+        shutil.move(src, os.path.join(dest_dir, dest_name))
+        moved_count += 1
+
+    # Fallback: if no tracks matched (e.g. single-title disc without track
+    # records), move all MKV files using the job-level rendered title.
+    if moved_count == 0:
+        for fname in os.listdir(raw_path):
+            if fname.lower().endswith('.mkv'):
+                rendered_title = render_title(job, config_dict)
+                if rendered_title:
+                    dest_name = _clean_for_filename(rendered_title) + '.mkv'
+                else:
+                    dest_name = fname
+                shutil.move(os.path.join(raw_path, fname),
+                            os.path.join(final_dir, dest_name))
+                moved_count += 1
+
+    # Update job.path and persist
+    job.path = final_dir
+    db.session.commit()
+
+    # Remove empty work directory
+    try:
+        if os.path.isdir(raw_path) and not os.listdir(raw_path):
+            os.rmdir(raw_path)
+    except OSError:
+        pass
+
+    logging.info("finalize_output: moved %d files to %s", moved_count, final_dir)

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -28,6 +28,8 @@ PATTERN_VARIABLES = {
     'episode':    'TV episode number (zero-padded to 2 digits)',
     'label':      'Original disc label from drive',
     'video_type': 'Media type: movie, series, or music',
+    'disc_number': 'Disc number in a multi-disc set',
+    'disc_total':  'Total number of discs in the set',
 }
 
 # Frozen set for fast validation — derived from PATTERN_VARIABLES
@@ -73,6 +75,8 @@ def _build_variables(job):
         'episode': episode,
         'label': getattr(job, 'label', '') or '',
         'video_type': getattr(job, 'video_type', '') or '',
+        'disc_number': str(getattr(job, 'disc_number', '') or ''),
+        'disc_total': str(getattr(job, 'disc_total', '') or ''),
     })
 
 

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -364,6 +364,64 @@ def validate_pattern(pattern):
 # ======================================================================
 
 
+def _move_track(track, raw_path, final_dir, rendered_map):
+    """Move a single track file to its final rendered destination.
+
+    Returns True if the file was moved, False if skipped.
+    """
+    import shutil
+
+    if not track.filename:
+        return False
+    src = os.path.join(raw_path, track.filename)
+    if not os.path.isfile(src):
+        return False
+
+    r = rendered_map.get(str(track.track_number or ''), {})
+    rendered_title = r.get("rendered_title", '')
+
+    if rendered_title:
+        ext = os.path.splitext(track.filename)[1]
+        dest_name = clean_for_filename(rendered_title) + ext
+    else:
+        dest_name = track.filename
+
+    rendered_folder = r.get("rendered_folder", '')
+    dest_dir = os.path.join(final_dir, rendered_folder) if rendered_folder else final_dir
+
+    os.makedirs(dest_dir, exist_ok=True)
+    shutil.move(src, os.path.join(dest_dir, dest_name))
+    return True
+
+
+def _move_untracked_mkvs(raw_path, final_dir, job, config_dict):
+    """Fallback: move all MKV files using the job-level rendered title.
+
+    Used when no track records matched (e.g. single-title disc).
+    Returns the number of files moved.
+    """
+    import shutil
+
+    moved = 0
+    rendered_title = render_title(job, config_dict)
+    for fname in os.listdir(raw_path):
+        if not fname.lower().endswith('.mkv'):
+            continue
+        dest_name = clean_for_filename(rendered_title) + '.mkv' if rendered_title else fname
+        shutil.move(os.path.join(raw_path, fname), os.path.join(final_dir, dest_name))
+        moved += 1
+    return moved
+
+
+def _cleanup_empty_dir(path):
+    """Remove a directory if it exists and is empty."""
+    try:
+        if os.path.isdir(path) and not os.listdir(path):
+            os.rmdir(path)
+    except OSError:
+        pass
+
+
 def finalize_output(job):
     """Move ripped files from GUID work directory to final named location.
 
@@ -371,7 +429,6 @@ def finalize_output(job):
     Renders folder/file names via the naming engine, moves files, updates
     job.path, and cleans up the empty work directory.
     """
-    import shutil
     from arm.database import db
     import arm.config.config as cfg
 
@@ -385,60 +442,16 @@ def finalize_output(job):
     final_dir = job.build_final_path()
     os.makedirs(final_dir, exist_ok=True)
 
-    # Get rendered names for each track
     rendered = render_all_tracks(job, config_dict)
     rendered_map = {r["track_number"]: r for r in rendered}
 
-    moved_count = 0
-    for track in job.tracks:
-        if not track.filename:
-            continue
-        src = os.path.join(raw_path, track.filename)
-        if not os.path.isfile(src):
-            continue
+    moved_count = sum(1 for t in job.tracks if _move_track(t, raw_path, final_dir, rendered_map))
 
-        r = rendered_map.get(str(track.track_number or ''), {})
-        rendered_title = r.get("rendered_title", '')
-        rendered_folder = r.get("rendered_folder", '')
-
-        if rendered_title:
-            ext = os.path.splitext(track.filename)[1]
-            dest_name = clean_for_filename(rendered_title) + ext
-        else:
-            dest_name = track.filename
-
-        if rendered_folder:
-            dest_dir = os.path.join(final_dir, rendered_folder)
-        else:
-            dest_dir = final_dir
-
-        os.makedirs(dest_dir, exist_ok=True)
-        shutil.move(src, os.path.join(dest_dir, dest_name))
-        moved_count += 1
-
-    # Fallback: if no tracks matched (e.g. single-title disc without track
-    # records), move all MKV files using the job-level rendered title.
     if moved_count == 0:
-        for fname in os.listdir(raw_path):
-            if fname.lower().endswith('.mkv'):
-                rendered_title = render_title(job, config_dict)
-                if rendered_title:
-                    dest_name = clean_for_filename(rendered_title) + '.mkv'
-                else:
-                    dest_name = fname
-                shutil.move(os.path.join(raw_path, fname),
-                            os.path.join(final_dir, dest_name))
-                moved_count += 1
+        moved_count = _move_untracked_mkvs(raw_path, final_dir, job, config_dict)
 
-    # Update job.path and persist
     job.path = final_dir
     db.session.commit()
 
-    # Remove empty work directory
-    try:
-        if os.path.isdir(raw_path) and not os.listdir(raw_path):
-            os.rmdir(raw_path)
-    except OSError:
-        pass
-
+    _cleanup_empty_dir(raw_path)
     logging.info("finalize_output: moved %d files to %s", moved_count, final_dir)

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -397,13 +397,13 @@ def finalize_output(job):
         if not os.path.isfile(src):
             continue
 
-        r = rendered_map.get(track.track_number, {})
+        r = rendered_map.get(str(track.track_number or ''), {})
         rendered_title = r.get("rendered_title", '')
         rendered_folder = r.get("rendered_folder", '')
 
         if rendered_title:
             ext = os.path.splitext(track.filename)[1]
-            dest_name = _clean_for_filename(rendered_title) + ext
+            dest_name = clean_for_filename(rendered_title) + ext
         else:
             dest_name = track.filename
 
@@ -423,7 +423,7 @@ def finalize_output(job):
             if fname.lower().endswith('.mkv'):
                 rendered_title = render_title(job, config_dict)
                 if rendered_title:
-                    dest_name = _clean_for_filename(rendered_title) + '.mkv'
+                    dest_name = clean_for_filename(rendered_title) + '.mkv'
                 else:
                     dest_name = fname
                 shutil.move(os.path.join(raw_path, fname),

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -194,7 +194,7 @@ def _build_webhook_payload(title, body, job, raw_basename):
     doesn't need its own naming logic — ARM is the single source of truth
     for folder/file naming patterns configured in arm.yaml.
     """
-    from arm.ripper.naming import render_folder, render_title, render_all_tracks, _clean_for_filename
+    from arm.ripper.naming import render_folder, render_title, render_all_tracks, clean_for_filename
 
     payload = {"title": title, "body": body, "type": "info"}
     if raw_basename:
@@ -211,7 +211,7 @@ def _build_webhook_payload(title, body, job, raw_basename):
         # render_folder may contain '/' for nested dirs (e.g. "Title/Season 01")
         # — it already sanitizes each segment, so don't strip slashes here.
         payload["folder_name"] = render_folder(job, config_dict)
-        payload["title_name"] = _clean_for_filename(render_title(job, config_dict))
+        payload["title_name"] = clean_for_filename(render_title(job, config_dict))
         if job.transcode_overrides:
             try:
                 payload["config_overrides"] = json.loads(job.transcode_overrides)
@@ -239,9 +239,9 @@ def _build_webhook_payload(title, body, job, raw_basename):
                 "filename": str(track.filename or ''),
                 "has_custom_title": bool(track.title) or bool(getattr(track, 'custom_filename', None)),
                 "folder_name": r.get("rendered_folder", ''),
-                # _clean_for_filename is idempotent; render_track_title already
+                # clean_for_filename is idempotent; render_track_title already
                 # sanitizes custom_filename but raw pattern output needs it here.
-                "title_name": _clean_for_filename(r.get("rendered_title", '')) if r.get("rendered_title") else '',
+                "title_name": clean_for_filename(r.get("rendered_title", '')) if r.get("rendered_title") else '',
                 "episode_number": str(getattr(track, 'episode_number', '') or ''),
                 "episode_name": str(getattr(track, 'episode_name', '') or ''),
             })
@@ -924,21 +924,6 @@ def check_ip():
         return ip_list[0]
     return '127.0.0.1'
 
-
-def clean_for_filename(string):
-    """ Cleans up string for use in filename """
-    string = re.sub('\\[(.*?)]', '', string)
-    string = string.replace(' : ', ' - ')
-    string = string.replace(':', '-')
-    string = string.replace('&', 'and')
-    string = string.replace("\\", " - ")
-    string = re.sub('\\s+', ' ', string)
-    string = string.replace(' - ', '-')
-    string = re.sub('\\s+', '-', string)
-    # Collapse consecutive hyphens (e.g. "Title - Disc" -> "Title-Disc" not "Title---Disc")
-    string = re.sub('-{2,}', '-', string)
-    string = string.strip(' -')
-    return re.sub('[^\\w.() -]', '', string)
 
 
 def duplicate_run_check(dev_path):

--- a/docs/superpowers/plans/2026-04-06-naming-lifecycle-cleanup.md
+++ b/docs/superpowers/plans/2026-04-06-naming-lifecycle-cleanup.md
@@ -1,0 +1,1109 @@
+# Naming Lifecycle Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace title-based work paths with GUID-based paths, consolidate three `clean_for_filename` implementations into one, stop sanitizing titles at storage time, and add a `finalize_output` path for transcoder-disabled deployments.
+
+**Architecture:** Job gets a `guid` column (UUID4) set at creation. Raw/work directories use `{RAW_PATH}/{guid}/` instead of title-based names. All filesystem sanitization happens at render time via the naming engine's single `clean_for_filename`. A new `finalize_output()` function handles file placement when the transcoder is disabled.
+
+**Tech Stack:** Python 3.11, SQLAlchemy/Alembic, pytest, Flask-SQLAlchemy
+
+**Spec:** `docs/superpowers/specs/2026-04-06-naming-lifecycle-cleanup-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `arm/models/job.py` | Modify | Add `guid` column, rewrite `build_raw_path` to use GUID |
+| `arm/ripper/naming.py` | Modify | Make `_clean_for_filename` public, add `disc_number`/`disc_total` to `_build_variables`, add `finalize_output()` |
+| `arm/ripper/identify.py` | Modify | Remove `utils.clean_for_filename` call in `update_job` |
+| `arm/ripper/utils.py` | Modify | Delete `clean_for_filename`, update `_build_webhook_payload` import |
+| `arm/ripper/makemkv.py` | Modify | Simplify `setup_rawpath` (remove collision branch) |
+| `arm/ripper/arm_ripper.py` | Modify | Call `finalize_output` when transcoder disabled |
+| `arm/ripper/folder_ripper.py` | Modify | Call `finalize_output` when transcoder disabled |
+| `arm/ripper/music_brainz.py` | Modify | Remove `utils.clean_for_filename` usage |
+| `arm/api/v1/jobs.py` | Modify | Remove `_clean_for_filename` function and callsites, add `disc_number`/`disc_total` to `_FIELD_MAP` |
+| `arm/migrations/versions/l7m8n9o0p1q2_job_add_guid.py` | Create | Migration to add `guid` column |
+| `test/test_job_model.py` | Modify | Rewrite `build_raw_path` tests for GUID paths |
+| `test/test_naming.py` | Modify | Update imports for public `clean_for_filename` |
+| `test/test_utils.py` | Modify | Remove `TestCleanForFilename` class |
+| `test/test_makemkv_coverage.py` | Modify | Rewrite `TestSetupRawpath` for simplified function |
+| `test/test_finalize_output.py` | Create | Tests for new `finalize_output()` function |
+| `test/test_identify_no_sanitize.py` | Create | Tests verifying titles stored without aggressive sanitization |
+
+---
+
+### Task 1: Add `guid` column to Job model + migration
+
+**Files:**
+- Modify: `arm/models/job.py:113-169` (column definitions), `arm/models/job.py:172-189` (`__init__`), `arm/models/job.py:191-205` (`from_folder`)
+- Create: `arm/migrations/versions/l7m8n9o0p1q2_job_add_guid.py`
+- Modify: `test/conftest.py:100-149` (sample_job fixture)
+- Modify: `test/test_job_model.py`
+
+- [ ] **Step 1: Write failing test for GUID on new job**
+
+Add to `test/test_job_model.py`:
+
+```python
+import uuid
+
+
+class TestJobGuid:
+    def test_new_job_has_guid(self, sample_job):
+        """Every job gets a UUID4 guid at creation."""
+        assert sample_job.guid is not None
+        # Validate it's a proper UUID4
+        parsed = uuid.UUID(sample_job.guid)
+        assert parsed.version == 4
+
+    def test_guid_is_unique_per_job(self, app_context):
+        """Two jobs get different GUIDs."""
+        from arm.models.job import Job
+        import unittest.mock
+        with unittest.mock.patch.object(Job, 'parse_udev'), \
+             unittest.mock.patch.object(Job, 'get_pid'):
+            job1 = Job('/dev/sr0')
+            job2 = Job('/dev/sr1')
+        assert job1.guid != job2.guid
+
+    def test_folder_job_has_guid(self, app_context):
+        """Folder-import jobs also get GUIDs."""
+        from arm.models.job import Job
+        job = Job.from_folder('/tmp/test', 'dvd')
+        assert job.guid is not None
+        parsed = uuid.UUID(job.guid)
+        assert parsed.version == 4
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest test/test_job_model.py::TestJobGuid -v
+```
+
+Expected: FAIL - `AttributeError: guid`
+
+- [ ] **Step 3: Add guid column to Job model**
+
+In `arm/models/job.py`, add import at top:
+
+```python
+import uuid
+```
+
+Add column after line 155 (`tvdb_id`):
+
+```python
+    guid = db.Column(db.String(36), nullable=False, unique=True, default=lambda: str(uuid.uuid4()))
+```
+
+In `__init__` (line 172), add after `self.devpath = devpath`:
+
+```python
+        self.guid = str(uuid.uuid4())
+```
+
+In `from_folder` (line 191), the `guid` is auto-set by `__init__` via `cls(devpath=None, ...)` - no change needed.
+
+- [ ] **Step 4: Update sample_job fixture**
+
+In `test/conftest.py`, the fixture creates a Job via `Job('/dev/sr0')` which will now auto-generate a guid. No change needed for the fixture itself since `__init__` handles it. But verify it works.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pytest test/test_job_model.py::TestJobGuid -v
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Create Alembic migration**
+
+Create `arm/migrations/versions/l7m8n9o0p1q2_job_add_guid.py`:
+
+```python
+"""job: add guid column for GUID-based work paths
+
+Revision ID: l7m8n9o0p1q2
+Revises: k6l7m8n9o0p1
+Create Date: 2026-04-06
+
+"""
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'l7m8n9o0p1q2'
+down_revision = 'k6l7m8n9o0p1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add as nullable first so we can backfill
+    with op.batch_alter_table('job') as batch_op:
+        batch_op.add_column(sa.Column('guid', sa.String(36), nullable=True))
+
+    # Backfill existing rows with generated UUIDs
+    conn = op.get_bind()
+    rows = conn.execute(sa.text("SELECT job_id FROM job WHERE guid IS NULL"))
+    for row in rows:
+        conn.execute(
+            sa.text("UPDATE job SET guid = :guid WHERE job_id = :id"),
+            {"guid": str(uuid.uuid4()), "id": row[0]},
+        )
+
+    # Make non-nullable and add unique constraint
+    with op.batch_alter_table('job') as batch_op:
+        batch_op.alter_column('guid', nullable=False)
+        batch_op.create_unique_constraint('uq_job_guid', ['guid'])
+
+
+def downgrade():
+    with op.batch_alter_table('job') as batch_op:
+        batch_op.drop_constraint('uq_job_guid', type_='unique')
+        batch_op.drop_column('guid')
+```
+
+- [ ] **Step 7: Run full test suite to check nothing breaks**
+
+```bash
+pytest test/ -v
+```
+
+Expected: All existing tests PASS, new TestJobGuid PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add arm/models/job.py arm/migrations/versions/l7m8n9o0p1q2_job_add_guid.py test/test_job_model.py
+git commit -m "feat: add guid column to Job model for GUID-based work paths"
+```
+
+---
+
+### Task 2: Rewrite `build_raw_path` to use GUID
+
+**Files:**
+- Modify: `arm/models/job.py:453-457` (`build_raw_path`)
+- Modify: `test/test_job_model.py:42-70` (`TestBuildPaths`)
+
+- [ ] **Step 1: Update existing build_raw_path tests**
+
+In `test/test_job_model.py`, rewrite `TestBuildPaths`:
+
+```python
+class TestBuildPaths:
+    def test_build_raw_path_uses_guid(self, sample_job):
+        """Raw path uses job GUID, not title."""
+        expected = f"/home/arm/media/raw/{sample_job.guid}"
+        assert sample_job.build_raw_path() == expected
+
+    def test_build_raw_path_independent_of_title(self, sample_job):
+        """Changing title does not affect raw path."""
+        path_before = sample_job.build_raw_path()
+        sample_job.title = "Something Else"
+        sample_job.title_auto = "Something Else"
+        assert sample_job.build_raw_path() == path_before
+
+    def test_build_raw_path_independent_of_manual_title(self, sample_job):
+        """Manual title correction does not affect raw path."""
+        path_before = sample_job.build_raw_path()
+        sample_job.title_manual = "Serial Mom"
+        assert sample_job.build_raw_path() == path_before
+
+    def test_build_transcode_path(self, sample_job):
+        assert sample_job.build_transcode_path() == "/home/arm/media/transcode/movies/SERIAL_MOM (1994)"
+
+    def test_build_final_path(self, sample_job):
+        assert sample_job.build_final_path() == "/home/arm/media/completed/movies/SERIAL_MOM (1994)"
+
+    def test_build_paths_with_manual_title(self, sample_job):
+        sample_job.title_manual = "Serial Mom"
+        # raw_path uses GUID (independent of title)
+        assert sample_job.build_raw_path() == f"/home/arm/media/raw/{sample_job.guid}"
+        # transcode and final use formatted_title (prefers manual)
+        assert sample_job.build_transcode_path() == "/home/arm/media/transcode/movies/Serial Mom (1994)"
+        assert sample_job.build_final_path() == "/home/arm/media/completed/movies/Serial Mom (1994)"
+
+    def test_build_paths_series(self, sample_job):
+        sample_job.video_type = "series"
+        assert sample_job.build_transcode_path() == "/home/arm/media/transcode/tv/SERIAL_MOM (1994)"
+        assert sample_job.build_final_path() == "/home/arm/media/completed/tv/SERIAL_MOM (1994)"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest test/test_job_model.py::TestBuildPaths -v
+```
+
+Expected: FAIL - `build_raw_path` still returns title-based path.
+
+- [ ] **Step 3: Rewrite build_raw_path**
+
+In `arm/models/job.py`, replace `build_raw_path` (lines 453-457):
+
+```python
+    def build_raw_path(self):
+        """Compute the raw rip directory path. Uses GUID for uniqueness -
+        no dependency on title fields, no collision handling needed."""
+        return os.path.join(str(self.config.RAW_PATH), str(self.guid))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest test/test_job_model.py::TestBuildPaths -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+pytest test/ -v
+```
+
+Expected: Some tests may need updating if they assert specific raw path formats. Fix any failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add arm/models/job.py test/test_job_model.py
+git commit -m "feat: build_raw_path uses GUID instead of title"
+```
+
+---
+
+### Task 3: Simplify `setup_rawpath` (remove collision branch)
+
+**Files:**
+- Modify: `arm/ripper/makemkv.py:1234-1263` (`setup_rawpath`)
+- Modify: `test/test_makemkv_coverage.py:438-464` (`TestSetupRawpath`)
+
+- [ ] **Step 1: Rewrite setup_rawpath tests**
+
+In `test/test_makemkv_coverage.py`, replace `TestSetupRawpath`:
+
+```python
+class TestSetupRawpath:
+    """Test setup_rawpath() directory creation with GUID-based paths."""
+
+    def test_creates_new_path(self, tmp_path):
+        from arm.ripper.makemkv import setup_rawpath
+
+        job = unittest.mock.MagicMock()
+        raw = str(tmp_path / "raw" / "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        result = setup_rawpath(job, raw)
+        assert result == raw
+        assert os.path.isdir(raw)
+
+    def test_existing_path_is_reused(self, tmp_path):
+        """With GUID paths, collision is impossible. If dir exists (e.g. retry),
+        just reuse it."""
+        from arm.ripper.makemkv import setup_rawpath
+
+        raw = str(tmp_path / "raw" / "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        os.makedirs(raw)
+
+        job = unittest.mock.MagicMock()
+        result = setup_rawpath(job, raw)
+        assert result == raw
+        assert os.path.isdir(raw)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest test/test_makemkv_coverage.py::TestSetupRawpath -v
+```
+
+Expected: `test_existing_path_is_reused` FAILS because current code appends timestamp.
+
+- [ ] **Step 3: Simplify setup_rawpath**
+
+In `arm/ripper/makemkv.py`, replace `setup_rawpath` (lines 1234-1263):
+
+```python
+def setup_rawpath(job, raw_path):
+    """Create the raw rip output directory.
+
+    With GUID-based paths, collision is not possible. If the directory
+    already exists (e.g. retry after partial rip), reuse it.
+
+    Parameters:
+        job: arm.models.job.Job
+        raw_path: str - absolute path to create
+    Returns:
+        str: the raw_path (unchanged)
+    """
+    logging.info(f"Destination is {raw_path}")
+    try:
+        os.makedirs(raw_path, exist_ok=True)
+    except OSError:
+        err = f"Couldn't create the base file path: {raw_path}. Probably a permissions error"
+        logging.error(err)
+        raise
+    return raw_path
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest test/test_makemkv_coverage.py::TestSetupRawpath -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+pytest test/ -v
+```
+
+Expected: PASS. Some folder_ripper or rip_logic tests may mock `setup_rawpath` - verify they still work.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add arm/ripper/makemkv.py test/test_makemkv_coverage.py
+git commit -m "feat: simplify setup_rawpath - GUID paths eliminate collisions"
+```
+
+---
+
+### Task 4: Make `clean_for_filename` public in naming.py, delete the other two
+
+**Files:**
+- Modify: `arm/ripper/naming.py:84-93` (rename `_clean_for_filename` to `clean_for_filename`)
+- Modify: `arm/ripper/utils.py:197,928-941` (delete function, update import)
+- Modify: `arm/api/v1/jobs.py:422-423,992-1000` (delete function, remove callsite)
+- Modify: `test/test_utils.py:123-159` (delete `TestCleanForFilename`)
+- Modify: `test/test_naming.py:272-296` (update import)
+
+- [ ] **Step 1: Rename in naming.py**
+
+In `arm/ripper/naming.py`, rename `_clean_for_filename` to `clean_for_filename` (line 84). Also update all internal references in the same file:
+
+- Line 84: `def clean_for_filename(s):` (was `_clean_for_filename`)
+- Line 147: `segments = [clean_for_filename(seg) for seg in segments if seg.strip()]`
+- Line 199: `return clean_for_filename(track.custom_filename)`
+- Line 272: `segments = [clean_for_filename(seg) for seg in segments if seg.strip()]`
+
+- [ ] **Step 2: Update utils.py webhook import**
+
+In `arm/ripper/utils.py` line 197, change:
+
+```python
+    from arm.ripper.naming import render_folder, render_title, render_all_tracks, _clean_for_filename
+```
+
+to:
+
+```python
+    from arm.ripper.naming import render_folder, render_title, render_all_tracks, clean_for_filename
+```
+
+Update references at lines 214 and 244 from `_clean_for_filename` to `clean_for_filename`.
+
+- [ ] **Step 3: Delete `utils.clean_for_filename`**
+
+In `arm/ripper/utils.py`, delete lines 928-941 (the `clean_for_filename` function).
+
+- [ ] **Step 4: Delete `jobs.py _clean_for_filename`**
+
+In `arm/api/v1/jobs.py`, delete lines 992-1000 (the `_clean_for_filename` function).
+
+- [ ] **Step 5: Remove sanitization from API title edit**
+
+In `arm/api/v1/jobs.py` line 422-423, remove the sanitization:
+
+Before:
+```python
+        if key == 'title':
+            value = _clean_for_filename(value)
+```
+
+After: delete those two lines entirely. The `value = str(body[key]).strip()` on line 421 is sufficient.
+
+- [ ] **Step 6: Update test imports**
+
+In `test/test_naming.py`, update the import at the top from `_clean_for_filename` to `clean_for_filename`, and update the test function calls (lines 272-296) to use `clean_for_filename`.
+
+In `test/test_utils.py`, delete the entire `TestCleanForFilename` class (lines 123-159).
+
+- [ ] **Step 7: Run tests**
+
+```bash
+pytest test/test_naming.py test/test_utils.py -v
+```
+
+Expected: PASS
+
+- [ ] **Step 8: Run full test suite**
+
+```bash
+pytest test/ -v
+```
+
+Expected: PASS. Any test that imports `utils.clean_for_filename` or `_clean_for_filename` from jobs.py needs updating.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add arm/ripper/naming.py arm/ripper/utils.py arm/api/v1/jobs.py test/test_naming.py test/test_utils.py
+git commit -m "refactor: consolidate to single clean_for_filename in naming.py"
+```
+
+---
+
+### Task 5: Remove aggressive sanitization from `identify.py` and `music_brainz.py`
+
+**Files:**
+- Modify: `arm/ripper/identify.py:547` (`update_job`)
+- Modify: `arm/ripper/music_brainz.py:375-387`
+- Create: `test/test_identify_no_sanitize.py`
+
+- [ ] **Step 1: Write failing test for clean title storage**
+
+Create `test/test_identify_no_sanitize.py`:
+
+```python
+"""Tests that identification stores clean, unsanitized titles."""
+import unittest.mock
+
+from arm.ripper import identify
+
+
+class TestUpdateJobNoSanitize:
+    """update_job should store API titles without aggressive sanitization."""
+
+    def test_title_preserves_spaces(self, app_context, sample_job):
+        """Metadata title 'Serial Mom' should not become 'Serial-Mom'."""
+        match = unittest.mock.MagicMock()
+        match.title = "Serial Mom"
+        match.year = "1994"
+        match.type = "movie"
+        match.imdb_id = "tt0111127"
+        match.poster_url = ""
+        match.score = 0.95
+        match.title_score = 0.95
+        match.year_score = 1.0
+        match.type_score = 1.0
+
+        selection = unittest.mock.MagicMock()
+        selection.confident = True
+        selection.best = match
+        selection.all_scored = [match]
+        selection.label_info = None
+
+        sample_job.label = "SERIAL_MOM"
+
+        with unittest.mock.patch('arm.ripper.identify.arm_matcher') as mock_matcher:
+            mock_matcher.return_value = selection
+            identify.update_job(sample_job, [{"Title": "Serial Mom", "Year": "1994"}])
+
+        assert sample_job.title == "Serial Mom"
+        assert " " in sample_job.title  # spaces preserved, not converted to hyphens
+
+    def test_title_preserves_colons(self, app_context, sample_job):
+        """Colons in metadata titles are preserved for display/search."""
+        match = unittest.mock.MagicMock()
+        match.title = "Star Wars: A New Hope"
+        match.year = "1977"
+        match.type = "movie"
+        match.imdb_id = "tt0076759"
+        match.poster_url = ""
+        match.score = 0.95
+        match.title_score = 0.95
+        match.year_score = 1.0
+        match.type_score = 1.0
+
+        selection = unittest.mock.MagicMock()
+        selection.confident = True
+        selection.best = match
+        selection.all_scored = [match]
+        selection.label_info = None
+
+        sample_job.label = "STAR_WARS"
+
+        with unittest.mock.patch('arm.ripper.identify.arm_matcher') as mock_matcher:
+            mock_matcher.return_value = selection
+            identify.update_job(sample_job, [{"Title": "Star Wars: A New Hope", "Year": "1977"}])
+
+        assert sample_job.title == "Star Wars: A New Hope"
+
+
+class TestMusicBrainzNoSanitize:
+    """music_brainz should return clean artist + title without filesystem sanitization."""
+
+    def test_return_value_preserves_spaces(self, app_context, sample_job):
+        """Return value should be 'Artist Title', not 'Artist-Title'."""
+        import arm.ripper.music_brainz as mb
+        import musicbrainzngs
+
+        disc_info = {
+            'disc': {
+                'release-list': [{
+                    'id': 'test-release-id',
+                    'title': 'The Dark Side of the Moon',
+                    'artist-credit': [{'artist': {'name': 'Pink Floyd'}}],
+                    'date': '1973-03-01',
+                    'medium-list': [{'disc-list': [{}], 'track-list': []}],
+                }]
+            }
+        }
+
+        with unittest.mock.patch.object(mb, 'get_cd_art', return_value=False), \
+             unittest.mock.patch.object(musicbrainzngs, 'get_releases_by_discid',
+                                        return_value=disc_info):
+            result = mb.music_brainz('fake-disc-id', sample_job)
+
+        # Should contain spaces, not hyphens between words
+        assert "Pink Floyd" in result
+        assert "The Dark Side of the Moon" in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest test/test_identify_no_sanitize.py -v
+```
+
+Expected: FAIL - title gets aggressively sanitized.
+
+- [ ] **Step 3: Remove sanitization from update_job**
+
+In `arm/ripper/identify.py` line 547, change:
+
+```python
+    title = utils.clean_for_filename(best.title)
+```
+
+to:
+
+```python
+    title = best.title
+```
+
+- [ ] **Step 4: Remove sanitization from music_brainz.py**
+
+In `arm/ripper/music_brainz.py` line 375, change:
+
+```python
+        clean_title = u.clean_for_filename(artist) + "-" + u.clean_for_filename(title)
+```
+
+to:
+
+```python
+        clean_title = f"{artist} {title}"
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+pytest test/test_identify_no_sanitize.py -v
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+pytest test/ -v
+```
+
+Expected: PASS. Some music_brainz tests may assert hyphens in return values - update those.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add arm/ripper/identify.py arm/ripper/music_brainz.py test/test_identify_no_sanitize.py
+git commit -m "feat: store clean titles without aggressive sanitization"
+```
+
+---
+
+### Task 6: Add `disc_number`/`disc_total` to naming engine variables
+
+**Files:**
+- Modify: `arm/ripper/naming.py:50-76` (`_build_variables`)
+- Modify: `test/test_naming.py`
+
+Note: `disc_number` and `disc_total` columns already exist on the Job model (lines 153-154) and migration `d3e4f5a6b7c8` already created them. We just need to wire them into the naming pattern engine.
+
+- [ ] **Step 1: Write failing test**
+
+Add to `test/test_naming.py`:
+
+```python
+def test_disc_number_in_pattern():
+    """disc_number variable is available in naming patterns."""
+    job = _make_job(title='Dynasties', year='2018', video_type='movie')
+    job.disc_number = 2
+    cfg = {'MOVIE_TITLE_PATTERN': '{title} - Disc {disc_number}'}
+    assert render_title(job, cfg) == 'Dynasties - Disc 2'
+
+
+def test_disc_number_omitted_when_none():
+    """Missing disc_number renders as empty string (cleaned up by pattern engine)."""
+    job = _make_job(title='Dynasties', year='2018', video_type='movie')
+    job.disc_number = None
+    cfg = {'MOVIE_TITLE_PATTERN': '{title} ({year})'}
+    assert render_title(job, cfg) == 'Dynasties (2018)'
+
+
+def test_disc_total_in_pattern():
+    job = _make_job(title='Dynasties', year='2018', video_type='movie')
+    job.disc_number = 2
+    job.disc_total = 3
+    cfg = {'MOVIE_FOLDER_PATTERN': '{title} ({year})/Disc {disc_number} of {disc_total}'}
+    assert render_folder(job, cfg) == os.path.join('Dynasties (2018)', 'Disc 2 of 3')
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest test/test_naming.py::test_disc_number_in_pattern test/test_naming.py::test_disc_number_omitted_when_none test/test_naming.py::test_disc_total_in_pattern -v
+```
+
+Expected: FAIL - `disc_number` not in pattern variables.
+
+- [ ] **Step 3: Add disc_number/disc_total to _build_variables**
+
+In `arm/ripper/naming.py`, update `_build_variables` (around line 67):
+
+```python
+    return _SafeDict({
+        'title': title,
+        'year': year,
+        'artist': artist,
+        'album': album,
+        'season': season,
+        'episode': episode,
+        'label': getattr(job, 'label', '') or '',
+        'video_type': getattr(job, 'video_type', '') or '',
+        'disc_number': str(getattr(job, 'disc_number', '') or ''),
+        'disc_total': str(getattr(job, 'disc_total', '') or ''),
+    })
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest test/test_naming.py -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add arm/ripper/naming.py test/test_naming.py
+git commit -m "feat: add disc_number/disc_total to naming pattern variables"
+```
+
+---
+
+### Task 7: Add `finalize_output()` for transcoder-disabled deployments
+
+**Files:**
+- Modify: `arm/ripper/naming.py` (add `finalize_output` function)
+- Create: `test/test_finalize_output.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `test/test_finalize_output.py`:
+
+```python
+"""Tests for finalize_output() — moves files from GUID work dir to final library."""
+import os
+import unittest.mock
+
+import pytest
+
+from arm.ripper.naming import finalize_output
+
+
+class TestFinalizeOutput:
+    """finalize_output moves ripped files from GUID raw dir to final named path."""
+
+    def test_moves_single_movie(self, app_context, sample_job, tmp_path):
+        """Single MKV file moved to completed path with rendered name."""
+        # Setup: create raw GUID dir with one MKV
+        raw_dir = tmp_path / "raw" / sample_job.guid
+        raw_dir.mkdir(parents=True)
+        (raw_dir / "B1_t00.mkv").write_bytes(b"fake mkv")
+
+        sample_job.raw_path = str(raw_dir)
+        sample_job.config.COMPLETED_PATH = str(tmp_path / "completed")
+        sample_job.video_type = "movie"
+        sample_job.title = "Serial Mom"
+        sample_job.year = "1994"
+
+        finalize_output(sample_job)
+
+        # File should be in completed/movies/Serial Mom (1994)/
+        final_dir = tmp_path / "completed" / "movies"
+        assert final_dir.exists()
+        # At least one .mkv file in the final tree
+        mkv_files = list(final_dir.rglob("*.mkv"))
+        assert len(mkv_files) == 1
+
+    def test_moves_multiple_tracks(self, app_context, sample_job, tmp_path):
+        """Multi-title disc: each track gets its rendered name."""
+        from arm.models.track import Track
+        from arm.database import db
+
+        raw_dir = tmp_path / "raw" / sample_job.guid
+        raw_dir.mkdir(parents=True)
+        (raw_dir / "B1_t00.mkv").write_bytes(b"fake")
+        (raw_dir / "B1_t01.mkv").write_bytes(b"fake")
+
+        sample_job.raw_path = str(raw_dir)
+        sample_job.config.COMPLETED_PATH = str(tmp_path / "completed")
+        sample_job.video_type = "movie"
+        sample_job.title = "Serial Mom"
+        sample_job.year = "1994"
+
+        # Create track records
+        t1 = Track(job_id=sample_job.job_id, track_number=0, filename="B1_t00.mkv", ripped=True)
+        t2 = Track(job_id=sample_job.job_id, track_number=1, filename="B1_t01.mkv", ripped=True)
+        db.session.add_all([t1, t2])
+        db.session.commit()
+
+        finalize_output(sample_job)
+
+        final_dir = tmp_path / "completed" / "movies"
+        mkv_files = list(final_dir.rglob("*.mkv"))
+        assert len(mkv_files) == 2
+
+    def test_cleans_up_empty_raw_dir(self, app_context, sample_job, tmp_path):
+        """After moving all files, empty GUID directory is removed."""
+        raw_dir = tmp_path / "raw" / sample_job.guid
+        raw_dir.mkdir(parents=True)
+        (raw_dir / "B1_t00.mkv").write_bytes(b"fake")
+
+        sample_job.raw_path = str(raw_dir)
+        sample_job.config.COMPLETED_PATH = str(tmp_path / "completed")
+
+        finalize_output(sample_job)
+
+        assert not raw_dir.exists()
+
+    def test_updates_job_path(self, app_context, sample_job, tmp_path):
+        """job.path is updated to the final directory after move."""
+        raw_dir = tmp_path / "raw" / sample_job.guid
+        raw_dir.mkdir(parents=True)
+        (raw_dir / "B1_t00.mkv").write_bytes(b"fake")
+
+        sample_job.raw_path = str(raw_dir)
+        sample_job.config.COMPLETED_PATH = str(tmp_path / "completed")
+
+        finalize_output(sample_job)
+
+        assert sample_job.path is not None
+        assert "completed" in sample_job.path
+
+    def test_noop_if_no_raw_path(self, app_context, sample_job):
+        """No error if raw_path is not set."""
+        sample_job.raw_path = None
+        finalize_output(sample_job)  # should not raise
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest test/test_finalize_output.py -v
+```
+
+Expected: FAIL - `ImportError: cannot import name 'finalize_output'`
+
+- [ ] **Step 3: Implement finalize_output**
+
+In `arm/ripper/naming.py`, add at the end of the file:
+
+```python
+def finalize_output(job):
+    """Move ripped files from GUID work directory to final named location.
+
+    Used when the transcoder is disabled - ARM handles final naming directly.
+    Renders folder/file names via the naming engine, moves files, updates job.path,
+    and cleans up the empty work directory.
+    """
+    import shutil
+    from arm.database import db
+    import arm.config.config as cfg
+
+    raw_path = getattr(job, 'raw_path', None)
+    if not raw_path or not os.path.isdir(raw_path):
+        logging.warning("finalize_output: no raw_path for job %s", getattr(job, 'job_id', '?'))
+        return
+
+    config_dict = cfg.arm_config if hasattr(cfg, 'arm_config') else None
+    final_dir = job.build_final_path()
+    os.makedirs(final_dir, exist_ok=True)
+
+    # Get rendered names for each track
+    rendered = render_all_tracks(job, config_dict)
+    rendered_map = {r["track_number"]: r for r in rendered}
+
+    moved_count = 0
+    for track in job.tracks:
+        if not track.filename:
+            continue
+        src = os.path.join(raw_path, track.filename)
+        if not os.path.isfile(src):
+            continue
+
+        r = rendered_map.get(str(track.track_number or ''), {})
+        rendered_title = r.get("rendered_title", '')
+        rendered_folder = r.get("rendered_folder", '')
+
+        if rendered_title:
+            dest_name = clean_for_filename(rendered_title) + os.path.splitext(track.filename)[1]
+        else:
+            dest_name = track.filename
+
+        if rendered_folder:
+            dest_dir = os.path.join(final_dir, rendered_folder)
+        else:
+            dest_dir = final_dir
+
+        os.makedirs(dest_dir, exist_ok=True)
+        shutil.move(src, os.path.join(dest_dir, dest_name))
+        moved_count += 1
+
+    # If no tracks (single-title disc without track records), move all MKVs
+    if moved_count == 0:
+        for fname in os.listdir(raw_path):
+            if fname.lower().endswith('.mkv'):
+                rendered_title = render_title(job, config_dict)
+                if rendered_title:
+                    dest_name = clean_for_filename(rendered_title) + '.mkv'
+                else:
+                    dest_name = fname
+                shutil.move(os.path.join(raw_path, fname), os.path.join(final_dir, dest_name))
+
+    # Update job.path and clean up
+    job.path = final_dir
+    db.session.commit()
+
+    # Remove empty work directory
+    try:
+        if os.path.isdir(raw_path) and not os.listdir(raw_path):
+            os.rmdir(raw_path)
+    except OSError:
+        pass
+
+    logging.info("finalize_output: moved %d files to %s", moved_count, final_dir)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest test/test_finalize_output.py -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add arm/ripper/naming.py test/test_finalize_output.py
+git commit -m "feat: add finalize_output for transcoder-disabled deployments"
+```
+
+---
+
+### Task 8: Wire `finalize_output` into rip pipelines
+
+**Files:**
+- Modify: `arm/ripper/arm_ripper.py:57-71`
+- Modify: `arm/ripper/folder_ripper.py:205-218`
+
+- [ ] **Step 1: Update arm_ripper.py**
+
+In `arm/ripper/arm_ripper.py`, replace lines 57-71:
+
+```python
+    # Persist raw_path to DB — this is the actual directory on disk
+    utils.database_updater({'raw_path': makemkv_out_path}, job)
+
+    # Determine whether to hand off to transcoder or finalize locally
+    import arm.config.config as cfg
+    transcoder_url = cfg.arm_config.get('TRANSCODER_URL', '')
+
+    if transcoder_url:
+        if job.config.NOTIFY_RIP:
+            # notify() also calls transcoder_notify internally
+            utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete.")
+        else:
+            # Always notify the transcoder when TRANSCODER_URL is set, even if
+            # NOTIFY_RIP is off.  The transcoder webhook is a pipeline trigger,
+            # not a user notification.
+            utils.transcoder_notify(
+                cfg.arm_config, constants.NOTIFY_TITLE,
+                f"{job.title} rip complete.", job,
+            )
+    else:
+        # No transcoder — finalize output locally
+        from arm.ripper.naming import finalize_output
+        logging.info("No transcoder configured — finalizing output locally")
+        finalize_output(job)
+        if job.config.NOTIFY_RIP:
+            utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete.")
+```
+
+- [ ] **Step 2: Update folder_ripper.py**
+
+In `arm/ripper/folder_ripper.py`, replace lines 205-218:
+
+```python
+        # 7. Notify transcoder or finalize locally
+        transcoder_url = cfg.arm_config.get("TRANSCODER_URL", "")
+        if transcoder_url:
+            utils.transcoder_notify(
+                cfg.arm_config,
+                "ARM Notification",
+                f"{job.title} folder import rip complete.",
+                job,
+            )
+            job.status = JobState.TRANSCODE_WAITING.value
+        else:
+            from arm.ripper.naming import finalize_output
+            log.info("No transcoder configured — finalizing output locally")
+            finalize_output(job)
+            job.status = JobState.SUCCESS.value
+
+        db.session.commit()
+        log.info("Folder import rip complete for job %s", job.job_id)
+```
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+pytest test/ -v
+```
+
+Expected: PASS. Mocked tests should still work since they mock `transcoder_notify`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add arm/ripper/arm_ripper.py arm/ripper/folder_ripper.py
+git commit -m "feat: call finalize_output when transcoder is disabled"
+```
+
+---
+
+### Task 9: Add `disc_number`/`disc_total` to API field maps
+
+**Files:**
+- Modify: `arm/api/v1/jobs.py:398-411` (`_FIELD_MAP`, `_DIRECT_FIELDS`)
+
+- [ ] **Step 1: Update field maps**
+
+`disc_number` and `disc_total` are already in `_DIRECT_FIELDS` on line 409:
+
+```python
+_DIRECT_FIELDS = ('path', 'label', 'disctype', 'disc_number', 'disc_total')
+```
+
+These are already editable via the title edit endpoint. No code change needed here - verify with a test.
+
+- [ ] **Step 2: Write test to verify disc_number is editable via API**
+
+Add to test file for API (or create if needed):
+
+```python
+def test_disc_number_editable_via_title_endpoint(self, app_context, sample_job, client):
+    """disc_number can be set via PUT /jobs/{id}/title."""
+    from arm.database import db
+    db.session.add(sample_job)
+    db.session.commit()
+
+    resp = client.put(
+        f"/api/v1/jobs/{sample_job.job_id}/title",
+        json={"disc_number": 2, "disc_total": 3},
+    )
+    assert resp.status_code == 200
+    assert sample_job.disc_number == 2
+    assert sample_job.disc_total == 3
+```
+
+- [ ] **Step 3: Run test**
+
+```bash
+pytest test/ -k "disc_number_editable" -v
+```
+
+Expected: PASS (already supported).
+
+- [ ] **Step 4: Commit (if any changes were needed)**
+
+```bash
+git add -A && git commit -m "test: verify disc_number/disc_total API editability"
+```
+
+---
+
+### Task 10: Final integration pass - run full test suite and CI checks
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite with coverage**
+
+```bash
+pytest test/ -v --cov=arm --cov-report=term-missing
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 2: Check for any remaining references to deleted functions**
+
+```bash
+grep -rn "utils.clean_for_filename\|from arm.ripper.utils import.*clean_for_filename" arm/ test/
+grep -rn "_clean_for_filename" arm/api/
+```
+
+Expected: No hits (all references removed).
+
+- [ ] **Step 3: Check for any remaining imports of deleted code**
+
+```bash
+grep -rn "from arm.ripper.naming import.*_clean_for_filename" arm/ test/
+```
+
+Expected: No hits (all switched to `clean_for_filename` without underscore).
+
+- [ ] **Step 4: Verify linting passes**
+
+```bash
+python -m py_compile arm/models/job.py
+python -m py_compile arm/ripper/naming.py
+python -m py_compile arm/ripper/identify.py
+python -m py_compile arm/ripper/utils.py
+python -m py_compile arm/ripper/makemkv.py
+python -m py_compile arm/ripper/arm_ripper.py
+python -m py_compile arm/ripper/folder_ripper.py
+python -m py_compile arm/ripper/music_brainz.py
+python -m py_compile arm/api/v1/jobs.py
+```
+
+Expected: No syntax errors.
+
+- [ ] **Step 5: Final commit if any fixups needed, then prepare PR**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Review commit history, then create PR.

--- a/docs/superpowers/specs/2026-04-06-naming-lifecycle-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-06-naming-lifecycle-cleanup-design.md
@@ -1,0 +1,296 @@
+# Naming Lifecycle Cleanup - Design Spec
+
+**Date:** 2026-04-06
+**Branch:** TBD (feature/naming-lifecycle-cleanup)
+**Status:** Draft
+
+## Problem
+
+`job.title` is a single field serving three conflicting roles:
+
+1. **Display** (UI, logs, notifications) - wants human-readable text
+2. **Metadata search** (OMDb/TMDB queries) - wants clean text without filesystem artifacts
+3. **Filesystem paths** (raw rip directories) - wants sanitized, OS-safe characters
+
+Different identification paths apply different sanitization before storing `job.title`:
+
+- `identify_bluray`: light sanitization (only strips OS-illegal chars, PR #186)
+- `update_job` metadata match: aggressive `utils.clean_for_filename` (spaces to hyphens, strips brackets)
+- `_apply_label_as_title`: light (underscores to spaces, title-case)
+
+Three separate `clean_for_filename` implementations exist with different behavior:
+
+| Location | Behavior |
+|----------|----------|
+| `arm/ripper/utils.py:928` | Aggressive - spaces to hyphens, strips brackets, collapses hyphens |
+| `arm/ripper/naming.py:84` | Conservative - preserves spaces/parens, prevents traversal |
+| `arm/api/v1/jobs.py:992` | API variant - preserves spaces, no traversal protection |
+
+**User-reported symptom:** Blu-ray XML title `Dynasties - Disc 2` was stored as `Dynasties-Disc-2`, causing 8+ wasted OMDb API calls before the fallback loop stripped enough hyphens to find the real title.
+
+## Solution Overview
+
+1. **GUID-based work paths** - raw/work directories use job GUID, not title. Eliminates filesystem dependency on title quality entirely.
+2. **Clean title storage** - stop sanitizing titles at store time. Store human-readable text for display and search.
+3. **Single sanitization function** - consolidate three implementations into one public `naming.clean_for_filename`.
+4. **Structured disc metadata** - `disc_number`/`disc_total` as DB columns instead of embedded in title strings.
+5. **Deferred naming** - human-readable names produced only at final placement, via the naming engine.
+6. **DB-based file correlation** - all file-to-record lookups go through DB (job_id/guid/track_number), never by parsing directory or file names.
+
+## Design
+
+### 1. GUID-based work paths
+
+#### New column
+
+`job.guid` - String(36), UUID4, non-nullable, unique. Set in `Job.__init__` at job creation time.
+
+```python
+import uuid
+
+class Job(db.Model):
+    guid = db.Column(db.String(36), nullable=False, unique=True, default=lambda: str(uuid.uuid4()))
+```
+
+Tracks do not need GUIDs. They are always looked up by `job_id` + `track_number`, and MakeMKV output files are correlated to tracks via track number, not filename.
+
+#### build_raw_path
+
+```python
+def build_raw_path(self):
+    """Raw rip directory path. Uses GUID for uniqueness."""
+    return os.path.join(str(self.config.RAW_PATH), str(self.guid))
+```
+
+No dependency on any title field. GUID guarantees uniqueness - no collision handling needed.
+
+#### setup_rawpath
+
+Simplified to just create the directory. The entire collision/timestamp branch is removed.
+
+```python
+def setup_rawpath(job, raw_path):
+    """Create the raw rip output directory."""
+    logging.info(f"Destination is {raw_path}")
+    os.makedirs(raw_path, exist_ok=True)
+    return raw_path
+```
+
+#### File-to-record correlation
+
+Any code that currently identifies files by matching against title-based directory names must switch to DB lookups:
+
+- **Raw directory lookup:** Use `job.guid` to find the directory, or query `Job.raw_path` (absolute path stored in DB after rip starts).
+- **Track file matching:** Use `track.track_number` and `track.filename` (MakeMKV's original filename like `B1_t00.mkv`), never parse the containing directory name.
+- **Transcoder input:** Webhook includes `path` (GUID basename) and per-track `filename` values - transcoder matches files by filename within the GUID directory.
+
+Files to audit for path-based lookups:
+- `arm/ripper/makemkv.py` - `_scan_output_dir`, any post-rip file reconciliation
+- `arm/ripper/utils.py` - `move_files`, `transcoder_notify` raw_basename extraction
+- `arm/ripper/arm_ripper.py` - post-rip file handling
+- `arm/ripper/folder_ripper.py` - folder import file handling
+- `arm/api/v1/jobs.py` - any endpoint that resolves files from job metadata
+
+### 2. Clean title storage
+
+Remove all sanitization at title-store time. The only cleanup when setting `job.title` is stripping characters that are truly illegal (null bytes) or would break logging/DB queries.
+
+#### Changes by identification path
+
+| Location | Current | After |
+|----------|---------|-------|
+| `identify.py:547` (`update_job`) | `utils.clean_for_filename(best.title)` | Store `best.title` directly |
+| `identify.py:434` (`identify_bluray`) | Light regex `[/\\<>"\|?*\x00]` | Keep as-is (already correct) |
+| `identify.py:312` (`_apply_label_as_title`) | Replace `_` with space, `.title()` | Keep as-is |
+| `jobs.py:423` (manual title edit API) | `_clean_for_filename(value)` | Store user input directly (strip only null bytes/control chars) |
+| `jobs.py:455` (`_re_render_title`) | Writes `render_title()` output back to `title` + `title_manual` | Keep as-is - this is the naming engine producing a display value, not filesystem sanitization |
+| `jobs.py:560` (track title edit API) | `_clean_for_filename(value)` | Store user input directly |
+| `music_brainz.py:378-379` | Stores `artist + " " + title` | Keep as-is (already clean) |
+| `folder.py:103` (folder import) | Stores user-provided title | Keep as-is |
+
+#### Rationale
+
+- Metadata API results (OMDb, TMDB) are already clean human-readable text
+- User input via API should be stored as-provided (naming engine handles filesystem safety at render time)
+- Disc labels need only light cleanup (underscores, case normalization)
+- Blu-ray XML needs only OS-illegal char removal
+
+### 3. Single clean_for_filename
+
+#### Keep and make public
+
+`naming.py:_clean_for_filename` becomes `naming.clean_for_filename` (drop the underscore).
+
+This is the single authoritative sanitization function for filesystem output. It:
+- Replaces colons with ` - `
+- Normalizes whitespace
+- Replaces `&` with `and`
+- Replaces backslashes with ` - `
+- Removes non-word characters except `. ()-`
+- Prevents path traversal (`..` collapsed)
+- Strips leading/trailing dots and spaces
+
+#### Delete
+
+- `arm/ripper/utils.py:928-938` `clean_for_filename` - aggressive version, all callsites removed
+- `arm/api/v1/jobs.py:992-1000` `_clean_for_filename` - API variant, callsites no longer sanitize at store time
+
+#### Remaining callsites after consolidation
+
+All internal to the naming engine (called at render time, not store time):
+- `naming.render_folder` - sanitizes each path segment
+- `naming.render_track_title` - sanitizes custom filenames
+- `naming.render_track_folder` - sanitizes each path segment
+- `utils._build_webhook_payload` - sanitizes rendered title for webhook
+
+#### music_brainz.py:375
+
+```python
+clean_title = u.clean_for_filename(artist) + "-" + u.clean_for_filename(title)
+```
+
+This return value is used as `job.label` in `job.py:258`. Switch to:
+
+```python
+clean_title = f"{artist} {title}"
+```
+
+The label is a display/identification value, not a filesystem path. No sanitization needed.
+
+### 4. Structured disc metadata
+
+#### New columns
+
+```python
+disc_number = db.Column(db.Integer, nullable=True)    # e.g. 2 for "Disc 2"
+disc_total = db.Column(db.Integer, nullable=True)      # e.g. 3 for a 3-disc set
+```
+
+#### Extraction
+
+During identification, parse disc number from:
+- Blu-ray XML title: `"Dynasties - Disc 2"` -> `title="Dynasties"`, `disc_number=2`
+- DVD label: `"DYNASTIES_DISC_2"` -> same
+- Regex patterns to detect (case-insensitive, applied in order):
+  - `[- ]+Disc\s+(\d+)` - "Dynasties - Disc 2"
+  - `[- ]+Disk\s+(\d+)` - "Dynasties - Disk 2"
+  - `[_-]+D(\d+)$` - "DYNASTIES_D2" (label format)
+  - `[- ]+Part\s+(\d+)` - "Dynasties - Part 2"
+
+The matched suffix is stripped from the title. The captured group becomes `disc_number`. If no pattern matches, `disc_number` stays NULL and the title is stored as-is.
+
+#### Naming pattern variable
+
+Available as `{disc_number}` and `{disc_total}` in naming patterns:
+- `{title} - Disc {disc_number}` -> `"Dynasties - Disc 2"`
+- `{title} ({year})` -> `"Dynasties (2018)"` (disc number omitted if not in pattern)
+
+Add corresponding `_auto` / `_manual` columns for consistency with the existing field pattern:
+- `disc_number_auto`, `disc_number_manual`
+- `disc_total_auto`, `disc_total_manual`
+
+### 5. Deferred naming - three paths
+
+Human-readable output names are produced at exactly one moment, depending on the pipeline:
+
+#### Path A: Transcoder enabled (current default)
+
+1. Rip completes -> files in `{RAW_PATH}/{guid}/`
+2. ARM builds webhook payload with pre-rendered names from naming engine (`render_folder`, `render_title`, `render_all_tracks`)
+3. Transcoder receives payload, transcodes files, places output at rendered paths
+4. No change to this flow - naming engine already handles it
+
+#### Path B: Transcoder disabled
+
+1. Rip completes -> files in `{RAW_PATH}/{guid}/`
+2. New function `finalize_output(job)`:
+   - Renders final folder/file names via naming engine
+   - Moves files from GUID work directory to `{COMPLETED_PATH}/{rendered_folder}/{rendered_title}.mkv`
+   - Handles per-track naming for multi-title discs
+   - Updates `job.path` to final location
+   - Cleans up empty GUID work directory
+3. Called from `arm_ripper.rip_visual_media` when `SKIP_TRANSCODE=true` or `TRANSCODER_URL` not configured
+
+#### Path C: Music rip
+
+1. abcde handles rip + encoding + output naming via its own config (`OUTPUTDIR`)
+2. No change - music pipeline is independent of the video naming engine
+
+### 6. Webhook contract
+
+#### Changes
+
+| Field | Before | After | Breaking? |
+|-------|--------|-------|-----------|
+| `path` | Title-based basename (e.g. `"Dynasties-Disc-2"`) | GUID basename (e.g. `"a1b2c3d4-..."`) | Yes - transcoder must use this as opaque directory name (it already does) |
+| All other fields | Unchanged | Unchanged | No |
+
+The transcoder already treats `path` as an opaque string - it concatenates `{input_base}/{path}/` to find MKV files. The switch from title-based to GUID-based should be transparent.
+
+**Coordinated release required:** Transcoder must accept GUID-format `path` values. Since it doesn't parse the path, this should be a no-op, but verify with integration test.
+
+### 7. Database migration
+
+Single Alembic migration:
+
+```python
+# New columns
+op.add_column('job', sa.Column('guid', sa.String(36), nullable=True, unique=True))
+op.add_column('job', sa.Column('disc_number', sa.Integer(), nullable=True))
+op.add_column('job', sa.Column('disc_number_auto', sa.Integer(), nullable=True))
+op.add_column('job', sa.Column('disc_number_manual', sa.Integer(), nullable=True))
+op.add_column('job', sa.Column('disc_total', sa.Integer(), nullable=True))
+op.add_column('job', sa.Column('disc_total_auto', sa.Integer(), nullable=True))
+op.add_column('job', sa.Column('disc_total_manual', sa.Integer(), nullable=True))
+
+# Backfill existing rows with generated UUIDs
+for row in conn.execute(sa.text("SELECT job_id FROM job WHERE guid IS NULL")):
+    conn.execute(
+        sa.text("UPDATE job SET guid = :guid WHERE job_id = :id"),
+        {"guid": str(uuid.uuid4()), "id": row.job_id},
+    )
+
+# Make guid non-nullable after backfill
+op.alter_column('job', 'guid', nullable=False)
+```
+
+Existing `raw_path` values in the DB are absolute paths, so old jobs continue to work - they don't depend on `build_raw_path()` after the raw path is persisted.
+
+### 8. Test changes
+
+| Action | Files | Details |
+|--------|-------|---------|
+| Delete | `test_utils.py:TestCleanForFilename` | 8 tests for removed `utils.clean_for_filename` |
+| Rewrite | `test_job_model.py` build_raw_path tests | Assert GUID-based paths instead of title-based |
+| Rewrite | `test_makemkv_coverage.py` setup_rawpath tests | No collision branch, just directory creation |
+| Update | `test_music_rip.py` | Assertions on `music_brainz.main()` return value format |
+| Add | New test file or section | `disc_number` extraction from XML titles and labels |
+| Add | New test file or section | `finalize_output` for transcoder-disabled path |
+| Add | New test file or section | GUID generation and uniqueness on Job creation |
+| Keep | `test_naming.py` | Naming engine unchanged except function visibility (private to public) |
+| Update | `conftest.py`, `test_pipeline.py` | Fixtures gain `guid` field |
+
+### 9. Files changed (complete inventory)
+
+| File | Changes |
+|------|---------|
+| `arm/models/job.py` | Add `guid`, `disc_number`, `disc_total` columns + `_auto`/`_manual` variants. Rewrite `build_raw_path` to use GUID. Update `__init__` to generate GUID. |
+| `arm/ripper/identify.py` | Remove `utils.clean_for_filename` call in `update_job` (line 547). Add disc_number extraction logic. |
+| `arm/ripper/naming.py` | Make `_clean_for_filename` public. Add `disc_number`, `disc_total` to `_build_variables`. Add `finalize_output` function. |
+| `arm/ripper/utils.py` | Delete `clean_for_filename` function. Update `_build_webhook_payload` (path field now GUID). |
+| `arm/ripper/makemkv.py` | Simplify `setup_rawpath` (remove collision branch). |
+| `arm/ripper/arm_ripper.py` | Call `finalize_output` when transcoder is disabled. |
+| `arm/ripper/music_brainz.py` | Remove `clean_for_filename` usage in return value. |
+| `arm/ripper/folder_ripper.py` | Update for GUID paths. Call `finalize_output` when transcoder is disabled. |
+| `arm/api/v1/jobs.py` | Remove `_clean_for_filename` function and its callsites (lines 423, 560, 992-1000). Add `disc_number`/`disc_total` to title edit endpoint field map. |
+| `arm/api/v1/folder.py` | Accept `disc_number`/`disc_total` in folder import. |
+| `arm/migrations/versions/` | New migration for `guid`, `disc_number`, `disc_total` columns. |
+| Tests (multiple) | See Section 8. |
+
+### 10. Out of scope
+
+- Renaming existing raw directories on disk (old jobs use stored absolute `raw_path`)
+- Changing MakeMKV's internal file naming (`B1_t00.mkv` etc.)
+- Changing the music rip pipeline (abcde manages its own output)
+- Changing the naming pattern syntax or config format
+- Modifying the transcoder's internal logic (it already treats paths as opaque)

--- a/docs/superpowers/specs/2026-04-06-naming-lifecycle-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-06-naming-lifecycle-cleanup-design.md
@@ -84,12 +84,20 @@ Any code that currently identifies files by matching against title-based directo
 - **Track file matching:** Use `track.track_number` and `track.filename` (MakeMKV's original filename like `B1_t00.mkv`), never parse the containing directory name.
 - **Transcoder input:** Webhook includes `path` (GUID basename) and per-track `filename` values - transcoder matches files by filename within the GUID directory.
 
-Files to audit for path-based lookups:
-- `arm/ripper/makemkv.py` - `_scan_output_dir`, any post-rip file reconciliation
-- `arm/ripper/utils.py` - `move_files`, `transcoder_notify` raw_basename extraction
-- `arm/ripper/arm_ripper.py` - post-rip file handling
-- `arm/ripper/folder_ripper.py` - folder import file handling
-- `arm/api/v1/jobs.py` - any endpoint that resolves files from job metadata
+Audit of all downstream file identification (completed):
+
+| Component | How it identifies files | GUID-safe? |
+|-----------|----------------------|------------|
+| `makemkv._reconcile_filenames` | Matches `track.filename` against `os.listdir(rawpath)`, then `_t\d+` suffix extraction on filenames | Yes - directory name irrelevant |
+| `makemkv._strip_track_suffix` | Regex on filenames only (`_t\d+$`) | Yes |
+| `utils._move_to_shared_storage` | `os.path.basename(job.raw_path)` | Yes - reads persisted path |
+| `utils._build_webhook_payload` | `os.path.basename(job.raw_path)` for `path` field | Yes - transcoder treats as opaque |
+| `folder_ripper` file check | `track.filename in os.listdir(rawpath)` | Yes |
+| `services/maintenance.py` orphan cleanup | `Path(job.raw_path).name` against directory listing | Yes - matches persisted basename |
+| UI file browser | `os.scandir(path)` | Yes - displays name, doesn't parse |
+| Notifications | `job.title` (display field) | Yes - never uses directory name |
+
+No component parses the directory name to extract title/metadata. All file-to-record correlation uses DB fields (`track.filename`, `track.track_number`) matched against actual files on disk.
 
 ### 2. Clean title storage
 

--- a/docs/superpowers/specs/2026-04-06-naming-lifecycle-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-06-naming-lifecycle-cleanup-design.md
@@ -193,9 +193,7 @@ Available as `{disc_number}` and `{disc_total}` in naming patterns:
 - `{title} - Disc {disc_number}` -> `"Dynasties - Disc 2"`
 - `{title} ({year})` -> `"Dynasties (2018)"` (disc number omitted if not in pattern)
 
-Add corresponding `_auto` / `_manual` columns for consistency with the existing field pattern:
-- `disc_number_auto`, `disc_number_manual`
-- `disc_total_auto`, `disc_total_manual`
+`disc_number` and `disc_total` columns already exist on the Job model (migration `d3e4f5a6b7c8`). No `_auto`/`_manual` variants needed - disc number is a structural property of the physical disc, not a metadata field that users would override independently. The API already supports editing them via `_DIRECT_FIELDS`.
 
 ### 5. Deferred naming - three paths
 
@@ -242,14 +240,8 @@ The transcoder already treats `path` as an opaque string - it concatenates `{inp
 Single Alembic migration:
 
 ```python
-# New columns
+# guid is the only new column — disc_number/disc_total already exist (migration d3e4f5a6b7c8)
 op.add_column('job', sa.Column('guid', sa.String(36), nullable=True, unique=True))
-op.add_column('job', sa.Column('disc_number', sa.Integer(), nullable=True))
-op.add_column('job', sa.Column('disc_number_auto', sa.Integer(), nullable=True))
-op.add_column('job', sa.Column('disc_number_manual', sa.Integer(), nullable=True))
-op.add_column('job', sa.Column('disc_total', sa.Integer(), nullable=True))
-op.add_column('job', sa.Column('disc_total_auto', sa.Integer(), nullable=True))
-op.add_column('job', sa.Column('disc_total_manual', sa.Integer(), nullable=True))
 
 # Backfill existing rows with generated UUIDs
 for row in conn.execute(sa.text("SELECT job_id FROM job WHERE guid IS NULL")):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1996,27 +1996,6 @@ class TestApiTvdbEpisodes:
         assert len(data["episodes"]) == 1
 
 
-class TestApiCleanForFilename:
-    """Test _clean_for_filename helper in jobs.py."""
-
-    def test_colons_replaced(self):
-        from arm.api.v1.jobs import _clean_for_filename
-        assert _clean_for_filename("Movie: Subtitle") == "Movie- Subtitle"
-
-    def test_ampersand_replaced(self):
-        from arm.api.v1.jobs import _clean_for_filename
-        assert _clean_for_filename("Tom & Jerry") == "Tom and Jerry"
-
-    def test_backslash_replaced(self):
-        from arm.api.v1.jobs import _clean_for_filename
-        assert _clean_for_filename("A\\B") == "A - B"
-
-    def test_special_chars_removed(self):
-        from arm.api.v1.jobs import _clean_for_filename
-        result = _clean_for_filename("Movie! (2024) #1")
-        assert "!" not in result
-        assert "#" not in result
-
 
 class TestApiAutoFlagTracks:
     """Test _auto_flag_tracks helper."""

--- a/test/test_drive_system_controls.py
+++ b/test/test_drive_system_controls.py
@@ -28,13 +28,16 @@ def _make_drive(db_obj, **overrides):
 
 def _make_job(db_obj, **overrides):
     """Create a test job in the DB by inserting directly."""
+    import uuid
     from sqlalchemy import text
     title = overrides.get('title', 'Test')
     status = overrides.get('status', 'success')
     video_type = overrides.get('video_type', 'movie')
     db_obj.session.execute(text(
-        "INSERT INTO job (title, status, video_type, devpath) VALUES (:t, :s, :v, :d)"
-    ), {"t": title, "s": status, "v": video_type, "d": "/dev/sr0"})
+        "INSERT INTO job (title, status, video_type, devpath, guid)"
+        " VALUES (:t, :s, :v, :d, :g)"
+    ), {"t": title, "s": status, "v": video_type, "d": "/dev/sr0",
+        "g": str(uuid.uuid4())})
     return None
 
 

--- a/test/test_finalize_output.py
+++ b/test/test_finalize_output.py
@@ -1,0 +1,193 @@
+"""Tests for finalize_output() - moves files from GUID work dir to final library."""
+import os
+import unittest.mock
+
+from arm.ripper.naming import finalize_output
+
+
+class TestFinalizeOutput:
+    """finalize_output moves ripped files from GUID raw dir to final named path."""
+
+    def test_moves_single_movie(self, app_context, sample_job, tmp_path):
+        """Single MKV file moved to completed path with rendered name."""
+        from arm.database import db
+        from arm.models.track import Track
+
+        raw_dir = tmp_path / "raw" / "test-guid"
+        raw_dir.mkdir(parents=True)
+        (raw_dir / "B1_t00.mkv").write_bytes(b"fake mkv")
+
+        sample_job.raw_path = str(raw_dir)
+        sample_job.config.COMPLETED_PATH = str(tmp_path / "completed")
+        sample_job.video_type = "movie"
+        sample_job.title = "Serial Mom"
+        sample_job.year = "1994"
+
+        t1 = Track(
+            job_id=sample_job.job_id, track_number="0", length=7200,
+            aspect_ratio="16:9", fps=23.976, main_feature=True,
+            source="MakeMKV", basename="B1_t00.mkv", filename="B1_t00.mkv",
+        )
+        t1.ripped = True
+        db.session.add(t1)
+        db.session.commit()
+
+        finalize_output(sample_job)
+
+        final_dir = tmp_path / "completed" / "movies"
+        assert final_dir.exists()
+        mkv_files = list(final_dir.rglob("*.mkv"))
+        assert len(mkv_files) == 1
+
+    def test_moves_multiple_tracks(self, app_context, sample_job, tmp_path):
+        """Multi-title disc: each track file is moved."""
+        from arm.database import db
+        from arm.models.track import Track
+
+        raw_dir = tmp_path / "raw" / "test-guid"
+        raw_dir.mkdir(parents=True)
+        (raw_dir / "B1_t00.mkv").write_bytes(b"fake")
+        (raw_dir / "B1_t01.mkv").write_bytes(b"fake")
+
+        sample_job.raw_path = str(raw_dir)
+        sample_job.config.COMPLETED_PATH = str(tmp_path / "completed")
+        sample_job.video_type = "movie"
+        sample_job.title = "Serial Mom"
+        sample_job.year = "1994"
+
+        t1 = Track(
+            job_id=sample_job.job_id, track_number="0", length=7200,
+            aspect_ratio="16:9", fps=23.976, main_feature=True,
+            source="MakeMKV", basename="B1_t00.mkv", filename="B1_t00.mkv",
+        )
+        t1.ripped = True
+        t2 = Track(
+            job_id=sample_job.job_id, track_number="1", length=3600,
+            aspect_ratio="16:9", fps=23.976, main_feature=False,
+            source="MakeMKV", basename="B1_t01.mkv", filename="B1_t01.mkv",
+        )
+        t2.ripped = True
+        db.session.add_all([t1, t2])
+        db.session.commit()
+
+        finalize_output(sample_job)
+
+        final_dir = tmp_path / "completed" / "movies"
+        mkv_files = list(final_dir.rglob("*.mkv"))
+        assert len(mkv_files) == 2
+
+    def test_cleans_up_empty_raw_dir(self, app_context, sample_job, tmp_path):
+        """After moving all files, empty GUID directory is removed."""
+        from arm.database import db
+        from arm.models.track import Track
+
+        raw_dir = tmp_path / "raw" / "test-guid"
+        raw_dir.mkdir(parents=True)
+        (raw_dir / "B1_t00.mkv").write_bytes(b"fake")
+
+        sample_job.raw_path = str(raw_dir)
+        sample_job.config.COMPLETED_PATH = str(tmp_path / "completed")
+
+        t1 = Track(
+            job_id=sample_job.job_id, track_number="0", length=7200,
+            aspect_ratio="16:9", fps=23.976, main_feature=True,
+            source="MakeMKV", basename="B1_t00.mkv", filename="B1_t00.mkv",
+        )
+        t1.ripped = True
+        db.session.add(t1)
+        db.session.commit()
+
+        finalize_output(sample_job)
+
+        assert not raw_dir.exists()
+
+    def test_updates_job_path(self, app_context, sample_job, tmp_path):
+        """job.path is updated to the final directory after move."""
+        from arm.database import db
+        from arm.models.track import Track
+
+        raw_dir = tmp_path / "raw" / "test-guid"
+        raw_dir.mkdir(parents=True)
+        (raw_dir / "B1_t00.mkv").write_bytes(b"fake")
+
+        sample_job.raw_path = str(raw_dir)
+        sample_job.config.COMPLETED_PATH = str(tmp_path / "completed")
+
+        t1 = Track(
+            job_id=sample_job.job_id, track_number="0", length=7200,
+            aspect_ratio="16:9", fps=23.976, main_feature=True,
+            source="MakeMKV", basename="B1_t00.mkv", filename="B1_t00.mkv",
+        )
+        t1.ripped = True
+        db.session.add(t1)
+        db.session.commit()
+
+        finalize_output(sample_job)
+
+        assert sample_job.path is not None
+        assert "completed" in sample_job.path
+
+    def test_noop_if_no_raw_path(self, app_context, sample_job):
+        """No error if raw_path is not set."""
+        sample_job.raw_path = None
+        finalize_output(sample_job)  # should not raise
+
+    def test_fallback_moves_mkv_without_tracks(self, app_context, sample_job, tmp_path):
+        """If no track records exist, move all MKV files with fallback naming."""
+        raw_dir = tmp_path / "raw" / "test-guid"
+        raw_dir.mkdir(parents=True)
+        (raw_dir / "B1_t00.mkv").write_bytes(b"fake")
+
+        sample_job.raw_path = str(raw_dir)
+        sample_job.config.COMPLETED_PATH = str(tmp_path / "completed")
+        sample_job.video_type = "movie"
+        sample_job.title = "Serial Mom"
+        sample_job.year = "1994"
+
+        finalize_output(sample_job)
+
+        final_dir = tmp_path / "completed" / "movies"
+        mkv_files = list(final_dir.rglob("*.mkv"))
+        assert len(mkv_files) == 1
+
+    def test_noop_if_raw_path_missing(self, app_context, sample_job, tmp_path):
+        """No error if raw_path points to a non-existent directory."""
+        sample_job.raw_path = str(tmp_path / "nonexistent")
+        finalize_output(sample_job)  # should not raise
+
+    def test_skips_tracks_without_filename(self, app_context, sample_job, tmp_path):
+        """Tracks with no filename are silently skipped."""
+        from arm.database import db
+        from arm.models.track import Track
+
+        raw_dir = tmp_path / "raw" / "test-guid"
+        raw_dir.mkdir(parents=True)
+        (raw_dir / "B1_t00.mkv").write_bytes(b"fake")
+
+        sample_job.raw_path = str(raw_dir)
+        sample_job.config.COMPLETED_PATH = str(tmp_path / "completed")
+        sample_job.video_type = "movie"
+        sample_job.title = "Serial Mom"
+        sample_job.year = "1994"
+
+        t1 = Track(
+            job_id=sample_job.job_id, track_number="0", length=7200,
+            aspect_ratio="16:9", fps=23.976, main_feature=True,
+            source="MakeMKV", basename="B1_t00.mkv", filename="B1_t00.mkv",
+        )
+        t1.ripped = True
+        # Second track has no file on disk
+        t2 = Track(
+            job_id=sample_job.job_id, track_number="1", length=600,
+            aspect_ratio="16:9", fps=23.976, main_feature=False,
+            source="MakeMKV", basename="B1_t01.mkv", filename=None,
+        )
+        t2.ripped = True
+        db.session.add_all([t1, t2])
+        db.session.commit()
+
+        finalize_output(sample_job)
+
+        final_dir = tmp_path / "completed" / "movies"
+        mkv_files = list(final_dir.rglob("*.mkv"))
+        assert len(mkv_files) == 1

--- a/test/test_folder_ripper.py
+++ b/test/test_folder_ripper.py
@@ -48,6 +48,7 @@ class TestRipFolder:
         self, mock_prep, mock_prescan, mock_run,
         mock_reconcile, mock_notify, mock_db, tmp_path
     ):
+        """No transcoder configured - finalize_output runs, status is success."""
         from arm.ripper.folder_ripper import rip_folder
 
         rawpath = tmp_path / "raw" / "Test Movie"
@@ -57,7 +58,8 @@ class TestRipFolder:
         mock_run.return_value = iter([])  # MakeMKV yields nothing on success
 
         with patch("arm.ripper.folder_ripper.setup_rawpath", return_value=str(rawpath)), \
-             patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
+             patch("arm.ripper.folder_ripper.cfg") as mock_cfg, \
+             patch("arm.ripper.naming.finalize_output") as mock_finalize:
             mock_cfg.arm_config = {"TRANSCODER_URL": ""}
             rip_folder(job)
 
@@ -69,7 +71,8 @@ class TestRipFolder:
         assert args[1] == str(rawpath)
         assert "title_map" in kwargs
         mock_notify.assert_not_called()
-        assert job.status == "waiting_transcode"
+        mock_finalize.assert_called_once_with(job)
+        assert job.status == "success"
 
     @patch("arm.ripper.folder_ripper.db")
     @patch("arm.ripper.folder_ripper.utils.transcoder_notify")
@@ -129,7 +132,8 @@ class TestRipFolder:
         job.tracks = [track0, track1, track2]
         mock_run.return_value = iter([])
 
-        with patch("arm.ripper.folder_ripper.cfg") as mock_cfg, mock_setup:
+        with patch("arm.ripper.folder_ripper.cfg") as mock_cfg, mock_setup, \
+             patch("arm.ripper.naming.finalize_output"):
             mock_cfg.arm_config = {"TRANSCODER_URL": ""}
             rip_folder(job)
 

--- a/test/test_identify.py
+++ b/test/test_identify.py
@@ -1178,10 +1178,10 @@ class TestMatcherIntegration:
         ]})
         assert job.poster_url == poster
 
-    # -- Label cleaning applied to stored title --
+    # -- Title stored as-is from API (no sanitization) --
 
-    def test_title_cleaned_for_filename(self, app_context):
-        """Matched title is run through clean_for_filename before storing."""
+    def test_title_stored_unsanitized(self, app_context):
+        """Matched title is stored as-is from the API, preserving colons and spaces."""
         from arm.ripper.identify import update_job
 
         job = self._make_job(app_context, label="LOTR_FELLOWSHIP_OF_THE_RING_P1",
@@ -1190,8 +1190,8 @@ class TestMatcherIntegration:
             {'Title': 'The Lord of the Rings: The Fellowship of the Ring', 'Year': '2001',
              'imdbID': 'tt0120737', 'Type': 'movie', 'Poster': 'N/A'},
         ]})
-        # clean_for_filename replaces colons with hyphens and spaces with hyphens
-        assert ':' not in job.title
+        # Title is stored clean for display/search - no filename sanitization
+        assert job.title == 'The Lord of the Rings: The Fellowship of the Ring'
         assert 'Fellowship' in job.title
 
     # -- No prior year/type (auto fields empty) --

--- a/test/test_identify_no_sanitize.py
+++ b/test/test_identify_no_sanitize.py
@@ -1,0 +1,68 @@
+"""Tests that identification stores clean, unsanitized titles."""
+import unittest.mock
+
+from arm.ripper import identify
+
+
+class TestUpdateJobNoSanitize:
+    """update_job should store API titles without aggressive sanitization."""
+
+    def test_title_preserves_spaces(self, app_context, sample_job):
+        """Metadata title 'Serial Mom' should not become 'Serial-Mom'."""
+        match = unittest.mock.MagicMock()
+        match.title = "Serial Mom"
+        match.year = "1994"
+        match.type = "movie"
+        match.imdb_id = "tt0111127"
+        match.poster_url = ""
+        match.score = 0.95
+        match.title_score = 0.95
+        match.year_score = 1.0
+        match.type_score = 1.0
+
+        selection = unittest.mock.MagicMock()
+        selection.hasnicetitle = True
+        selection.confident = True
+        selection.best = match
+        selection.all_scored = [match]
+        selection.label_info = None
+
+        sample_job.label = "SERIAL_MOM"
+
+        with unittest.mock.patch('arm.ripper.arm_matcher.match_disc', return_value=selection), \
+             unittest.mock.patch('arm.ripper.utils.database_updater') as mock_db:
+            identify.update_job(sample_job, {"Search": [{"Title": "Serial Mom", "Year": "1994"}]})
+
+        # Verify the title stored in the database_updater call has spaces
+        args_dict = mock_db.call_args[0][0]
+        assert args_dict['title'] == "Serial Mom"
+        assert " " in args_dict['title']
+
+    def test_title_preserves_colons(self, app_context, sample_job):
+        """Colons in metadata titles are preserved for display/search."""
+        match = unittest.mock.MagicMock()
+        match.title = "Star Wars: A New Hope"
+        match.year = "1977"
+        match.type = "movie"
+        match.imdb_id = "tt0076759"
+        match.poster_url = ""
+        match.score = 0.95
+        match.title_score = 0.95
+        match.year_score = 1.0
+        match.type_score = 1.0
+
+        selection = unittest.mock.MagicMock()
+        selection.hasnicetitle = True
+        selection.confident = True
+        selection.best = match
+        selection.all_scored = [match]
+        selection.label_info = None
+
+        sample_job.label = "STAR_WARS"
+
+        with unittest.mock.patch('arm.ripper.arm_matcher.match_disc', return_value=selection), \
+             unittest.mock.patch('arm.ripper.utils.database_updater') as mock_db:
+            identify.update_job(sample_job, {"Search": [{"Title": "Star Wars: A New Hope", "Year": "1977"}]})
+
+        args_dict = mock_db.call_args[0][0]
+        assert args_dict['title'] == "Star Wars: A New Hope"

--- a/test/test_job_model.py
+++ b/test/test_job_model.py
@@ -42,8 +42,23 @@ class TestTypeSubfolder:
 
 
 class TestBuildPaths:
-    def test_build_raw_path(self, sample_job):
-        assert sample_job.build_raw_path() == "/home/arm/media/raw/SERIAL_MOM"
+    def test_build_raw_path_uses_guid(self, sample_job):
+        """Raw path uses job GUID, not title."""
+        expected = f"/home/arm/media/raw/{sample_job.guid}"
+        assert sample_job.build_raw_path() == expected
+
+    def test_build_raw_path_independent_of_title(self, sample_job):
+        """Changing title does not affect raw path."""
+        path_before = sample_job.build_raw_path()
+        sample_job.title = "Something Else"
+        sample_job.title_auto = "Something Else"
+        assert sample_job.build_raw_path() == path_before
+
+    def test_build_raw_path_independent_of_manual_title(self, sample_job):
+        """Manual title correction does not affect raw path."""
+        path_before = sample_job.build_raw_path()
+        sample_job.title_manual = "Serial Mom"
+        assert sample_job.build_raw_path() == path_before
 
     def test_build_transcode_path(self, sample_job):
         assert sample_job.build_transcode_path() == "/home/arm/media/transcode/movies/SERIAL_MOM (1994)"
@@ -51,16 +66,10 @@ class TestBuildPaths:
     def test_build_final_path(self, sample_job):
         assert sample_job.build_final_path() == "/home/arm/media/completed/movies/SERIAL_MOM (1994)"
 
-    def test_build_raw_path_uses_title_auto(self, sample_job):
-        """raw_path should use title_auto, not title (which may be corrected)."""
-        sample_job.title = "Serial Mom"
-        sample_job.title_auto = "SERIAL_MOM"
-        assert sample_job.build_raw_path() == "/home/arm/media/raw/SERIAL_MOM"
-
     def test_build_paths_with_manual_title(self, sample_job):
         sample_job.title_manual = "Serial Mom"
-        # raw_path uses title_auto (original auto-detected title)
-        assert sample_job.build_raw_path() == "/home/arm/media/raw/SERIAL_MOM"
+        # raw_path uses GUID (independent of title)
+        assert sample_job.build_raw_path() == f"/home/arm/media/raw/{sample_job.guid}"
         # transcode and final use formatted_title (prefers manual)
         assert sample_job.build_transcode_path() == "/home/arm/media/transcode/movies/Serial Mom (1994)"
         assert sample_job.build_final_path() == "/home/arm/media/completed/movies/Serial Mom (1994)"
@@ -171,12 +180,12 @@ class TestPatternEngineIntegration:
     # --- Raw path never uses pattern ---
 
     def test_raw_path_unaffected_by_structured_fields(self, sample_job):
-        """build_raw_path always uses title_auto, never the pattern engine."""
+        """build_raw_path always uses GUID, never the pattern engine."""
         sample_job.video_type = "music"
         sample_job.artist = "The Beatles"
         sample_job.album = "Abbey Road"
         sample_job.title_auto = "Beatles Abbey Road"
-        assert sample_job.build_raw_path() == "/home/arm/media/raw/Beatles Abbey Road"
+        assert sample_job.build_raw_path() == f"/home/arm/media/raw/{sample_job.guid}"
 
 
 class TestStructuredFieldColumns:

--- a/test/test_job_model.py
+++ b/test/test_job_model.py
@@ -1,5 +1,6 @@
 """Tests for Job model properties and path builders (Phase 2)."""
 import os
+import uuid
 
 
 class TestFormattedTitle:
@@ -224,3 +225,29 @@ class TestStructuredFieldColumns:
         assert sample_job.album is None
         assert sample_job.season is None
         assert sample_job.episode is None
+
+
+class TestJobGuid:
+    def test_new_job_has_guid(self, sample_job):
+        """Every job gets a UUID4 guid at creation."""
+        assert sample_job.guid is not None
+        parsed = uuid.UUID(sample_job.guid)
+        assert parsed.version == 4
+
+    def test_guid_is_unique_per_job(self, app_context):
+        """Two jobs get different GUIDs."""
+        from arm.models.job import Job
+        import unittest.mock
+        with unittest.mock.patch.object(Job, 'parse_udev'), \
+             unittest.mock.patch.object(Job, 'get_pid'):
+            job1 = Job('/dev/sr0')
+            job2 = Job('/dev/sr1')
+        assert job1.guid != job2.guid
+
+    def test_folder_job_has_guid(self, app_context):
+        """Folder-import jobs also get GUIDs."""
+        from arm.models.job import Job
+        job = Job.from_folder('/tmp/test', 'dvd')
+        assert job.guid is not None
+        parsed = uuid.UUID(job.guid)
+        assert parsed.version == 4

--- a/test/test_makemkv_coverage.py
+++ b/test/test_makemkv_coverage.py
@@ -436,32 +436,28 @@ class TestPositionalMatchPass:
 
 
 class TestSetupRawpath:
-    """Test setup_rawpath() directory creation."""
+    """Test setup_rawpath() directory creation with GUID-based paths."""
 
     def test_creates_new_path(self, tmp_path):
         from arm.ripper.makemkv import setup_rawpath
 
         job = unittest.mock.MagicMock()
-        job.title = "TestMovie"
-        raw = str(tmp_path / "raw" / "TestMovie")
+        raw = str(tmp_path / "raw" / "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
         result = setup_rawpath(job, raw)
         assert result == raw
         assert os.path.isdir(raw)
 
-    def test_existing_path_gets_timestamp(self, tmp_path):
+    def test_existing_path_is_reused(self, tmp_path):
+        """With GUID paths, if dir exists (e.g. retry), just reuse it."""
         from arm.ripper.makemkv import setup_rawpath
 
-        raw = str(tmp_path / "raw" / "TestMovie")
+        raw = str(tmp_path / "raw" / "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
         os.makedirs(raw)
 
         job = unittest.mock.MagicMock()
-        job.title = "TestMovie"
-        job.config.RAW_PATH = str(tmp_path / "raw")
-
         result = setup_rawpath(job, raw)
-        assert result != raw
-        assert os.path.isdir(result)
-        assert "TestMovie_" in result
+        assert result == raw
+        assert os.path.isdir(raw)
 
 
 class TestProgressLog:

--- a/test/test_makemkv_coverage.py
+++ b/test/test_makemkv_coverage.py
@@ -441,9 +441,8 @@ class TestSetupRawpath:
     def test_creates_new_path(self, tmp_path):
         from arm.ripper.makemkv import setup_rawpath
 
-        job = unittest.mock.MagicMock()
         raw = str(tmp_path / "raw" / "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
-        result = setup_rawpath(job, raw)
+        result = setup_rawpath(raw)
         assert result == raw
         assert os.path.isdir(raw)
 
@@ -454,8 +453,7 @@ class TestSetupRawpath:
         raw = str(tmp_path / "raw" / "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
         os.makedirs(raw)
 
-        job = unittest.mock.MagicMock()
-        result = setup_rawpath(job, raw)
+        result = setup_rawpath(raw)
         assert result == raw
         assert os.path.isdir(raw)
 

--- a/test/test_music_rip.py
+++ b/test/test_music_rip.py
@@ -416,15 +416,13 @@ class TestProcessTracks:
 class TestGetTitle:
 
     def test_identified_disc_returns_clean_title(self, music_job, mb_disc_response):
-        """Returns 'Artist-Title' via clean_for_filename."""
+        """Returns 'Artist Title' with spaces preserved."""
         with unittest.mock.patch.object(mb, 'set_useragent'), \
              unittest.mock.patch.object(mb, 'get_releases_by_discid',
                                         return_value=mb_disc_response), \
              unittest.mock.patch('arm.ripper.utils.database_updater'):
             result = music_brainz.get_title('fake-id', music_job)
-        # clean_for_filename processes the name
-        assert 'Pink' in result
-        assert 'Floyd' in result
+        assert result == 'Pink Floyd The Dark Side of the Moon'
         assert 'not identified' not in result
 
     def test_identified_disc_sets_video_type(self, music_job, mb_disc_response):
@@ -438,7 +436,7 @@ class TestGetTitle:
         assert args_dict['video_type'] == "music"
 
     def test_cdstub_returns_title(self, music_job, mb_stub_response):
-        """Stub path returns artist-title."""
+        """Stub path returns 'artist title' with spaces."""
         with unittest.mock.patch.object(mb, 'set_useragent'), \
              unittest.mock.patch.object(mb, 'get_releases_by_discid',
                                         return_value=mb_stub_response), \

--- a/test/test_naming.py
+++ b/test/test_naming.py
@@ -9,7 +9,7 @@ from arm.ripper.naming import (
     render_preview,
     render_track_title,
     render_track_folder,
-    _clean_for_filename,
+    clean_for_filename,
 )
 
 
@@ -266,33 +266,33 @@ def test_track_title_with_custom_config():
     assert render_track_title(track, job, cfg) == 'Extended Cut [2020]'
 
 
-# --- _clean_for_filename ---
+# --- clean_for_filename ---
 
 
-def test_clean_for_filename_colons():
+def testclean_for_filename_colons():
     # All colon patterns produce ' - ' with normalized spacing
-    assert _clean_for_filename('Star Wars : A New Hope') == 'Star Wars - A New Hope'
-    assert _clean_for_filename('Star Wars: A New Hope') == 'Star Wars - A New Hope'
-    assert _clean_for_filename('Kolchak: The Night Stalker') == 'Kolchak - The Night Stalker'
+    assert clean_for_filename('Star Wars : A New Hope') == 'Star Wars - A New Hope'
+    assert clean_for_filename('Star Wars: A New Hope') == 'Star Wars - A New Hope'
+    assert clean_for_filename('Kolchak: The Night Stalker') == 'Kolchak - The Night Stalker'
 
 
-def test_clean_for_filename_ampersand():
-    assert _clean_for_filename('Tom & Jerry') == 'Tom and Jerry'
+def testclean_for_filename_ampersand():
+    assert clean_for_filename('Tom & Jerry') == 'Tom and Jerry'
 
 
-def test_clean_for_filename_backslash():
-    assert _clean_for_filename('AC\\DC') == 'AC - DC'
+def testclean_for_filename_backslash():
+    assert clean_for_filename('AC\\DC') == 'AC - DC'
 
 
-def test_clean_for_filename_special_chars():
-    result = _clean_for_filename('Movie? <Title>!')
+def testclean_for_filename_special_chars():
+    result = clean_for_filename('Movie? <Title>!')
     assert '?' not in result
     assert '<' not in result
     assert '>' not in result
 
 
-def test_clean_for_filename_whitespace():
-    assert _clean_for_filename('  too   many   spaces  ') == 'too many spaces'
+def testclean_for_filename_whitespace():
+    assert clean_for_filename('  too   many   spaces  ') == 'too many spaces'
 
 
 # --- render_track_folder ---

--- a/test/test_naming.py
+++ b/test/test_naming.py
@@ -657,3 +657,32 @@ class TestRenderWithJobFolderOverride:
         result = render_title(job)
         assert 'Episode' in result
         assert 'S01' not in result
+
+
+# ======================================================================
+# disc_number / disc_total pattern variables
+# ======================================================================
+
+
+def test_disc_number_in_pattern():
+    """disc_number variable is available in naming patterns."""
+    job = _make_job(title='Dynasties', year='2018', video_type='movie')
+    job.disc_number = 2
+    cfg = {'MOVIE_TITLE_PATTERN': '{title} - Disc {disc_number}'}
+    assert render_title(job, cfg) == 'Dynasties - Disc 2'
+
+
+def test_disc_number_omitted_when_none():
+    """Missing disc_number renders as empty string (cleaned up by pattern engine)."""
+    job = _make_job(title='Dynasties', year='2018', video_type='movie')
+    job.disc_number = None
+    cfg = {'MOVIE_TITLE_PATTERN': '{title} ({year})'}
+    assert render_title(job, cfg) == 'Dynasties (2018)'
+
+
+def test_disc_total_in_folder_pattern():
+    job = _make_job(title='Dynasties', year='2018', video_type='movie')
+    job.disc_number = 2
+    job.disc_total = 3
+    cfg = {'MOVIE_FOLDER_PATTERN': '{title} ({year})/Disc {disc_number} of {disc_total}'}
+    assert render_folder(job, cfg) == os.path.join('Dynasties (2018)', 'Disc 2 of 3')

--- a/test/test_title_map.py
+++ b/test/test_title_map.py
@@ -338,6 +338,7 @@ class TestFolderRipperTitleMap:
              patch("arm.ripper.folder_ripper.prescan_track_info"), \
              patch("arm.ripper.folder_ripper._reconcile_filenames") as m_reconcile, \
              patch("arm.ripper.folder_ripper.utils.transcoder_notify"), \
+             patch("arm.ripper.naming.finalize_output"), \
              patch("arm.ripper.folder_ripper.db"), \
              patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
             mock_cfg.arm_config = {"TRANSCODER_URL": ""}

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -120,43 +120,6 @@ class TestExtractYear:
         assert extract_year(raw) == expected
 
 
-class TestCleanForFilename:
-    """Test clean_for_filename() string sanitization."""
-
-    def test_simple_title(self):
-        from arm.ripper.utils import clean_for_filename
-        assert clean_for_filename("Serial Mom") == "Serial-Mom"
-
-    def test_brackets_removed(self):
-        from arm.ripper.utils import clean_for_filename
-        assert "Rated" not in clean_for_filename("Serial Mom [Rated R]")
-
-    def test_colon_replaced(self):
-        from arm.ripper.utils import clean_for_filename
-        result = clean_for_filename("Star Wars: A New Hope")
-        assert ":" not in result
-
-    def test_ampersand_replaced(self):
-        from arm.ripper.utils import clean_for_filename
-        result = clean_for_filename("Tom & Jerry")
-        assert "&" not in result
-        assert "and" in result
-
-    def test_special_chars_stripped(self):
-        from arm.ripper.utils import clean_for_filename
-        result = clean_for_filename("Movie! @#$% Title")
-        # Only word chars, dots, parens, spaces, hyphens allowed
-        assert all(c.isalnum() or c in '.() -_' for c in result)
-
-    def test_empty_string(self):
-        from arm.ripper.utils import clean_for_filename
-        assert clean_for_filename("") == ""
-
-    def test_preserves_year_parens(self):
-        from arm.ripper.utils import clean_for_filename
-        result = clean_for_filename("Serial Mom (1994)")
-        assert "(1994)" in result
-
 
 class TestDatabaseUpdaterUI:
     """Test database_updater in arm/ui/utils.py."""


### PR DESCRIPTION
## Summary

- **GUID-based work paths**: Raw rip directories now use `job.guid` (UUID4) instead of title-based names. Eliminates collisions, removes filesystem dependency on title quality.
- **Clean title storage**: Titles from metadata APIs (OMDb/TMDB) and user edits are stored without aggressive sanitization. Spaces, colons, and special characters preserved for display and search.
- **Single `clean_for_filename`**: Consolidated three separate implementations into one public function in `naming.py`. Deleted `utils.clean_for_filename` (aggressive) and `jobs.py _clean_for_filename` (API variant).
- **`disc_number`/`disc_total` in naming patterns**: Wired existing DB columns into the naming engine as `{disc_number}` and `{disc_total}` pattern variables.
- **`finalize_output()` for transcoder-disabled**: New function moves files from GUID work directory to final named location using the naming engine. Called when `TRANSCODER_URL` is not configured.
- **Database migration**: Adds `guid` column with UUID4 backfill for existing rows.

Fixes the root cause of wasted OMDb API calls when Blu-ray XML titles like "Dynasties - Disc 2" were aggressively sanitized to "Dynasties-Disc-2".

## Test plan

- [x] All 1799 tests pass (baseline was 1798 - net +1 after adding 19 new tests and removing 18 for deleted functions)
- [x] No remaining references to deleted `utils.clean_for_filename` or `jobs._clean_for_filename`
- [x] All modified Python files compile cleanly
- [ ] Integration test: insert disc with spaces/colons in title, verify clean storage and correct final naming
- [ ] Integration test: run without `TRANSCODER_URL`, verify `finalize_output` places files correctly
- [ ] Verify transcoder webhook still works with GUID-based `path` field

## Spec

`docs/superpowers/specs/2026-04-06-naming-lifecycle-cleanup-design.md`