### PR TITLE
feat: update transcode overrides to preset_slug + overrides shape

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -731,13 +731,13 @@ def get_naming_variables():
 
 
 TRANSCODE_OVERRIDE_KEYS = {
-    'video_encoder', 'video_quality', 'audio_encoder', 'subtitle_mode',
-    'handbrake_preset', 'handbrake_preset_4k', 'handbrake_preset_dvd',
-    'handbrake_preset_file', 'delete_source', 'output_extension',
+    'preset_slug',
+    'overrides',
+    'delete_source',
+    'output_extension',
 }
 
-# Type validation: int-valued, bool-valued, rest are strings
-_INT_KEYS = {'video_quality'}
+# Type validation: bool-valued, rest are strings
 _BOOL_KEYS = {'delete_source'}
 
 
@@ -751,7 +751,7 @@ def _coerce_bool(value):
 
 
 def _validate_transcode_overrides(body):
-    """Validate and coerce transcode override values. Returns (overrides, errors)."""
+    """Validate and coerce transcode override values."""
     overrides = {}
     errors = []
     for key, value in body.items():
@@ -760,13 +760,13 @@ def _validate_transcode_overrides(body):
             continue
         if value is None or value == '':
             continue
-        if key in _INT_KEYS:
-            try:
-                overrides[key] = int(value)
-            except (ValueError, TypeError):
-                errors.append(f"{key} must be an integer")
-        elif key in _BOOL_KEYS:
+        if key in _BOOL_KEYS:
             overrides[key] = _coerce_bool(value)
+        elif key == 'overrides':
+            if not isinstance(value, dict):
+                errors.append("overrides must be a dict")
+                continue
+            overrides[key] = value
         else:
             overrides[key] = str(value)
     return overrides, errors

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -2035,7 +2035,7 @@ class TestApiTranscodeConfig:
 
     def test_transcode_config_not_found(self, client):
         response = client.patch('/api/v1/jobs/99999/transcode-config',
-                                 json={"video_encoder": "x265"})
+                                 json={"preset_slug": "cpu_balanced"})
         assert response.status_code == 404
 
     def test_transcode_config_empty_body(self, client, sample_job, app_context):
@@ -2055,13 +2055,56 @@ class TestApiTranscodeConfig:
     def test_transcode_config_valid(self, client, sample_job, app_context):
         response = client.patch(
             f'/api/v1/jobs/{sample_job.job_id}/transcode-config',
-            json={"video_encoder": "nvenc_h265", "video_quality": "22"}
+            json={"preset_slug": "nvidia_balanced", "delete_source": "true"}
         )
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is True
-        assert data["overrides"]["video_encoder"] == "nvenc_h265"
-        assert data["overrides"]["video_quality"] == 22
+        assert data["overrides"]["preset_slug"] == "nvidia_balanced"
+        assert data["overrides"]["delete_source"] is True
+
+
+class TestTranscodeOverridesNewShape:
+    """Unit tests for the preset-based transcode override validation."""
+
+    def test_validate_preset_slug(self):
+        from arm.api.v1.jobs import _validate_transcode_overrides
+        body = {"preset_slug": "nvidia_balanced"}
+        overrides, errors = _validate_transcode_overrides(body)
+        assert not errors
+        assert overrides["preset_slug"] == "nvidia_balanced"
+
+    def test_validate_overrides_dict(self):
+        from arm.api.v1.jobs import _validate_transcode_overrides
+        body = {
+            "preset_slug": "nvidia_balanced",
+            "overrides": {"shared": {"audio_encoder": "aac"}, "tiers": {"uhd": {"video_quality": 18}}},
+        }
+        overrides, errors = _validate_transcode_overrides(body)
+        assert not errors
+        assert overrides["preset_slug"] == "nvidia_balanced"
+        assert overrides["overrides"]["tiers"]["uhd"]["video_quality"] == 18
+
+    def test_reject_old_flat_keys(self):
+        from arm.api.v1.jobs import _validate_transcode_overrides
+        body = {"video_encoder": "nvenc_h265"}
+        overrides, errors = _validate_transcode_overrides(body)
+        assert len(errors) == 1
+        assert "Unknown key" in errors[0]
+
+    def test_overrides_must_be_dict(self):
+        from arm.api.v1.jobs import _validate_transcode_overrides
+        body = {"overrides": "not_a_dict"}
+        overrides, errors = _validate_transcode_overrides(body)
+        assert len(errors) == 1
+        assert "dict" in errors[0]
+
+    def test_delete_source_still_works(self):
+        from arm.api.v1.jobs import _validate_transcode_overrides
+        body = {"delete_source": "true"}
+        overrides, errors = _validate_transcode_overrides(body)
+        assert not errors
+        assert overrides["delete_source"] is True
 
 
 class TestApiTranscodeCallback:
@@ -2629,12 +2672,12 @@ class TestApiRetranscodeInfo:
     def test_retranscode_info_with_overrides(self, client, sample_job, app_context):
         import json
         from arm.database import db
-        sample_job.transcode_overrides = json.dumps({"video_encoder": "nvenc_h265"})
+        sample_job.transcode_overrides = json.dumps({"preset_slug": "nvidia_balanced"})
         db.session.commit()
 
         response = client.get(f'/api/v1/jobs/{sample_job.job_id}/retranscode-info')
         data = response.json()
-        assert data["config_overrides"] == {"video_encoder": "nvenc_h265"}
+        assert data["config_overrides"] == {"preset_slug": "nvidia_balanced"}
 
     def test_retranscode_info_multi_title(self, client, sample_job, app_context):
         from arm.models.track import Track

--- a/test/test_coverage_gaps_2.py
+++ b/test/test_coverage_gaps_2.py
@@ -142,14 +142,14 @@ class TestBuildWebhookPayload:
         """Transcode overrides JSON is included in payload."""
         from arm.ripper.utils import _build_webhook_payload
 
-        overrides = {"video_encoder": "nvenc_h265", "video_quality": 22}
+        overrides = {"preset_slug": "nvidia_balanced", "overrides": {"shared": {"video_quality": 22}}}
         sample_job.transcode_overrides = json.dumps(overrides)
         db.session.commit()
 
         payload = _build_webhook_payload("Rip done", "body", sample_job, "raw_dir")
         assert "config_overrides" in payload
-        assert payload["config_overrides"]["video_encoder"] == "nvenc_h265"
-        assert payload["config_overrides"]["video_quality"] == 22
+        assert payload["config_overrides"]["preset_slug"] == "nvidia_balanced"
+        assert payload["config_overrides"]["overrides"]["shared"]["video_quality"] == 22
 
     def test_job_is_none(self):
         """When job is None, payload has only basic fields."""


### PR DESCRIPTION
## Summary

Updates the transcode override keys to match the new preset-based model in the transcoder. Old flat keys (`video_encoder`, `video_quality`, `handbrake_preset*`, etc.) are replaced with `preset_slug` + `overrides` dict.

- `TRANSCODE_OVERRIDE_KEYS` now: `preset_slug`, `overrides`, `delete_source`, `output_extension`
- `_validate_transcode_overrides()` updated: dict passthrough for `overrides`, removed int coercion for removed `video_quality`
- Webhook payload passthrough unchanged (already JSON round-trips `job.transcode_overrides`)

## Related PRs

- Depends on: uprightbass360/automatic-ripping-machine-transcoder#77
- Needed by: uprightbass360/automatic-ripping-machine-ui#feat/preset-picker

All three must merge together as a release train.

## Test plan

- [x] New validation tests cover preset_slug, overrides dict, reject old flat keys, overrides-must-be-dict
- [x] Updated existing tests (`TestApiTranscodeConfig`, `TestApiRetranscodeInfo`) for new shape
- [x] All 1901 existing tests still pass
- [x] Webhook payload passthrough verified