### PR TITLE
fix: poster fallback to OMDb/TMDb when CRC64 record has no image

### DIFF
--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -461,6 +461,18 @@ def identify_dvd(job):
             hit = crc_result["results"][0]
             logging.info("Found crc64 id from online API")
             logging.info(f"title is {hit['title']}")
+            poster = hit.get('poster_url') or None
+            # CRC64 DB often has no poster — fall back to OMDb/TMDb if we have an IMDB ID
+            if not poster and hit.get('imdb_id'):
+                logging.info("CRC64 record has no poster, fetching from metadata provider")
+                try:
+                    from arm.services.metadata_sync import get_details_sync
+                    details = get_details_sync(hit['imdb_id'])
+                    if details and details.get('poster_url'):
+                        poster = details['poster_url']
+                        logging.info(f"Poster fetched from metadata provider: {poster}")
+                except Exception as exc:
+                    logging.warning(f"Metadata poster fallback failed: {exc}")
             args = {
                 'title': hit['title'],
                 'title_auto': hit['title'],
@@ -470,8 +482,8 @@ def identify_dvd(job):
                 'imdb_id_auto': hit['imdb_id'],
                 'video_type': hit['video_type'],
                 'video_type_auto': hit['video_type'],
-                'poster_url': hit['poster_url'],
-                'poster_url_auto': hit['poster_url'],
+                'poster_url': poster or '',
+                'poster_url_auto': poster or '',
                 'hasnicetitle': True
             }
             utils.database_updater(args, job)

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -357,7 +357,7 @@ async def lookup_crc(crc64: str) -> dict[str, Any]:
             "video_type": entry.get("video_type", ""),
             "disctype": entry.get("disctype", ""),
             "label": entry.get("label", ""),
-            "poster_url": entry.get("poster_img", ""),
+            "poster_url": "" if entry.get("poster_img") in (None, "None", "N/A") else entry.get("poster_img", ""),
             "hasnicetitle": entry.get("hasnicetitle", ""),
             "validated": entry.get("validated", ""),
             "date_added": entry.get("date_added", ""),

--- a/test/test_identify.py
+++ b/test/test_identify.py
@@ -582,6 +582,91 @@ class TestIdentifyDvdCrc:
             result = identify_dvd(job)
         assert result is False
 
+    def test_crc_no_poster_falls_back_to_metadata(self):
+        """CRC match with no poster fetches it from OMDb/TMDb via IMDB ID."""
+        from arm.ripper.identify import identify_dvd
+
+        job = self._make_job()
+        crc_result = {
+            "found": True,
+            "results": [{
+                "title": "Gods Not Dead 2", "year": "2016",
+                "imdb_id": "tt4824308", "video_type": "movie",
+                "poster_url": "",
+            }]
+        }
+        details_result = {
+            "title": "God's Not Dead 2", "year": "2016",
+            "imdb_id": "tt4824308", "media_type": "movie",
+            "poster_url": "https://m.media-amazon.com/images/poster.jpg",
+        }
+        with unittest.mock.patch('arm.ripper.identify.pydvdid') as mock_dvdid, \
+             unittest.mock.patch('arm.services.metadata_sync.lookup_crc_sync',
+                                 return_value=crc_result), \
+             unittest.mock.patch('arm.services.metadata_sync.get_details_sync',
+                                 return_value=details_result) as mock_details, \
+             unittest.mock.patch('arm.ripper.identify.utils') as mock_utils, \
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+            mock_dvdid.compute.return_value = "abc123"
+            mock_utils.extract_year.return_value = "2016"
+            result = identify_dvd(job)
+        assert result is True
+        mock_details.assert_called_once_with("tt4824308")
+        call_args = mock_utils.database_updater.call_args[0][0]
+        assert call_args["poster_url"] == "https://m.media-amazon.com/images/poster.jpg"
+
+    def test_crc_no_poster_no_imdb_skips_fallback(self):
+        """CRC match with no poster and no IMDB ID doesn't attempt fallback."""
+        from arm.ripper.identify import identify_dvd
+
+        job = self._make_job()
+        crc_result = {
+            "found": True,
+            "results": [{
+                "title": "Unknown Disc", "year": "2020",
+                "imdb_id": "", "video_type": "movie",
+                "poster_url": "",
+            }]
+        }
+        with unittest.mock.patch('arm.ripper.identify.pydvdid') as mock_dvdid, \
+             unittest.mock.patch('arm.services.metadata_sync.lookup_crc_sync',
+                                 return_value=crc_result), \
+             unittest.mock.patch('arm.services.metadata_sync.get_details_sync') as mock_details, \
+             unittest.mock.patch('arm.ripper.identify.utils') as mock_utils, \
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+            mock_dvdid.compute.return_value = "abc123"
+            mock_utils.extract_year.return_value = "2020"
+            result = identify_dvd(job)
+        assert result is True
+        mock_details.assert_not_called()
+
+    def test_crc_poster_fallback_failure_still_succeeds(self):
+        """CRC match succeeds even when metadata poster fallback fails."""
+        from arm.ripper.identify import identify_dvd
+
+        job = self._make_job()
+        crc_result = {
+            "found": True,
+            "results": [{
+                "title": "Gods Not Dead 2", "year": "2016",
+                "imdb_id": "tt4824308", "video_type": "movie",
+                "poster_url": "",
+            }]
+        }
+        with unittest.mock.patch('arm.ripper.identify.pydvdid') as mock_dvdid, \
+             unittest.mock.patch('arm.services.metadata_sync.lookup_crc_sync',
+                                 return_value=crc_result), \
+             unittest.mock.patch('arm.services.metadata_sync.get_details_sync',
+                                 side_effect=Exception("API timeout")), \
+             unittest.mock.patch('arm.ripper.identify.utils') as mock_utils, \
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+            mock_dvdid.compute.return_value = "abc123"
+            mock_utils.extract_year.return_value = "2016"
+            result = identify_dvd(job)
+        assert result is True
+        call_args = mock_utils.database_updater.call_args[0][0]
+        assert call_args["poster_url"] == ""
+
     def test_pydvdid_exception_returns_false(self):
         """pydvdid.compute() exception is caught, returns False."""
         from arm.ripper.identify import identify_dvd

--- a/test/test_metadata_service.py
+++ b/test/test_metadata_service.py
@@ -997,6 +997,33 @@ class TestLookupCrc:
         assert result["found"] is False
         assert "error" in result
 
+    def test_poster_img_none_string_sanitized(self):
+        """CRC API returning poster_img='None' (string) should become empty string."""
+        from arm.services.metadata import lookup_crc
+        crc_resp = {
+            "success": True,
+            "results": {"0": {
+                "title": "Gods Not Dead 2", "year": "2016", "imdb_id": "tt4824308",
+                "tmdb_id": "None", "video_type": "movie", "disctype": "None",
+                "label": "Gods_Not_Dead_2", "poster_img": "None",
+                "hasnicetitle": "True", "validated": "False", "date_added": "2025-05-01",
+            }},
+        }
+        mock_resp = unittest.mock.MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = crc_resp
+        mock_resp.raise_for_status = unittest.mock.MagicMock()
+
+        with unittest.mock.patch('httpx.AsyncClient') as mock_cls:
+            ctx = unittest.mock.AsyncMock()
+            ctx.get = unittest.mock.AsyncMock(return_value=mock_resp)
+            mock_cls.return_value.__aenter__ = unittest.mock.AsyncMock(return_value=ctx)
+            mock_cls.return_value.__aexit__ = unittest.mock.AsyncMock(return_value=False)
+            result = _run(lookup_crc("90a40c808981776c"))
+
+        assert result["found"] is True
+        assert result["results"][0]["poster_url"] == ""
+
 
 # ---------------------------------------------------------------------------
 # test_configured_key


### PR DESCRIPTION
## Summary
- When CRC64 database lookup succeeds but returns no poster image (common — many records have `poster_img: "None"`), fall back to OMDb/TMDb using the IMDB ID from the CRC64 result
- Sanitize the string `"None"` returned by the CRC64 API so it becomes an empty string instead of being stored literally as the poster URL
- Fallback is non-blocking — if the metadata lookup fails, the CRC64 match still succeeds without a poster

Reported by external tester: Gods Not Dead 2 (tt4824308) identified correctly via CRC64 but had no poster because the CRC64 database record had `poster_img: "None"`.

## Test plan
- [x] `test_crc_no_poster_falls_back_to_metadata` — verifies poster is fetched from OMDb/TMDb
- [x] `test_crc_no_poster_no_imdb_skips_fallback` — no IMDB ID means no fallback attempt
- [x] `test_crc_poster_fallback_failure_still_succeeds` — API failure doesn't break CRC64 match
- [x] `test_poster_img_none_string_sanitized` — string "None" from API becomes empty string
- [x] All 1880 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)