### PR TITLE
feat: add force parameter to drives/rescan endpoint

### DIFF
--- a/arm/api/v1/drives.py
+++ b/arm/api/v1/drives.py
@@ -303,18 +303,27 @@ async def drive_diagnostic():
 
 
 @router.post('/drives/rescan')
-async def rescan_drives():
+async def rescan_drives(force: bool = False):
     """Re-detect optical drives and update the database.
 
     Python-level only - refreshes the drive inventory in the DB
     by scanning /sys and udev. Does NOT trigger rips.
+
+    With ``force=true``, deletes all non-processing drive records
+    before rescanning. Useful when stale entries accumulate from
+    previous container runs or drive reconnections.
     """
     from arm.services.drives import drives_update
 
     def _do_rescan():
         try:
+            if force:
+                for d in SystemDrives.query.all():
+                    if not d.processing:
+                        db.session.delete(d)
+                db.session.commit()
             before = SystemDrives.query.count()
-            removed = drives_update()
+            removed = drives_update(startup=force)
             after = SystemDrives.query.count()
             return before, after, removed
         finally:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -464,6 +464,20 @@ class TestApiDrivesRescan:
         assert response.status_code == 500
         assert response.json()["success"] is False
 
+    def test_rescan_force_deletes_non_processing(self, client, app_context):
+        d_idle = unittest.mock.MagicMock(processing=False)
+        d_busy = unittest.mock.MagicMock(processing=True)
+        with unittest.mock.patch("arm.services.drives.drives_update", return_value=0), \
+             unittest.mock.patch("arm.api.v1.drives.SystemDrives") as mock_sd, \
+             unittest.mock.patch("arm.api.v1.drives.db") as mock_db:
+            mock_sd.query.all.return_value = [d_idle, d_busy]
+            mock_sd.query.count.side_effect = [1, 1]
+            response = client.post('/api/v1/drives/rescan?force=true')
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        mock_db.session.delete.assert_called_once_with(d_idle)
+        mock_db.session.commit.assert_called()
+
 
 class TestApiDriveScan:
     """Test POST /api/v1/drives/{drive_id}/scan endpoint."""


### PR DESCRIPTION
Deletes all non-processing drive records before rescanning when force=true. Fixes stale entries from container restarts.