### PR TITLE
docs: document GPU transcoding setup for all vendors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,14 @@
 # For GPU transcoding: docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
 
 # --- Version Pinning ---
-# Pin to a specific release (e.g. 13.0.0) or use "latest"
+# Pin to a specific release (e.g. 15.0.0) or use "latest"
 ARM_VERSION=latest
 UI_VERSION=latest
+# Transcoder image tag controls GPU support:
+#   latest        — CPU-only (software x265, works everywhere)
+#   latest-nvidia — NVIDIA NVENC (requires docker-compose.gpu.yml overlay)
+#   latest-intel  — Intel Quick Sync (requires /dev/dri access, see README)
+#   latest-amd    — AMD VAAPI (requires /dev/dri access, see README)
 TRANSCODER_VERSION=latest
 
 # --- ARM Ripper ---
@@ -44,7 +49,10 @@ LOG_LEVEL=INFO
 # Library log level (HandBrake, FFmpeg output). Set to DEBUG for troubleshooting.
 LOG_LEVEL_LIBRARIES=WARNING
 
-# Video encoder: x265 (CPU), nvenc_h265 (NVIDIA), vaapi_h265 (AMD), qsv_h265 (Intel)
+# Video encoder — leave as x265 (safe default). The transcoder auto-detects
+# GPU hardware at startup and upgrades the encoder automatically.
+# Only override if you want to force a specific encoder:
+#   x265 (CPU), nvenc_h265 (NVIDIA), vaapi_h265 (AMD), qsv_h265 (Intel)
 VIDEO_ENCODER=x265
 VIDEO_QUALITY=22
 AUDIO_ENCODER=copy

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ ARM_CONFIG_PATH=/etc/arm/config
 ### 2. Start the stack
 
 ```bash
-# CPU-only (all three services)
+# CPU-only transcoding (default — works on any hardware)
 docker compose up -d
 
 # With NVIDIA GPU for transcoding
@@ -101,6 +101,32 @@ This pulls versioned images for all three services:
 | ARM ripper | `uprightbass360/automatic-ripping-machine` | 8080 |
 | UI dashboard | `uprightbass360/arm-ui` | 8888 |
 | Transcoder | `uprightbass360/arm-transcoder` | 5000 |
+
+### GPU Transcoding
+
+The transcoder image tag determines GPU support. Set `TRANSCODER_VERSION` in your `.env`:
+
+| GPU | `.env` setting | Additional setup |
+|-----|---------------|-----------------|
+| **None (CPU)** | `TRANSCODER_VERSION=latest` | None — uses software x265 |
+| **NVIDIA** | `TRANSCODER_VERSION=latest-nvidia` | Use `docker-compose.gpu.yml` overlay, install [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) |
+| **Intel (QSV)** | `TRANSCODER_VERSION=latest-intel` | Add `/dev/dri` device to transcoder (see below) |
+| **AMD (VAAPI)** | `TRANSCODER_VERSION=latest-amd` | Add `/dev/dri` device to transcoder (see below) |
+
+**Intel / AMD setup:** The transcoder needs access to `/dev/dri` for hardware encoding. Create a `docker-compose.override.yml`:
+
+```yaml
+services:
+  arm-transcoder:
+    devices:
+      - /dev/dri:/dev/dri
+```
+
+Then start normally with `docker compose up -d`. The override is automatically applied.
+
+The transcoder auto-detects the GPU at startup and selects the right encoder and presets. You do **not** need to set `VIDEO_ENCODER` manually — leave it as `x265` and the auto-resolver will upgrade it if GPU hardware is found.
+
+> **Common issue:** If transcoding fails with `HandBrake failed with exit code 3` or `Error creating a MFX session`, verify you're using the correct image tag for your GPU and that `/dev/dri` is accessible inside the container.
 
 ### 3. Verify
 


### PR DESCRIPTION
## Summary
- Add GPU Transcoding section to README covering CPU, NVIDIA, Intel QSV, and AMD VAAPI
- Document that `TRANSCODER_VERSION` image tag controls GPU support (`latest`, `latest-nvidia`, `latest-intel`, `latest-amd`)
- Add `docker-compose.override.yml` example for Intel/AMD `/dev/dri` device pass-through
- Document the common failure mode (HandBrake exit code 3 / MFX session error) when using wrong image
- Update `.env.example` with image tag documentation and clarify `VIDEO_ENCODER` auto-detection

Triggered by external tester using Intel QSV that failed because the setup wasn't documented.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] `.env.example` comments are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)