### PR TITLE
feat: re-introduce SKIP_TRANSCODE as source of truth

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -966,6 +966,43 @@ def transcode_callback(job_id: int, body: dict):
     return {"success": True, "job_id": job.job_id, "status": job.status}
 
 
+@router.post('/jobs/{job_id}/skip-and-finalize')
+def skip_and_finalize(job_id: int):
+    """Skip transcoding and finalize a job's output directly.
+
+    Only allowed when the job is in TRANSCODE_WAITING or TRANSCODE_ACTIVE state.
+    Moves ripped files to the final output path and marks the job as SUCCESS.
+    """
+    job = Job.query.get(job_id)
+    if not job:
+        return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
+
+    allowed = {JobState.TRANSCODE_WAITING.value, JobState.TRANSCODE_ACTIVE.value}
+    if job.status not in allowed:
+        return JSONResponse(
+            {"success": False, "error": f"Job is in '{job.status}' state, expected transcode_waiting or transcode_active"},
+            status_code=409,
+        )
+
+    try:
+        from arm.ripper.naming import finalize_output
+        finalize_output(job)
+        job.status = JobState.SUCCESS.value
+        notification = Notifications(
+            f"Job: {job.job_id} finalized without transcoding",
+            f"'{job.title}' skipped transcoding and finalized successfully",
+        )
+        db.session.add(notification)
+        db.session.commit()
+        return {"success": True, "message": "Job finalized without transcoding"}
+    except Exception as exc:
+        db.session.rollback()
+        return JSONResponse(
+            {"success": False, "error": f"Finalization failed: {exc}"},
+            status_code=500,
+        )
+
+
 @router.post('/jobs/{job_id}/tvdb-match')
 def tvdb_match(job_id: int, body: dict):
     """Run TVDB episode matching for a job.

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -997,8 +997,9 @@ def skip_and_finalize(job_id: int):
         return {"success": True, "message": "Job finalized without transcoding"}
     except Exception as exc:
         db.session.rollback()
+        logging.error("skip-and-finalize failed for job %s: %s", job_id, exc)
         return JSONResponse(
-            {"success": False, "error": f"Finalization failed: {exc}"},
+            {"success": False, "error": "Finalization failed"},
             status_code=500,
         )
 

--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -17,6 +17,45 @@ import arm.constants as constants  # noqa E402
 from arm.models.job import JobState  # noqa E402
 
 
+def _post_rip_handoff(job):
+    """Decide whether to hand off to the transcoder or finalize locally.
+
+    Decision logic:
+      1. If TRANSCODER_URL is empty → finalize locally (no transcoder at all).
+      2. If the per-job config has SKIP_TRANSCODE set (not None) → use it.
+      3. Otherwise fall back to the global SKIP_TRANSCODE (default False).
+
+    When skipping: finalize output, set SUCCESS, commit.
+    When not skipping: fire the transcoder webhook.
+    Always handles NOTIFY_RIP notification.
+    """
+    import arm.config.config as cfg
+    from arm.ripper.naming import finalize_output
+
+    transcoder_url = cfg.arm_config.get('TRANSCODER_URL', '')
+
+    # Determine skip_transcode value: per-job override > global config
+    if job.config.SKIP_TRANSCODE is not None:
+        skip = job.config.SKIP_TRANSCODE
+    else:
+        skip = cfg.arm_config.get('SKIP_TRANSCODE', False)
+
+    if not transcoder_url or skip:
+        reason = "SKIP_TRANSCODE is enabled" if skip else "No transcoder configured"
+        logging.info("%s - finalizing output locally", reason)
+        finalize_output(job)
+        job.status = JobState.SUCCESS.value
+        db.session.commit()
+    else:
+        utils.transcoder_notify(
+            cfg.arm_config, constants.NOTIFY_TITLE,
+            f"{job.title} rip complete.", job,
+        )
+
+    if job.config.NOTIFY_RIP:
+        utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete.")
+
+
 def rip_visual_media(have_dupes, job, logfile, protection):
     """
     Main ripping function for dvd and Blu-rays, movies or series.
@@ -58,28 +97,7 @@ def rip_visual_media(have_dupes, job, logfile, protection):
     # Persist raw_path to DB — this is the actual directory on disk
     utils.database_updater({'raw_path': makemkv_out_path}, job)
 
-    # Determine whether to hand off to transcoder or finalize locally
-    import arm.config.config as cfg
-    transcoder_url = cfg.arm_config.get('TRANSCODER_URL', '')
-
-    if transcoder_url:
-        # Always notify the transcoder after rip - this is a pipeline trigger,
-        # separate from user notifications.
-        utils.transcoder_notify(
-            cfg.arm_config, constants.NOTIFY_TITLE,
-            f"{job.title} rip complete.", job,
-        )
-        if job.config.NOTIFY_RIP:
-            utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete.")
-    else:
-        # No transcoder - finalize output locally
-        from arm.ripper.naming import finalize_output
-        logging.info("No transcoder configured - finalizing output locally")
-        finalize_output(job)
-        job.status = JobState.SUCCESS.value
-        db.session.commit()
-        if job.config.NOTIFY_RIP:
-            utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete.")
+    _post_rip_handoff(job)
     logging.info("************* Ripping with MakeMKV completed *************")
 
     # Report errors if any

--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -203,22 +203,8 @@ def rip_folder(job):
                  len(list(job.tracks)), rawpath)
 
         # 7. Notify transcoder or finalize locally
-        transcoder_url = cfg.arm_config.get("TRANSCODER_URL", "")
-        if transcoder_url:
-            utils.transcoder_notify(
-                cfg.arm_config,
-                "ARM Notification",
-                f"{job.title} folder import rip complete.",
-                job,
-            )
-            job.status = JobState.TRANSCODE_WAITING.value
-        else:
-            from arm.ripper.naming import finalize_output
-            log.info("No transcoder configured - finalizing output locally")
-            finalize_output(job)
-            job.status = JobState.SUCCESS.value
-
-        db.session.commit()
+        from arm.ripper.arm_ripper import _post_rip_handoff
+        _post_rip_handoff(job)
         log.info("Folder import rip complete for job %s", job.job_id)
 
     except Exception as exc:

--- a/setup/arm.yaml
+++ b/setup/arm.yaml
@@ -374,6 +374,13 @@ PO_APP_KEY: ""
 BASH_SCRIPT: ""
 
 ## Transcoder Integration
+
+# Skip transcoding — finalize ripped files directly without sending to
+# the transcoder service.  When true, TRANSCODER_URL is ignored and jobs
+# go straight to SUCCESS after ripping.
+# Per-job override: the review panel toggle overrides this default.
+SKIP_TRANSCODE: false
+
 # URL of the arm-transcoder webhook endpoint.
 # Default works with docker-compose (same machine). For remote transcoder,
 # use the host IP/hostname (e.g. http://192.168.0.92:5000/webhook/arm).

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -158,6 +158,58 @@ class TestApiJobSend:
             assert response.status_code == 200
 
 
+class TestSkipAndFinalize:
+    """Test POST /api/v1/jobs/<id>/skip-and-finalize endpoint."""
+
+    def test_skip_and_finalize_success(self, client, sample_job, app_context):
+        """TRANSCODE_WAITING job should finalize and become SUCCESS."""
+        from arm.ripper.utils import database_updater
+        from arm.database import db
+        database_updater({"status": "waiting_transcode"}, sample_job)
+
+        with unittest.mock.patch('arm.ripper.naming.finalize_output'):
+            response = client.post(f'/api/v1/jobs/{sample_job.job_id}/skip-and-finalize')
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert "finalized" in data["message"].lower()
+        db.session.refresh(sample_job)
+        assert sample_job.status == "success"
+
+    def test_skip_and_finalize_wrong_state(self, client, sample_job, app_context):
+        """Job in VIDEO_RIPPING state should return 409."""
+        from arm.ripper.utils import database_updater
+        database_updater({"status": "ripping"}, sample_job)
+
+        response = client.post(f'/api/v1/jobs/{sample_job.job_id}/skip-and-finalize')
+        assert response.status_code == 409
+        data = response.json()
+        assert data["success"] is False
+
+    def test_skip_and_finalize_not_found(self, client):
+        """Non-existent job should return 404."""
+        response = client.post('/api/v1/jobs/99999/skip-and-finalize')
+        assert response.status_code == 404
+        data = response.json()
+        assert data["success"] is False
+
+    def test_skip_and_finalize_transcoding_active(self, client, sample_job, app_context):
+        """TRANSCODE_ACTIVE job should also finalize successfully."""
+        from arm.ripper.utils import database_updater
+        from arm.database import db
+        database_updater({"status": "transcoding"}, sample_job)
+
+        with unittest.mock.patch('arm.ripper.naming.finalize_output'):
+            response = client.post(f'/api/v1/jobs/{sample_job.job_id}/skip-and-finalize')
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        db.session.refresh(sample_job)
+        assert sample_job.status == "success"
+
+
 class TestApiJobLog:
     """Test GET /api/v1/jobs/<id>/log endpoint."""
 

--- a/test/test_arm_ripper.py
+++ b/test/test_arm_ripper.py
@@ -154,3 +154,67 @@ class TestRipVisualMedia:
                 if 'rip complete' in str(c).lower()
             ]
             assert len(rip_complete_calls) == 0
+
+
+class TestSkipTranscode:
+    """Test _post_rip_handoff() SKIP_TRANSCODE decision logic."""
+
+    def _make_job(self, skip_transcode=None, notify_rip=False):
+        job = unittest.mock.MagicMock()
+        job.title = "Test Movie"
+        job.config.SKIP_TRANSCODE = skip_transcode
+        job.config.NOTIFY_RIP = notify_rip
+        return job
+
+    def test_skip_transcode_true_finalizes_locally(self):
+        from arm.ripper.arm_ripper import _post_rip_handoff
+
+        job = self._make_job(skip_transcode=True)
+
+        with unittest.mock.patch('arm.ripper.arm_ripper.db'), \
+             unittest.mock.patch('arm.ripper.arm_ripper.utils') as mock_utils, \
+             unittest.mock.patch('arm.config.config.arm_config', {'TRANSCODER_URL': 'http://transcoder:5000/webhook/arm', 'SKIP_TRANSCODE': False}), \
+             unittest.mock.patch('arm.ripper.naming.finalize_output') as mock_finalize:
+            _post_rip_handoff(job)
+            mock_finalize.assert_called_once_with(job)
+            mock_utils.transcoder_notify.assert_not_called()
+
+    def test_skip_transcode_false_notifies_transcoder(self):
+        from arm.ripper.arm_ripper import _post_rip_handoff
+
+        job = self._make_job(skip_transcode=False)
+
+        with unittest.mock.patch('arm.ripper.arm_ripper.db'), \
+             unittest.mock.patch('arm.ripper.arm_ripper.utils') as mock_utils, \
+             unittest.mock.patch('arm.config.config.arm_config', {'TRANSCODER_URL': 'http://transcoder:5000/webhook/arm', 'SKIP_TRANSCODE': False}), \
+             unittest.mock.patch('arm.ripper.naming.finalize_output') as mock_finalize:
+            _post_rip_handoff(job)
+            mock_finalize.assert_not_called()
+            mock_utils.transcoder_notify.assert_called_once()
+
+    def test_skip_transcode_no_url_finalizes_locally(self):
+        from arm.ripper.arm_ripper import _post_rip_handoff
+
+        job = self._make_job(skip_transcode=False)
+
+        with unittest.mock.patch('arm.ripper.arm_ripper.db'), \
+             unittest.mock.patch('arm.ripper.arm_ripper.utils') as mock_utils, \
+             unittest.mock.patch('arm.config.config.arm_config', {'TRANSCODER_URL': '', 'SKIP_TRANSCODE': False}), \
+             unittest.mock.patch('arm.ripper.naming.finalize_output') as mock_finalize:
+            _post_rip_handoff(job)
+            mock_finalize.assert_called_once_with(job)
+            mock_utils.transcoder_notify.assert_not_called()
+
+    def test_per_job_override_skip(self):
+        from arm.ripper.arm_ripper import _post_rip_handoff
+
+        # Global says don't skip, but per-job says skip
+        job = self._make_job(skip_transcode=True)
+
+        with unittest.mock.patch('arm.ripper.arm_ripper.db'), \
+             unittest.mock.patch('arm.ripper.arm_ripper.utils') as mock_utils, \
+             unittest.mock.patch('arm.config.config.arm_config', {'TRANSCODER_URL': 'http://transcoder:5000/webhook/arm', 'SKIP_TRANSCODE': False}), \
+             unittest.mock.patch('arm.ripper.naming.finalize_output') as mock_finalize:
+            _post_rip_handoff(job)
+            mock_finalize.assert_called_once_with(job)
+            mock_utils.transcoder_notify.assert_not_called()

--- a/test/test_folder_ripper.py
+++ b/test/test_folder_ripper.py
@@ -39,16 +39,15 @@ class TestRipFolder:
         return job
 
     @patch("arm.ripper.folder_ripper.db")
-    @patch("arm.ripper.folder_ripper.utils.transcoder_notify")
     @patch("arm.ripper.folder_ripper._reconcile_filenames")
     @patch("arm.ripper.makemkv.run")
     @patch("arm.ripper.folder_ripper.prescan_track_info")
     @patch("arm.ripper.folder_ripper.prep_mkv")
     def test_happy_path_all_mode(
         self, mock_prep, mock_prescan, mock_run,
-        mock_reconcile, mock_notify, mock_db, tmp_path
+        mock_reconcile, mock_db, tmp_path
     ):
-        """No transcoder configured - finalize_output runs, status is success."""
+        """Post-rip handoff is called after rip completes."""
         from arm.ripper.folder_ripper import rip_folder
 
         rawpath = tmp_path / "raw" / "Test Movie"
@@ -59,7 +58,7 @@ class TestRipFolder:
 
         with patch("arm.ripper.folder_ripper.setup_rawpath", return_value=str(rawpath)), \
              patch("arm.ripper.folder_ripper.cfg") as mock_cfg, \
-             patch("arm.ripper.naming.finalize_output") as mock_finalize:
+             patch("arm.ripper.arm_ripper._post_rip_handoff") as mock_handoff:
             mock_cfg.arm_config = {"TRANSCODER_URL": ""}
             rip_folder(job)
 
@@ -70,19 +69,16 @@ class TestRipFolder:
         assert args[0] is job
         assert args[1] == str(rawpath)
         assert "title_map" in kwargs
-        mock_notify.assert_not_called()
-        mock_finalize.assert_called_once_with(job)
-        assert job.status == "success"
+        mock_handoff.assert_called_once_with(job)
 
     @patch("arm.ripper.folder_ripper.db")
-    @patch("arm.ripper.folder_ripper.utils.transcoder_notify")
     @patch("arm.ripper.folder_ripper._reconcile_filenames")
     @patch("arm.ripper.makemkv.run")
     @patch("arm.ripper.folder_ripper.prescan_track_info")
     @patch("arm.ripper.folder_ripper.prep_mkv")
     def test_happy_path_with_transcoder_notify(
         self, mock_prep, mock_prescan, mock_run,
-        mock_reconcile, mock_notify, mock_db, tmp_path
+        mock_reconcile, mock_db, tmp_path
     ):
         from arm.ripper.folder_ripper import rip_folder
 
@@ -93,22 +89,21 @@ class TestRipFolder:
         mock_run.return_value = iter([])
 
         with patch("arm.ripper.folder_ripper.setup_rawpath", return_value=str(rawpath)), \
-             patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
+             patch("arm.ripper.folder_ripper.cfg") as mock_cfg, \
+             patch("arm.ripper.arm_ripper._post_rip_handoff") as mock_handoff:
             mock_cfg.arm_config = {"TRANSCODER_URL": "http://transcoder:8080"}
             rip_folder(job)
 
-        mock_notify.assert_called_once()
-        assert job.status == "waiting_transcode"
+        mock_handoff.assert_called_once_with(job)
 
     @patch("arm.ripper.folder_ripper.db")
-    @patch("arm.ripper.folder_ripper.utils.transcoder_notify")
     @patch("arm.ripper.folder_ripper._reconcile_filenames")
     @patch("arm.ripper.makemkv.run")
     @patch("arm.ripper.folder_ripper.prescan_track_info")
     @patch("arm.ripper.folder_ripper.prep_mkv")
     def test_tracks_marked_ripped_only_if_file_exists(
         self, mock_prep, mock_prescan, mock_run,
-        mock_reconcile, mock_notify, mock_db, tmp_path
+        mock_reconcile, mock_db, tmp_path
     ):
         """Only tracks whose filename exists on disk should be marked ripped."""
         from arm.ripper.folder_ripper import rip_folder
@@ -133,7 +128,7 @@ class TestRipFolder:
         mock_run.return_value = iter([])
 
         with patch("arm.ripper.folder_ripper.cfg") as mock_cfg, mock_setup, \
-             patch("arm.ripper.naming.finalize_output"):
+             patch("arm.ripper.arm_ripper._post_rip_handoff"):
             mock_cfg.arm_config = {"TRANSCODER_URL": ""}
             rip_folder(job)
 

--- a/test/test_title_map.py
+++ b/test/test_title_map.py
@@ -337,8 +337,7 @@ class TestFolderRipperTitleMap:
              patch("arm.ripper.folder_ripper.prep_mkv"), \
              patch("arm.ripper.folder_ripper.prescan_track_info"), \
              patch("arm.ripper.folder_ripper._reconcile_filenames") as m_reconcile, \
-             patch("arm.ripper.folder_ripper.utils.transcoder_notify"), \
-             patch("arm.ripper.naming.finalize_output"), \
+             patch("arm.ripper.arm_ripper._post_rip_handoff"), \
              patch("arm.ripper.folder_ripper.db"), \
              patch("arm.ripper.folder_ripper.cfg") as mock_cfg:
             mock_cfg.arm_config = {"TRANSCODER_URL": ""}


### PR DESCRIPTION
## Summary

Re-introduces `SKIP_TRANSCODE` as the authoritative control for whether a job gets transcoded, replacing the `TRANSCODER_URL` empty-check hack.

- Add `SKIP_TRANSCODE: false` to arm.yaml config templates
- Extract `_post_rip_handoff(job)` with 3-tier decision: empty URL → finalize; per-job override → use it; global config → default
- Folder ripper shares the same handoff function
- New `POST /api/v1/jobs/{job_id}/skip-and-finalize` endpoint for stuck TRANSCODE_WAITING/TRANSCODE_ACTIVE jobs

## Related PRs

- Transcoder: uprightbass360/automatic-ripping-machine-transcoder#79
- UI: uprightbass360/automatic-ripping-machine-ui#feat/skip-transcode

## Test plan

- [x] 4 new tests for SKIP_TRANSCODE logic (TestSkipTranscode)
- [x] 4 new tests for skip-and-finalize endpoint (TestSkipAndFinalize)
- [x] All 1909 existing tests pass