### PR TITLE
fix: suppress false warning for read-only transcode mount

### DIFF
--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -88,7 +88,9 @@ for dir in $SUBDIRS ; do
   # Verify the arm user can actually write to the directory.
   # On NFS with root_squash, mkdir-as-root + failed chown leaves
   # root-owned dirs that the arm user cannot write to.
-  if ! su -s /bin/sh arm -c "test -w '${thisDir}'" 2>/dev/null; then
+  # Skip check for media/transcode — it is intentionally mounted read-only
+  # from the transcoder work dir (for the file browser to show in-progress transcodes).
+  if [[ "$dir" != "media/transcode" ]] && ! su -s /bin/sh arm -c "test -w '${thisDir}'" 2>/dev/null; then
     WRITE_WARNINGS="${WRITE_WARNINGS}\n  [WARN] $thisDir is NOT writable by arm ($ARM_UID:$ARM_GID)"
   fi
 done


### PR DESCRIPTION
## Summary
- Skip writability check for `media/transcode` in the startup script — this directory is intentionally mounted `:ro` from the transcoder work dir so the file browser can show in-progress transcodes
- The warning fired on every container start, confusing users into thinking they had a permissions problem to fix

Reported by external tester (same session as PR #201).

## Test plan
- [ ] `docker compose up` no longer shows `[WARN] /home/arm/media/transcode is NOT writable` on startup
- [ ] Other writable directories still produce warnings if they have permission issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)