### PR TITLE
feat: async API safety - prevent worker blocking and fix thread races

### DIFF
--- a/arm/api/v1/drives.py
+++ b/arm/api/v1/drives.py
@@ -312,10 +312,13 @@ async def rescan_drives():
     from arm.services.drives import drives_update
 
     def _do_rescan():
-        before = SystemDrives.query.count()
-        removed = drives_update()
-        after = SystemDrives.query.count()
-        return before, after, removed
+        try:
+            before = SystemDrives.query.count()
+            removed = drives_update()
+            after = SystemDrives.query.count()
+            return before, after, removed
+        finally:
+            db.session.remove()
 
     try:
         before, after, removed = await asyncio.to_thread(_do_rescan)

--- a/arm/api/v1/drives.py
+++ b/arm/api/v1/drives.py
@@ -311,10 +311,14 @@ async def rescan_drives():
     """
     from arm.services.drives import drives_update
 
-    try:
+    def _do_rescan():
         before = SystemDrives.query.count()
-        removed = await asyncio.to_thread(drives_update)
+        removed = drives_update()
         after = SystemDrives.query.count()
+        return before, after, removed
+
+    try:
+        before, after, removed = await asyncio.to_thread(_do_rescan)
         log.info("Drive rescan: %d before, %d after, %d removed", before, after, removed)
         return {
             "success": True,

--- a/arm/api/v1/drives.py
+++ b/arm/api/v1/drives.py
@@ -303,17 +303,17 @@ async def drive_diagnostic():
 
 
 @router.post('/drives/rescan')
-def rescan_drives():
+async def rescan_drives():
     """Re-detect optical drives and update the database.
 
-    Python-level only — refreshes the drive inventory in the DB
+    Python-level only - refreshes the drive inventory in the DB
     by scanning /sys and udev. Does NOT trigger rips.
     """
     from arm.services.drives import drives_update
 
     try:
         before = SystemDrives.query.count()
-        removed = drives_update()
+        removed = await asyncio.to_thread(drives_update)
         after = SystemDrives.query.count()
         log.info("Drive rescan: %d before, %d after, %d removed", before, after, removed)
         return {

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -393,16 +393,30 @@ def change_job_config(job_id: int, body: dict):
     return {"success": True, "job_id": job.job_id}
 
 
+def _with_session_cleanup(fn, *args):
+    """Run *fn* and ensure the executor thread's scoped session is released.
+
+    asyncio.to_thread runs callables on executor threads whose scoped
+    sessions are NOT cleaned up by SessionCleanupMiddleware (which targets
+    the event-loop thread).  This wrapper prevents stale sessions from
+    accumulating on reused executor threads.
+    """
+    try:
+        return fn(*args)
+    finally:
+        db.session.remove()
+
+
 @router.post('/jobs/{job_id}/fix-permissions')
 async def fix_job_permissions(job_id: int):
     """Fix file permissions for a job."""
-    return await asyncio.to_thread(svc_files.fix_permissions, str(job_id))
+    return await asyncio.to_thread(_with_session_cleanup, svc_files.fix_permissions, str(job_id))
 
 
 @router.post('/jobs/{job_id}/send')
 async def send_job(job_id: int):
     """Send a job to a remote database."""
-    return await asyncio.to_thread(svc_files.send_to_remote_db, str(job_id))
+    return await asyncio.to_thread(_with_session_cleanup, svc_files.send_to_remote_db, str(job_id))
 
 
 _FIELD_MAP = {

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -1,9 +1,10 @@
-"""API v1 — Job endpoints.
+"""API v1 - Job endpoints.
 
-All handlers use sync def (not async def) so FastAPI runs them in a
-threadpool, preventing blocking the event loop during DB queries,
-external HTTP calls, or filesystem operations.
+Most handlers use sync def so FastAPI runs them in a threadpool.
+Heavy I/O endpoints (fix-permissions, remote DB send) use async def
+with asyncio.to_thread to avoid blocking the event loop.
 """
+import asyncio
 import json
 import math
 import re
@@ -286,6 +287,7 @@ def change_job_config(job_id: int, body: dict):
     config = job.config
     job_args = {}
     changes = []
+    config_updates = {}  # collected for atomic apply under lock
 
     valid_ripmethods = ('mkv', 'backup')
     valid_disctypes = ('dvd', 'bluray', 'bluray4k', 'music', 'data')
@@ -303,7 +305,7 @@ def change_job_config(job_id: int, body: dict):
                 status_code=400,
             )
         config.RIPMETHOD = val
-        cfg.arm_config["RIPMETHOD"] = val
+        config_updates["RIPMETHOD"] = val
         changes.append(f"Rip Method={val}")
 
     if 'DISCTYPE' in body:
@@ -319,7 +321,7 @@ def change_job_config(job_id: int, body: dict):
     if 'MAINFEATURE' in body:
         val = 1 if body['MAINFEATURE'] else 0
         config.MAINFEATURE = val
-        cfg.arm_config["MAINFEATURE"] = val
+        config_updates["MAINFEATURE"] = val
         changes.append(f"Main Feature={bool(val)}")
         # Re-flag tracks based on the new setting
         _auto_flag_tracks(job, mainfeature=bool(val))
@@ -327,13 +329,13 @@ def change_job_config(job_id: int, body: dict):
     if 'MINLENGTH' in body:
         val = str(int(body['MINLENGTH']))
         config.MINLENGTH = val
-        cfg.arm_config["MINLENGTH"] = val
+        config_updates["MINLENGTH"] = val
         changes.append(f"Min Length={val}")
 
     if 'MAXLENGTH' in body:
         val = str(int(body['MAXLENGTH']))
         config.MAXLENGTH = val
-        cfg.arm_config["MAXLENGTH"] = val
+        config_updates["MAXLENGTH"] = val
         changes.append(f"Max Length={val}")
 
     if 'AUDIO_FORMAT' in body:
@@ -344,7 +346,7 @@ def change_job_config(job_id: int, body: dict):
                 status_code=400,
             )
         config.AUDIO_FORMAT = val
-        cfg.arm_config["AUDIO_FORMAT"] = val
+        config_updates["AUDIO_FORMAT"] = val
         changes.append(f"Audio Format={val}")
 
     if 'RIP_SPEED_PROFILE' in body:
@@ -355,13 +357,13 @@ def change_job_config(job_id: int, body: dict):
                 status_code=400,
             )
         config.RIP_SPEED_PROFILE = val
-        cfg.arm_config["RIP_SPEED_PROFILE"] = val
+        config_updates["RIP_SPEED_PROFILE"] = val
         changes.append(f"Rip Speed={val}")
 
     if 'MUSIC_MULTI_DISC_SUBFOLDERS' in body:
         val = bool(body['MUSIC_MULTI_DISC_SUBFOLDERS'])
         config.MUSIC_MULTI_DISC_SUBFOLDERS = val
-        cfg.arm_config["MUSIC_MULTI_DISC_SUBFOLDERS"] = val
+        config_updates["MUSIC_MULTI_DISC_SUBFOLDERS"] = val
         changes.append(f"Multi-Disc Subfolders={val}")
 
     if 'MUSIC_DISC_FOLDER_PATTERN' in body:
@@ -372,11 +374,16 @@ def change_job_config(job_id: int, body: dict):
                 status_code=400,
             )
         config.MUSIC_DISC_FOLDER_PATTERN = val
-        cfg.arm_config["MUSIC_DISC_FOLDER_PATTERN"] = val
+        config_updates["MUSIC_DISC_FOLDER_PATTERN"] = val
         changes.append(f"Disc Folder Pattern={val}")
 
     if not changes:
         return JSONResponse({"success": False, "error": "No valid fields provided"}, status_code=400)
+
+    # Apply config updates atomically so concurrent readers never see partial state
+    if config_updates:
+        with cfg.arm_config_lock:
+            cfg.arm_config.update(config_updates)
 
     message = f"Parameters changed: {', '.join(changes)}"
     notification = Notifications(f"Job: {job.job_id} Config updated!", message)
@@ -389,14 +396,12 @@ def change_job_config(job_id: int, body: dict):
 @router.post('/jobs/{job_id}/fix-permissions')
 async def fix_job_permissions(job_id: int):
     """Fix file permissions for a job."""
-    import asyncio
     return await asyncio.to_thread(svc_files.fix_permissions, str(job_id))
 
 
 @router.post('/jobs/{job_id}/send')
 async def send_job(job_id: int):
     """Send a job to a remote database."""
-    import asyncio
     return await asyncio.to_thread(svc_files.send_to_remote_db, str(job_id))
 
 

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -32,11 +32,14 @@ _NOT_WAITING = "Job is not in waiting state"
 def _rip_folder_by_id(job_id: int):
     """Re-query job by ID in the thread's own session, then run rip_folder."""
     import logging
-    job = Job.query.get(job_id)
-    if not job:
-        logging.error("rip_folder thread: job %s not found", job_id)
-        return
-    rip_folder(job)
+    try:
+        job = Job.query.get(job_id)
+        if not job:
+            logging.error("rip_folder thread: job %s not found", job_id)
+            return
+        rip_folder(job)
+    finally:
+        db.session.remove()
 
 
 def _auto_flag_tracks(job, mainfeature: bool):
@@ -384,15 +387,17 @@ def change_job_config(job_id: int, body: dict):
 
 
 @router.post('/jobs/{job_id}/fix-permissions')
-def fix_job_permissions(job_id: int):
+async def fix_job_permissions(job_id: int):
     """Fix file permissions for a job."""
-    return svc_files.fix_permissions(str(job_id))
+    import asyncio
+    return await asyncio.to_thread(svc_files.fix_permissions, str(job_id))
 
 
 @router.post('/jobs/{job_id}/send')
-def send_job(job_id: int):
+async def send_job(job_id: int):
     """Send a job to a remote database."""
-    return svc_files.send_to_remote_db(str(job_id))
+    import asyncio
+    return await asyncio.to_thread(svc_files.send_to_remote_db, str(job_id))
 
 
 _FIELD_MAP = {

--- a/arm/api/v1/maintenance.py
+++ b/arm/api/v1/maintenance.py
@@ -1,4 +1,5 @@
 """API v1 — Maintenance endpoints for orphan detection and cleanup."""
+import asyncio
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
@@ -36,8 +37,8 @@ def get_orphan_folders():
 
 
 @router.post("/maintenance/delete-log")
-def delete_log(req: PathRequest):
-    result = svc.delete_log(req.path)
+async def delete_log(req: PathRequest):
+    result = await asyncio.to_thread(svc.delete_log, req.path)
     if not result["success"]:
         error = result.get("error", "")
         if "outside" in error:
@@ -48,8 +49,8 @@ def delete_log(req: PathRequest):
 
 
 @router.post("/maintenance/delete-folder")
-def delete_folder(req: PathRequest):
-    result = svc.delete_folder(req.path)
+async def delete_folder(req: PathRequest):
+    result = await asyncio.to_thread(svc.delete_folder, req.path)
     if not result["success"]:
         error = result.get("error", "")
         if "outside" in error:
@@ -60,9 +61,9 @@ def delete_folder(req: PathRequest):
 
 
 @router.post("/maintenance/bulk-delete-logs")
-def bulk_delete_logs(req: BulkPathRequest):
-    result = svc.bulk_delete_logs(req.paths)
-    # Sanitize error messages — don't expose internal paths
+async def bulk_delete_logs(req: BulkPathRequest):
+    result = await asyncio.to_thread(svc.bulk_delete_logs, req.paths)
+    # Sanitize error messages - don't expose internal paths
     result["errors"] = [
         f"{Path(e.split(':')[0]).name}: operation failed" if ':' in e else e
         for e in result.get("errors", [])
@@ -71,8 +72,8 @@ def bulk_delete_logs(req: BulkPathRequest):
 
 
 @router.post("/maintenance/bulk-delete-folders")
-def bulk_delete_folders(req: BulkPathRequest):
-    result = svc.bulk_delete_folders(req.paths)
+async def bulk_delete_folders(req: BulkPathRequest):
+    result = await asyncio.to_thread(svc.bulk_delete_folders, req.paths)
     result["errors"] = [
         f"{Path(e.split(':')[0]).name}: operation failed" if ':' in e else e
         for e in result.get("errors", [])
@@ -81,9 +82,9 @@ def bulk_delete_folders(req: BulkPathRequest):
 
 
 @router.post("/maintenance/clear-raw")
-def clear_raw():
+async def clear_raw():
     """Clear all contents of the raw/scratch directory."""
-    result = svc.clear_raw_directories()
+    result = await asyncio.to_thread(svc.clear_raw_directories)
     if not result["success"]:
         raise HTTPException(status_code=400, detail=result.get("error", "Failed"))
     return result

--- a/arm/api/v1/settings.py
+++ b/arm/api/v1/settings.py
@@ -93,8 +93,9 @@ async def update_config(request: Request):
     try:
         new_values = await asyncio.to_thread(_read_config)
         new_values = new_values or {}
-        cfg.arm_config.clear()
-        cfg.arm_config.update(new_values)
+        with cfg.arm_config_lock:
+            cfg.arm_config.clear()
+            cfg.arm_config.update(new_values)
     except Exception as e:
         log.error(f"Config reload failed: {e}")
         return {

--- a/arm/config/config.py
+++ b/arm/config/config.py
@@ -2,9 +2,14 @@
 """yaml config loader"""
 import json
 import os
+import threading
 import yaml
 
 import arm.config.config_utils as config_utils
+
+# Lock for atomic updates to arm_config (clear + update must not be
+# interleaved with concurrent readers).
+arm_config_lock = threading.Lock()
 
 arm_config: dict[str, str]
 arm_config_path: str = os.environ.get("ARM_CONFIG_FILE", "/etc/arm/config/arm.yaml")

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -894,44 +894,14 @@ def arm_setup(arm_log: Logger) -> None:
 
 
 def database_updater(args, job, wait_time=90):
-    """
-    Try to update our db for x seconds and handle it nicely if we can't
-    If args isn't a dict assume we are wanting a rollback\n
+    """Try to commit attribute changes to the database.
 
-    :param args: This needs to be a Dict with the key being the job.method
-    you want to change and the value being
-    the new value.
-    :param job: This is the job object
-    :param int wait_time: Number of times to try(1 sec sleep between try)
-    :return: Success
+    Delegates to :func:`arm.services.files.database_updater` (single
+    implementation).  Ripper callers keep a higher default *wait_time*
+    because rip processes are more tolerant of delays than API requests.
     """
-    if not isinstance(args, dict):
-        db.session.rollback()
-        return False
-    # Loop through our args and try to set any of our job variables
-    _sensitive_keys = {'api_key', 'arm_api_key', 'omdb_api_key', 'tmdb_api_key',
-                       'pb_key', 'ifttt_key', 'po_user_key', 'po_app_key', 'apprise'}
-    for (key, value) in args.items():
-        setattr(job, key, value)
-        safe_key = str(key)
-        if safe_key.lower() in _sensitive_keys:
-            logging.debug("ID:%s %s=<redacted>", int(job.job_id), safe_key)
-        else:
-            logging.debug("ID:%s %s=%s:%s", int(job.job_id), safe_key, str(value), type(value).__name__)
-
-    for i in range(wait_time):  # give up after the users wait period in seconds
-        try:
-            db.session.commit()
-            break
-        except Exception as error:
-            if "locked" in str(error):
-                time.sleep(1)
-                logging.debug(f"database is locked - try {i}/{wait_time}")
-            else:
-                logging.debug(f"Error: {error}")
-                raise RuntimeError(str(error)) from error
-    logging.debug("successfully written to the database")
-    return True
+    from arm.services.files import database_updater as _database_updater
+    return _database_updater(args, job, wait_time=wait_time)
 
 
 def database_adder(obj_class):

--- a/arm/services/files.py
+++ b/arm/services/files.py
@@ -1,5 +1,5 @@
 """
-File and database utility services — extracted from arm/ui/utils.py.
+File and database utility services - extracted from arm/ui/utils.py.
 
 All app.logger calls replaced with standard logging.
 """
@@ -18,35 +18,57 @@ from arm.database import db
 
 log = logging.getLogger(__name__)
 
+# Sensitive keys whose values should not appear in logs
+_SENSITIVE_KEYS = frozenset({
+    'api_key', 'arm_api_key', 'omdb_api_key', 'tmdb_api_key',
+    'pb_key', 'ifttt_key', 'po_user_key', 'po_app_key', 'apprise',
+})
 
-def database_updater(args, job, wait_time=90):
-    """
-    Try to update our db for x seconds and handle it nicely if we cant\n
 
-    :param args: This needs to be a Dict with the key being the
-    job.method you want to change and the value being the new value.
-    :param job: This is the job object
-    :param wait_time: The time to wait in seconds
-    :returns : Boolean
+def database_updater(args, job, wait_time=10):
+    """Try to commit attribute changes to the database with exponential backoff.
+
+    :param args: Dict of attribute names to new values, or a non-dict to
+        trigger a rollback (for backward compatibility with ripper callers).
+    :param job: ORM object to update (Job, Config, Notification, etc.)
+    :param wait_time: Maximum seconds to retry on SQLite BUSY (default 10
+        for API callers; ripper callers may pass a higher value).
+    :returns: True on success, False if args is not a dict (rollback).
+    :raises RuntimeError: on non-lock database errors.
     """
-    # Loop through our args and try to set any of our job variables
-    for (key, value) in args.items():
+    if not isinstance(args, dict):
+        db.session.rollback()
+        return False
+
+    for key, value in args.items():
         setattr(job, key, value)
-        log.debug(f"Setting {key}: {value}")
-    for i in range(wait_time):  # give up after the users wait period in seconds
+        if key.lower() in _SENSITIVE_KEYS:
+            log.debug("Setting %s=<redacted>", key)
+        else:
+            log.debug("Setting %s: %s", key, value)
+
+    elapsed = 0.0
+    backoff = 0.1
+    while elapsed < wait_time:
         try:
             db.session.commit()
-            break
+            log.debug("successfully written to the database")
+            return True
         except Exception as error:
             if "locked" in str(error):
-                sleep(1)
-                log.debug(f"database is locked - trying in 1 second {i}/{wait_time} - {error}")
+                sleep(backoff)
+                elapsed += backoff
+                log.debug(
+                    "database is locked - retrying in %.1fs (%.1f/%.0fs)",
+                    backoff, elapsed, wait_time,
+                )
+                backoff = min(backoff * 2, 2.0)
             else:
-                log.debug("Error: " + str(error))
+                log.debug("Error: %s", error)
                 db.session.rollback()
                 raise RuntimeError(str(error)) from error
 
-    log.debug("successfully written to the database")
+    log.warning("database_updater timed out after %.0fs", wait_time)
     return True
 
 
@@ -164,7 +186,7 @@ def send_to_remote_db(job_id):
           f"&hnt={job.hasnicetitle}&l={job.label}&vt={job.video_type}"
     redacted_url = url.replace(api_key, "<redacted>") if api_key else "<no api key>"
     log.debug("Remote DB URL: %s", str(redacted_url))
-    response = requests.get(url)
+    response = requests.get(url, timeout=15)
     req = json.loads(response.text)
     log.debug("Remote DB response success: %s", str(req.get('success', 'unknown')))
     job_dict = job.get_d().items()

--- a/arm/services/files.py
+++ b/arm/services/files.py
@@ -40,12 +40,15 @@ def database_updater(args, job, wait_time=10):
         db.session.rollback()
         return False
 
+    job_id = getattr(job, 'job_id', None)
+    prefix = f"ID:{job_id} " if job_id is not None else ""
+
     for key, value in args.items():
         setattr(job, key, value)
         if key.lower() in _SENSITIVE_KEYS:
-            log.debug("Setting %s=<redacted>", key)
+            log.debug("%s%s=<redacted>", prefix, key)
         else:
-            log.debug("Setting %s: %s", key, value)
+            log.debug("%s%s=%s", prefix, key, value)
 
     elapsed = 0.0
     backoff = 0.1

--- a/arm/services/files.py
+++ b/arm/services/files.py
@@ -69,7 +69,7 @@ def database_updater(args, job, wait_time=10):
                 raise RuntimeError(str(error)) from error
 
     log.warning("database_updater timed out after %.0fs", wait_time)
-    return True
+    raise RuntimeError(f"database_updater timed out after {wait_time:.0f}s")
 
 
 def make_dir(path):

--- a/arm/services/files.py
+++ b/arm/services/files.py
@@ -69,6 +69,7 @@ def database_updater(args, job, wait_time=10):
                 raise RuntimeError(str(error)) from error
 
     log.warning("database_updater timed out after %.0fs", wait_time)
+    db.session.rollback()
     raise RuntimeError(f"database_updater timed out after {wait_time:.0f}s")
 
 

--- a/arm/services/tvdb.py
+++ b/arm/services/tvdb.py
@@ -12,6 +12,7 @@ The old names are re-exported here for backward compatibility.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any
@@ -26,26 +27,28 @@ _BASE = "https://api4.thetvdb.com/v4"
 _TOKEN: str | None = None
 _TOKEN_EXPIRES: float = 0
 _TOKEN_TTL = 23 * 3600  # refresh after 23 hours (tokens last 30 days)
+_TOKEN_LOCK = asyncio.Lock()
 
 
 async def _ensure_token() -> str:
-    """Obtain or reuse a TVDB bearer token."""
+    """Obtain or reuse a TVDB bearer token (thread-safe via asyncio.Lock)."""
     global _TOKEN, _TOKEN_EXPIRES
-    if _TOKEN and time.time() < _TOKEN_EXPIRES:
-        return _TOKEN
+    async with _TOKEN_LOCK:
+        if _TOKEN and time.time() < _TOKEN_EXPIRES:
+            return _TOKEN
 
-    api_key = cfg.arm_config.get("TVDB_API_KEY", "")
-    if not api_key:
-        raise ValueError("TVDB_API_KEY not configured")
+        api_key = cfg.arm_config.get("TVDB_API_KEY", "")
+        if not api_key:
+            raise ValueError("TVDB_API_KEY not configured")
 
-    async with httpx.AsyncClient(timeout=15.0) as client:
-        resp = await client.post(f"{_BASE}/login", json={"apikey": api_key})
-        resp.raise_for_status()
-        data = resp.json()
-        _TOKEN = data["data"]["token"]
-        _TOKEN_EXPIRES = time.time() + _TOKEN_TTL
-        log.info("TVDB token acquired")
-        return _TOKEN
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(f"{_BASE}/login", json={"apikey": api_key})
+            resp.raise_for_status()
+            data = resp.json()
+            _TOKEN = data["data"]["token"]
+            _TOKEN_EXPIRES = time.time() + _TOKEN_TTL
+            log.info("TVDB token acquired")
+            return _TOKEN
 
 
 async def validate_tvdb_key(api_key: str) -> dict[str, str]:

--- a/arm/services/tvdb.py
+++ b/arm/services/tvdb.py
@@ -31,7 +31,7 @@ _TOKEN_LOCK = asyncio.Lock()
 
 
 async def _ensure_token() -> str:
-    """Obtain or reuse a TVDB bearer token (thread-safe via asyncio.Lock)."""
+    """Obtain or reuse a TVDB bearer token (serialized via asyncio.Lock)."""
     global _TOKEN, _TOKEN_EXPIRES
     async with _TOKEN_LOCK:
         if _TOKEN and time.time() < _TOKEN_EXPIRES:

--- a/test/test_async_safety.py
+++ b/test/test_async_safety.py
@@ -1,0 +1,416 @@
+"""Tests for async API safety improvements.
+
+Covers: database_updater exponential backoff, session cleanup in daemon
+threads, TVDB token lock, arm_config lock, async endpoint wrappers,
+and send_to_remote_db timeout.
+"""
+import asyncio
+import threading
+import time
+import unittest.mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(app_context):
+    """FastAPI test client."""
+    from arm.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+# =====================================================================
+# database_updater - exponential backoff
+# =====================================================================
+
+
+class TestDatabaseUpdaterBackoff:
+    """Test exponential backoff in database_updater."""
+
+    def test_backoff_increases_sleep_duration(self, app_context):
+        """Sleep durations should increase exponentially."""
+        from arm.services.files import database_updater
+
+        sleep_calls = []
+        call_count = 0
+
+        def commit_side_effect():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 4:
+                raise Exception("database is locked")
+
+        def mock_sleep(duration):
+            sleep_calls.append(duration)
+
+        job = unittest.mock.MagicMock()
+        with unittest.mock.patch("arm.services.files.db") as mock_db, \
+             unittest.mock.patch("arm.services.files.sleep", side_effect=mock_sleep):
+            mock_db.session.commit.side_effect = commit_side_effect
+            result = database_updater({"status": "x"}, job, wait_time=10)
+
+        assert result is True
+        assert len(sleep_calls) == 3
+        # Exponential: 0.1, 0.2, 0.4
+        assert sleep_calls[0] == pytest.approx(0.1)
+        assert sleep_calls[1] == pytest.approx(0.2)
+        assert sleep_calls[2] == pytest.approx(0.4)
+
+    def test_backoff_caps_at_two_seconds(self, app_context):
+        """Sleep duration should not exceed 2 seconds."""
+        from arm.services.files import database_updater
+
+        sleep_calls = []
+        call_count = 0
+
+        def commit_side_effect():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 20:
+                raise Exception("database is locked")
+
+        def mock_sleep(duration):
+            sleep_calls.append(duration)
+
+        job = unittest.mock.MagicMock()
+        with unittest.mock.patch("arm.services.files.db") as mock_db, \
+             unittest.mock.patch("arm.services.files.sleep", side_effect=mock_sleep):
+            mock_db.session.commit.side_effect = commit_side_effect
+            database_updater({"status": "x"}, job, wait_time=60)
+
+        # After enough doublings (0.1, 0.2, 0.4, 0.8, 1.6, 2.0, 2.0, ...),
+        # all subsequent sleeps should be capped at 2.0
+        for duration in sleep_calls:
+            assert duration <= 2.0
+
+    def test_default_wait_time_is_ten(self, app_context):
+        """API callers get 10s default, not the old 90s."""
+        from arm.services.files import database_updater
+        import inspect
+
+        sig = inspect.signature(database_updater)
+        assert sig.parameters["wait_time"].default == 10
+
+    def test_ripper_delegates_with_high_wait_time(self, app_context):
+        """Ripper's database_updater passes wait_time=90 by default."""
+        from arm.ripper.utils import database_updater
+        import inspect
+
+        sig = inspect.signature(database_updater)
+        assert sig.parameters["wait_time"].default == 90
+
+    def test_non_dict_returns_false(self, app_context):
+        """Non-dict args should trigger rollback and return False."""
+        from arm.services.files import database_updater
+
+        job = unittest.mock.MagicMock()
+        with unittest.mock.patch("arm.services.files.db") as mock_db:
+            result = database_updater("not a dict", job)
+
+        assert result is False
+        mock_db.session.rollback.assert_called_once()
+
+    def test_none_returns_false(self, app_context):
+        """None args should trigger rollback and return False."""
+        from arm.services.files import database_updater
+
+        job = unittest.mock.MagicMock()
+        with unittest.mock.patch("arm.services.files.db") as mock_db:
+            result = database_updater(None, job)
+
+        assert result is False
+        mock_db.session.rollback.assert_called_once()
+
+    def test_sensitive_keys_redacted_in_log(self, app_context):
+        """Sensitive keys should log '<redacted>' instead of the value."""
+        from arm.services.files import database_updater
+
+        job = unittest.mock.MagicMock()
+        with unittest.mock.patch("arm.services.files.db"), \
+             unittest.mock.patch("arm.services.files.log") as mock_log:
+            database_updater({"omdb_api_key": "secret123"}, job)
+
+        # Find the debug call for the key
+        debug_calls = [str(c) for c in mock_log.debug.call_args_list]
+        assert any("<redacted>" in c for c in debug_calls)
+        assert not any("secret123" in c for c in debug_calls)
+
+
+# =====================================================================
+# _rip_folder_by_id - session cleanup
+# =====================================================================
+
+
+class TestRipFolderSessionCleanup:
+    """Test that _rip_folder_by_id cleans up the DB session."""
+
+    def test_session_removed_on_success(self, app_context, sample_job):
+        """db.session.remove() called after successful rip."""
+        from arm.api.v1.jobs import _rip_folder_by_id
+
+        with unittest.mock.patch("arm.api.v1.jobs.rip_folder") as mock_rip, \
+             unittest.mock.patch("arm.api.v1.jobs.db") as mock_db:
+            mock_db.session.remove = unittest.mock.MagicMock()
+            # Provide a real Job.query.get that returns something
+            mock_job = unittest.mock.MagicMock()
+            with unittest.mock.patch("arm.api.v1.jobs.Job") as MockJob:
+                MockJob.query.get.return_value = mock_job
+                _rip_folder_by_id(1)
+
+            mock_rip.assert_called_once_with(mock_job)
+            mock_db.session.remove.assert_called_once()
+
+    def test_session_removed_on_exception(self, app_context):
+        """db.session.remove() called even when rip_folder raises."""
+        from arm.api.v1.jobs import _rip_folder_by_id
+
+        with unittest.mock.patch("arm.api.v1.jobs.rip_folder", side_effect=RuntimeError("boom")), \
+             unittest.mock.patch("arm.api.v1.jobs.db") as mock_db:
+            mock_db.session.remove = unittest.mock.MagicMock()
+            mock_job = unittest.mock.MagicMock()
+            with unittest.mock.patch("arm.api.v1.jobs.Job") as MockJob:
+                MockJob.query.get.return_value = mock_job
+                with pytest.raises(RuntimeError, match="boom"):
+                    _rip_folder_by_id(1)
+
+            mock_db.session.remove.assert_called_once()
+
+    def test_session_removed_when_job_not_found(self, app_context):
+        """db.session.remove() called even when job is not found."""
+        from arm.api.v1.jobs import _rip_folder_by_id
+
+        with unittest.mock.patch("arm.api.v1.jobs.db") as mock_db:
+            mock_db.session.remove = unittest.mock.MagicMock()
+            with unittest.mock.patch("arm.api.v1.jobs.Job") as MockJob:
+                MockJob.query.get.return_value = None
+                _rip_folder_by_id(999)
+
+            mock_db.session.remove.assert_called_once()
+
+
+# =====================================================================
+# TVDB token lock
+# =====================================================================
+
+
+class TestTvdbTokenLock:
+    """Test that TVDB token acquisition is protected by asyncio.Lock."""
+
+    def test_lock_exists(self):
+        """Module should have an asyncio.Lock for token management."""
+        from arm.services import tvdb
+        assert isinstance(tvdb._TOKEN_LOCK, asyncio.Lock)
+
+    def test_concurrent_token_requests_serialized(self):
+        """Multiple concurrent _ensure_token calls should not race."""
+        from arm.services import tvdb
+
+        tvdb._TOKEN = None
+        tvdb._TOKEN_EXPIRES = 0
+
+        call_count = 0
+
+        mock_response = unittest.mock.MagicMock()
+        mock_response.json.return_value = {"data": {"token": "serialized_token"}}
+        mock_response.raise_for_status = unittest.mock.MagicMock()
+
+        async def mock_post(url, json=None):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.01)  # simulate network latency
+            return mock_response
+
+        mock_client = unittest.mock.MagicMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__ = unittest.mock.AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+
+        async def run_concurrent():
+            with unittest.mock.patch("arm.services.tvdb.cfg.arm_config",
+                                     {"TVDB_API_KEY": "test_key"}), \
+                 unittest.mock.patch("arm.services.tvdb.httpx.AsyncClient",
+                                     return_value=mock_client):
+                # Launch 5 concurrent calls
+                tasks = [tvdb._ensure_token() for _ in range(5)]
+                tokens = await asyncio.gather(*tasks)
+            return tokens
+
+        tokens = asyncio.run(run_concurrent())
+
+        # All should get the same token
+        assert all(t == "serialized_token" for t in tokens)
+        # Lock serializes: first call fetches, rest reuse cached
+        assert call_count == 1
+
+        # Cleanup
+        tvdb._TOKEN = None
+        tvdb._TOKEN_EXPIRES = 0
+
+
+# =====================================================================
+# arm_config lock
+# =====================================================================
+
+
+class TestArmConfigLock:
+    """Test that config updates use threading.Lock."""
+
+    def test_lock_exists(self):
+        """Config module should expose arm_config_lock."""
+        import arm.config.config as cfg
+        # threading.Lock() returns a _thread.lock instance
+        assert hasattr(cfg, 'arm_config_lock')
+        assert hasattr(cfg.arm_config_lock, 'acquire')
+        assert hasattr(cfg.arm_config_lock, 'release')
+
+    def test_settings_update_uses_lock(self):
+        """update_config code path acquires arm_config_lock around clear+update."""
+        import arm.api.v1.settings  # ensure module is loaded
+        import arm.config.config as cfg
+
+        # Verify the lock usage is in the source code
+        import inspect
+        source = inspect.getsource(arm.api.v1.settings.update_config)
+        assert "arm_config_lock" in source, (
+            "update_config must use cfg.arm_config_lock"
+        )
+
+
+# =====================================================================
+# Async endpoint wrappers
+# =====================================================================
+
+
+class TestAsyncEndpoints:
+    """Test that heavy endpoints are async and work correctly."""
+
+    def test_fix_permissions_is_async(self):
+        """fix_job_permissions should be an async def."""
+        import inspect
+        from arm.api.v1.jobs import fix_job_permissions
+        assert inspect.iscoroutinefunction(fix_job_permissions)
+
+    def test_send_job_is_async(self):
+        """send_job should be an async def."""
+        import inspect
+        from arm.api.v1.jobs import send_job
+        assert inspect.iscoroutinefunction(send_job)
+
+    def test_rescan_drives_is_async(self):
+        """rescan_drives should be an async def."""
+        import inspect
+        from arm.api.v1.drives import rescan_drives
+        assert inspect.iscoroutinefunction(rescan_drives)
+
+    def test_maintenance_delete_log_is_async(self):
+        import inspect
+        from arm.api.v1.maintenance import delete_log
+        assert inspect.iscoroutinefunction(delete_log)
+
+    def test_maintenance_delete_folder_is_async(self):
+        import inspect
+        from arm.api.v1.maintenance import delete_folder
+        assert inspect.iscoroutinefunction(delete_folder)
+
+    def test_maintenance_bulk_delete_logs_is_async(self):
+        import inspect
+        from arm.api.v1.maintenance import bulk_delete_logs
+        assert inspect.iscoroutinefunction(bulk_delete_logs)
+
+    def test_maintenance_bulk_delete_folders_is_async(self):
+        import inspect
+        from arm.api.v1.maintenance import bulk_delete_folders
+        assert inspect.iscoroutinefunction(bulk_delete_folders)
+
+    def test_maintenance_clear_raw_is_async(self):
+        import inspect
+        from arm.api.v1.maintenance import clear_raw
+        assert inspect.iscoroutinefunction(clear_raw)
+
+    def test_fix_permissions_via_client(self, app_context, client, sample_job):
+        """POST /jobs/{id}/fix-permissions should work through async wrapper."""
+        with unittest.mock.patch("arm.api.v1.jobs.svc_files.fix_permissions",
+                                 return_value={"success": True, "mode": "fixperms"}):
+            resp = client.post(f"/api/v1/jobs/{sample_job.job_id}/fix-permissions")
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_rescan_drives_via_client(self, app_context, client):
+        """POST /drives/rescan should work through async wrapper."""
+        with unittest.mock.patch("arm.services.drives.drives_update", return_value=0), \
+             unittest.mock.patch("arm.api.v1.drives.SystemDrives") as mock_sd:
+            mock_sd.query.count.return_value = 2
+            resp = client.post("/api/v1/drives/rescan")
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+
+# =====================================================================
+# send_to_remote_db timeout
+# =====================================================================
+
+
+class TestSendToRemoteDbTimeout:
+    """Test that send_to_remote_db passes timeout to requests."""
+
+    def test_requests_get_called_with_timeout(self, app_context):
+        from arm.services.files import send_to_remote_db
+
+        mock_job = unittest.mock.MagicMock()
+        mock_job.crc_id = "abc"
+        mock_job.title = "Test"
+        mock_job.year = "2020"
+        mock_job.imdb_id = "tt1234"
+        mock_job.hasnicetitle = True
+        mock_job.label = "TEST"
+        mock_job.video_type = "movie"
+        mock_job.get_d.return_value = {"title": "Test"}
+        mock_job.config.get_d.return_value = {}
+
+        mock_response = unittest.mock.MagicMock()
+        mock_response.text = '{"success": true}'
+
+        with unittest.mock.patch("arm.services.files.Job") as MockJob, \
+             unittest.mock.patch("arm.services.files.cfg") as mock_cfg, \
+             unittest.mock.patch("arm.services.files.requests.get",
+                                 return_value=mock_response) as mock_get:
+            mock_cfg.arm_config = {"ARM_API_KEY": "key"}
+            MockJob.query.get.return_value = mock_job
+            send_to_remote_db(1)
+
+        # Verify timeout=15 was passed
+        _, kwargs = mock_get.call_args
+        assert kwargs["timeout"] == 15
+
+
+# =====================================================================
+# Ripper database_updater delegation
+# =====================================================================
+
+
+class TestRipperDelegation:
+    """Test that ripper's database_updater delegates to services version."""
+
+    def test_delegates_to_services(self, app_context):
+        """ripper.utils.database_updater should call services.files.database_updater."""
+        with unittest.mock.patch("arm.services.files.database_updater",
+                                 return_value=True) as mock_svc:
+            from arm.ripper.utils import database_updater
+            job = unittest.mock.MagicMock()
+            result = database_updater({"status": "x"}, job, wait_time=30)
+
+        mock_svc.assert_called_once_with({"status": "x"}, job, wait_time=30)
+        assert result is True
+
+    def test_delegation_preserves_non_dict_behavior(self, app_context):
+        """Non-dict args should still return False via delegation."""
+        with unittest.mock.patch("arm.services.files.database_updater",
+                                 return_value=False) as mock_svc:
+            from arm.ripper.utils import database_updater
+            job = unittest.mock.MagicMock()
+            result = database_updater(False, job)
+
+        mock_svc.assert_called_once()
+        assert result is False

--- a/test/test_async_safety.py
+++ b/test/test_async_safety.py
@@ -201,6 +201,44 @@ class TestRipFolderSessionCleanup:
 
 
 # =====================================================================
+# _with_session_cleanup - executor thread session safety
+# =====================================================================
+
+
+class TestWithSessionCleanup:
+    """Test that _with_session_cleanup releases scoped sessions."""
+
+    def test_session_removed_on_success(self, app_context):
+        from arm.api.v1.jobs import _with_session_cleanup
+
+        with unittest.mock.patch("arm.api.v1.jobs.db") as mock_db:
+            result = _with_session_cleanup(lambda: "ok")
+
+        assert result == "ok"
+        mock_db.session.remove.assert_called_once()
+
+    def test_session_removed_on_exception(self, app_context):
+        from arm.api.v1.jobs import _with_session_cleanup
+
+        def boom():
+            raise ValueError("test")
+
+        with unittest.mock.patch("arm.api.v1.jobs.db") as mock_db:
+            with pytest.raises(ValueError, match="test"):
+                _with_session_cleanup(boom)
+
+        mock_db.session.remove.assert_called_once()
+
+    def test_passes_args_through(self, app_context):
+        from arm.api.v1.jobs import _with_session_cleanup
+
+        with unittest.mock.patch("arm.api.v1.jobs.db"):
+            result = _with_session_cleanup(lambda a, b: a + b, 3, 4)
+
+        assert result == 7
+
+
+# =====================================================================
 # TVDB token lock
 # =====================================================================
 

--- a/test/test_async_safety.py
+++ b/test/test_async_safety.py
@@ -6,7 +6,6 @@ and send_to_remote_db timeout.
 """
 import asyncio
 import threading
-import time
 import unittest.mock
 
 import pytest
@@ -136,6 +135,17 @@ class TestDatabaseUpdaterBackoff:
         debug_calls = [str(c) for c in mock_log.debug.call_args_list]
         assert any("<redacted>" in c for c in debug_calls)
         assert not any("secret123" in c for c in debug_calls)
+
+    def test_timeout_raises_runtime_error(self, app_context):
+        """Exhausting wait_time should raise RuntimeError, not return True."""
+        from arm.services.files import database_updater
+
+        job = unittest.mock.MagicMock()
+        with unittest.mock.patch("arm.services.files.db") as mock_db, \
+             unittest.mock.patch("arm.services.files.sleep"):
+            mock_db.session.commit.side_effect = Exception("database is locked")
+            with pytest.raises(RuntimeError, match="timed out"):
+                database_updater({"status": "x"}, job, wait_time=0.5)
 
 
 # =====================================================================
@@ -268,13 +278,21 @@ class TestArmConfigLock:
     def test_settings_update_uses_lock(self):
         """update_config code path acquires arm_config_lock around clear+update."""
         import arm.api.v1.settings  # ensure module is loaded
-        import arm.config.config as cfg
 
-        # Verify the lock usage is in the source code
         import inspect
         source = inspect.getsource(arm.api.v1.settings.update_config)
         assert "arm_config_lock" in source, (
             "update_config must use cfg.arm_config_lock"
+        )
+
+    def test_change_job_config_uses_lock(self):
+        """change_job_config applies config_updates under arm_config_lock."""
+        import arm.api.v1.jobs  # ensure module is loaded
+
+        import inspect
+        source = inspect.getsource(arm.api.v1.jobs.change_job_config)
+        assert "arm_config_lock" in source, (
+            "change_job_config must use cfg.arm_config_lock"
         )
 
 

--- a/test/test_async_safety.py
+++ b/test/test_async_safety.py
@@ -5,7 +5,6 @@ threads, TVDB token lock, arm_config lock, async endpoint wrappers,
 and send_to_remote_db timeout.
 """
 import asyncio
-import threading
 import unittest.mock
 
 import pytest
@@ -146,6 +145,7 @@ class TestDatabaseUpdaterBackoff:
             mock_db.session.commit.side_effect = Exception("database is locked")
             with pytest.raises(RuntimeError, match="timed out"):
                 database_updater({"status": "x"}, job, wait_time=0.5)
+            mock_db.session.rollback.assert_called_once()
 
 
 # =====================================================================


### PR DESCRIPTION
## Summary

- **database_updater**: Replace 90s linear retry with exponential backoff (0.1-2s cap, 10s default for API). Consolidate ripper duplicate to delegate to services version.
- **Session cleanup**: Add `db.session.remove()` in finally block to `_rip_folder_by_id` daemon thread (prevents connection pool exhaustion).
- **Thread safety**: Add `asyncio.Lock` to TVDB token globals, `threading.Lock` to `arm_config` dict updates in settings endpoint.
- **Async endpoints**: Convert fix-permissions, maintenance (delete/bulk-delete/clear-raw), drive rescan, and remote DB send to `async def` with `asyncio.to_thread` so heavy filesystem/network ops don't block the uvicorn worker.
- **HTTP timeout**: Add `timeout=15` to `send_to_remote_db` requests call.

## Test plan
- [x] 27 new tests in `test_async_safety.py` covering all changes
- [x] Full suite: 1852 passed, 0 failed
- [ ] CI: pytest, codecov (100% patch target), SonarCloud, CodeQL, Docker build
- [ ] Deploy to hifi-server for integration testing