### PR TITLE
fix: prevent silent ripper death during MakeMKV file write

### DIFF
--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -1701,7 +1701,15 @@ def run(options, select):
     cmd += list(options)
     buffer = []
     logging.debug(f"command: '{' '.join(cmd)}'")
-    with subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True) as proc:
+    # Do NOT use `with Popen(...) as proc:` here.  The context manager
+    # calls proc.wait() during generator cleanup (__del__/close), which
+    # blocks while MakeMKV finishes writing files to disk.  If a SIGTERM
+    # arrives during that wait, Python silently swallows the exception
+    # (PEP 342) and the process dies without logging.  Instead, manage
+    # the process lifecycle explicitly so proc.wait() runs in the main
+    # execution path where signal handlers work normally.
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True)
+    try:
         logging.debug(f"PID {proc.pid}: command: '{' '.join(cmd)}'")
         for line in proc.stdout:
             line = line.rstrip(os.linesep)
@@ -1729,6 +1737,13 @@ def run(options, select):
                 logging.debug(data)
             if msg_type in select:
                 yield data
+    finally:
+        # Explicitly wait for the process in a finally block so it runs
+        # in the caller's execution context, not during GC.  This ensures
+        # SIGTERM handlers fire properly and any errors are logged.
+        logging.info("Waiting for MakeMKV process (PID %d) to finish...", proc.pid)
+        proc.stdout.close()
+        proc.wait()
     if proc.returncode:
         raise MakeMkvRuntimeError(proc.returncode, cmd, output=os.linesep.join(buffer))
     logging.info("MakeMKV exits gracefully.")

--- a/test/test_logging_levels.py
+++ b/test/test_logging_levels.py
@@ -3,6 +3,7 @@
 Verifies that key MakeMKV events are logged at INFO (visible in production)
 and that rsync progress lines are logged at DEBUG (not flooding structured logs).
 """
+import io
 import logging
 import os
 import subprocess
@@ -21,11 +22,9 @@ class TestMakeMKVLogLevels:
         # Mock makemkvcon to emit a TCOUNT line
         mock_stdout = "TCOUNT:3\n"
         mock_proc = unittest.mock.MagicMock()
-        mock_proc.stdout = iter(mock_stdout.splitlines(keepends=True))
+        mock_proc.stdout = io.StringIO(mock_stdout)
         mock_proc.returncode = 0
         mock_proc.pid = 12345
-        mock_proc.__enter__ = lambda s: s
-        mock_proc.__exit__ = lambda s, *a: None
 
         with (
             unittest.mock.patch("subprocess.Popen", return_value=mock_proc),
@@ -45,11 +44,9 @@ class TestMakeMKVLogLevels:
 
         mock_stdout = 'MSG:5010,0,0,"Copy complete - 1 titles saved.","%1 titles saved.","1"\n'
         mock_proc = unittest.mock.MagicMock()
-        mock_proc.stdout = iter(mock_stdout.splitlines(keepends=True))
+        mock_proc.stdout = io.StringIO(mock_stdout)
         mock_proc.returncode = 0
         mock_proc.pid = 12345
-        mock_proc.__enter__ = lambda s: s
-        mock_proc.__exit__ = lambda s, *a: None
 
         with (
             unittest.mock.patch("subprocess.Popen", return_value=mock_proc),
@@ -69,11 +66,9 @@ class TestMakeMKVLogLevels:
 
         mock_stdout = "PRGV:100,200,65536\n"
         mock_proc = unittest.mock.MagicMock()
-        mock_proc.stdout = iter(mock_stdout.splitlines(keepends=True))
+        mock_proc.stdout = io.StringIO(mock_stdout)
         mock_proc.returncode = 0
         mock_proc.pid = 12345
-        mock_proc.__enter__ = lambda s: s
-        mock_proc.__exit__ = lambda s, *a: None
 
         with (
             unittest.mock.patch("subprocess.Popen", return_value=mock_proc),
@@ -95,11 +90,9 @@ class TestMakeMKVLogLevels:
 
         mock_stdout = 'SINFO:0,0,1,6201,"Video"\n'
         mock_proc = unittest.mock.MagicMock()
-        mock_proc.stdout = iter(mock_stdout.splitlines(keepends=True))
+        mock_proc.stdout = io.StringIO(mock_stdout)
         mock_proc.returncode = 0
         mock_proc.pid = 12345
-        mock_proc.__enter__ = lambda s: s
-        mock_proc.__exit__ = lambda s, *a: None
 
         with (
             unittest.mock.patch("subprocess.Popen", return_value=mock_proc),

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -3,6 +3,7 @@
 Covers job_dupe_check(), check_for_dupe_folder(), find_file(), scan_emby(),
 check_for_wait(), duplicate_run_check(), and MusicBrainz helper functions.
 """
+import io
 import os
 import unittest.mock
 
@@ -686,11 +687,9 @@ class TestMakeMkvRunParserFragility:
             'MSG:1005,0,1,"MakeMKV started","","""\n',  # valid MSG
         ]
         mock_proc = unittest.mock.MagicMock()
-        mock_proc.stdout = iter(fake_stdout)
+        mock_proc.stdout = io.StringIO("".join(fake_stdout))
         mock_proc.returncode = 0
         mock_proc.pid = 12345
-        mock_proc.__enter__ = lambda s: s
-        mock_proc.__exit__ = unittest.mock.MagicMock(return_value=False)
 
         with unittest.mock.patch('shutil.which', return_value='/usr/bin/makemkvcon'), \
              unittest.mock.patch('subprocess.Popen', return_value=mock_proc):
@@ -704,11 +703,9 @@ class TestMakeMkvRunParserFragility:
 
         fake_stdout = ['Some error output\n']
         mock_proc = unittest.mock.MagicMock()
-        mock_proc.stdout = iter(fake_stdout)
+        mock_proc.stdout = io.StringIO("".join(fake_stdout))
         mock_proc.returncode = 1
         mock_proc.pid = 12345
-        mock_proc.__enter__ = lambda s: s
-        mock_proc.__exit__ = unittest.mock.MagicMock(return_value=False)
 
         with unittest.mock.patch('shutil.which', return_value='/usr/bin/makemkvcon'), \
              unittest.mock.patch('subprocess.Popen', return_value=mock_proc):
@@ -724,11 +721,9 @@ class TestMakeMkvRunParserFragility:
             'Using direct disc access mode\n',
         ]
         mock_proc = unittest.mock.MagicMock()
-        mock_proc.stdout = iter(fake_stdout)
+        mock_proc.stdout = io.StringIO("".join(fake_stdout))
         mock_proc.returncode = 0
         mock_proc.pid = 12345
-        mock_proc.__enter__ = lambda s: s
-        mock_proc.__exit__ = unittest.mock.MagicMock(return_value=False)
 
         with unittest.mock.patch('shutil.which', return_value='/usr/bin/makemkvcon'), \
              unittest.mock.patch('subprocess.Popen', return_value=mock_proc):


### PR DESCRIPTION
## Summary
- Replace `with subprocess.Popen` context manager in `run()` with explicit `try/finally` for `proc.wait()`
- The context manager defers `__exit__` (and `proc.wait()`) to generator GC/close, where SIGTERM exceptions are silently swallowed per PEP 342
- With `try/finally`, `proc.wait()` runs during normal generator execution when stdout is exhausted, keeping signal handlers functional
- No caller changes needed — all six call sites (`deque(run(...))`, `for msg in run(...)`, `yield from run(...)`) work identically

## Root Cause
MakeMKV v1.18.3 on DVDs closes stdout and reports "Operation successfully completed" while still writing MKV files to disk (3-5 minutes later). The `run()` generator's `with Popen.__exit__` called `proc.wait()` during generator cleanup (GC), where Python silently swallows exceptions. If a SIGTERM arrived during that wait, the process died without logging — leaving jobs stuck in `ripping` status permanently.

## Test plan
- [x] All 1876 tests pass
- [x] Verified `try/finally` in generators executes during normal exhaustion, not GC
- [ ] Hardware test: rip a DVD, confirm "Waiting for MakeMKV process..." and "MakeMKV exits gracefully." appear in logs
- [ ] Hardware test: confirm job completes and status transitions to success/waiting_transcode

🤖 Generated with [Claude Code](https://claude.com/claude-code)