### PR TITLE
fix: detect and break stale per-device lock files

### DIFF
--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -445,7 +445,7 @@ if __name__ == "__main__":
         # script holds flock on fd 9 which auto-releases when this
         # process exits, but the file itself would remain and confuse
         # stale-lock detection.  Best-effort removal (ignore errors).
-        try:
+        try:  # pragma: no cover — entry-point cleanup, not reachable in unit tests
             import os
             dev = args.devpath if args else None
             if dev:

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -440,3 +440,15 @@ if __name__ == "__main__":
         # Release scoped session to prevent DB connection pool exhaustion
         # (this function runs in a daemon thread spawned by udev/drive detection)
         db.session.remove()
+        # Remove the per-device lock file so it doesn't persist on the
+        # bind-mounted volume after the flock is released.  The wrapper
+        # script holds flock on fd 9 which auto-releases when this
+        # process exits, but the file itself would remain and confuse
+        # stale-lock detection.  Best-effort removal (ignore errors).
+        try:
+            import os
+            dev = args.devpath if args else None
+            if dev:
+                os.remove(f"/home/arm/.arm_{dev}.lock")
+        except Exception:
+            pass

--- a/scripts/docker/rescan_drive.sh
+++ b/scripts/docker/rescan_drive.sh
@@ -93,8 +93,17 @@ fi
 # --- Check if ARM is already processing this drive ---
 LOCKFILE="/home/arm/.arm_${DEVNAME}.lock"
 if ! flock -n "$LOCKFILE" true 2>/dev/null; then
-    log "ARM already running for $DEVNAME (lock held), skipping"
-    exit 0
+    # Lock is held - verify the holding process is actually alive.
+    # A stuck or killed ARM process can leave a held flock if fd 9
+    # is inherited by a zombie child or the process is in D-state.
+    # Check if any python main.py process is running for this device.
+    if pgrep -f "main.py.*-d ${DEVNAME}" > /dev/null 2>&1; then
+        log "ARM already running for $DEVNAME (lock held, process alive), skipping"
+        exit 0
+    else
+        log "Stale lock detected for $DEVNAME (lock held but no ARM process found), breaking lock"
+        rm -f "$LOCKFILE"
+    fi
 fi
 
 # --- Launch ARM wrapper directly ---

--- a/scripts/host/arm-drive-watcher.sh
+++ b/scripts/host/arm-drive-watcher.sh
@@ -42,8 +42,14 @@ fi
 
 # --- Check if ARM is already processing this device ---
 if ! docker exec "$CONTAINER" flock -n "/home/arm/.arm_${DEVNAME}.lock" true 2>/dev/null; then
-    log "ARM already processing $DEVNAME, skipping"
-    exit 0
+    # Lock is held - verify an ARM process is actually running for this device.
+    if docker exec "$CONTAINER" pgrep -f "main.py.*-d ${DEVNAME}" > /dev/null 2>&1; then
+        log "ARM already processing $DEVNAME (lock held, process alive), skipping"
+        exit 0
+    else
+        log "Stale lock for $DEVNAME (no ARM process found), removing"
+        docker exec "$CONTAINER" rm -f "/home/arm/.arm_${DEVNAME}.lock"
+    fi
 fi
 
 # --- Check if a disc is present (ioctl inside container) ---


### PR DESCRIPTION
## Summary

- Remove lock file on normal process exit in `main.py` finally block
- Validate stale locks in `rescan_drive.sh` by checking if an ARM process is actually alive (`pgrep`) before skipping - if no process found, break the lock and proceed
- Same stale lock validation in `arm-drive-watcher.sh` on the host side via `docker exec`

## Problem

After a rip completes, the Python process should exit and release the flock. However if the process gets stuck in the finally block (hung eject, DB commit timeout, NFS D-state), the flock stays held indefinitely. This blocks all disc detection for that drive until the container is restarted or the lock file is manually deleted.

Observed: job 133 logged "ARM processing complete", disc ejected, but the flock was held for 10+ hours. Inserting a new disc failed silently.

## Test plan

- [ ] Normal rip completes - lock file should be removed after exit
- [ ] If ARM process is killed mid-rip - next disc insert should detect stale lock, log it, break it, and proceed
- [ ] If ARM process is actively ripping - lock check should see the process alive and skip correctly
- [ ] Container restart - cleanup_orphaned_jobs.sh still removes lock files at startup (unchanged)