### PR TITLE
fix: chown /home/arm after usermod to fix non-default UID startup

### DIFF
--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -68,6 +68,11 @@ usermod -a -G render arm
 # read-only filesystem (e.g. rescan_drive.sh mounted with :ro).
 chown -R --quiet arm:arm /opt/arm || true
 
+# Fix /home/arm ownership after usermod changes the UID.
+# The image bakes /home/arm as UID 1000; if ARM_UID differs,
+# the directory must be re-owned before the access check.
+chown arm:arm "$ARM_HOME" 2>/dev/null || true
+
 # Check ownership of the ARM home folder
 check_folder_ownership "/home/arm"
 


### PR DESCRIPTION
## Summary

When `ARM_UID` differs from the default 1000, `usermod` changes the arm user's UID but `/home/arm` (baked into the image at UID 1000) is not re-owned. The `check_folder_ownership` call then fails because the directory owner doesn't match the new UID.

Adds `chown arm:arm /home/arm` between `usermod` and the ownership check.

## Test plan

- [x] Verified with `ARM_UID=1001` — container was failing to start, now starts correctly