### PR TITLE
feat!: mark preset system as breaking change for major version bump

### DIFF
--- a/setup/arm.yaml
+++ b/setup/arm.yaml
@@ -379,6 +379,7 @@ BASH_SCRIPT: ""
 # the transcoder service.  When true, TRANSCODER_URL is ignored and jobs
 # go straight to SUCCESS after ripping.
 # Per-job override: the review panel toggle overrides this default.
+# v16+ breaking change: replaces the old TRANSCODER_URL empty-check behavior.
 SKIP_TRANSCODE: false
 
 # URL of the arm-transcoder webhook endpoint.


### PR DESCRIPTION
## Summary

The `feat!:` breaking change indicator was lost during rebase merge of earlier PRs. Release-please generated 15.6.0 (minor) instead of 16.0.0 (major).

This commit adds a real file change to `setup/arm.yaml` with `feat!:` + `BREAKING CHANGE` footer so release-please correctly bumps to 16.0.0.

Previous attempt (PR #232) was merged but the commit was dropped during rebase — this branch is based on current main to avoid that.