### PR TITLE
feat: add force-complete endpoint for stuck jobs

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -1004,6 +1004,32 @@ def skip_and_finalize(job_id: int):
         )
 
 
+@router.post('/jobs/{job_id}/force-complete')
+def force_complete(job_id: int):
+    """Mark a job as complete without moving files.
+
+    Use when the transcoder already processed the job but the callback
+    to ARM failed — the files are already in the right place, we just
+    need to update the status.
+    """
+    job = Job.query.get(job_id)
+    if not job:
+        return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
+
+    if job.status == JobState.SUCCESS.value:
+        return {"success": True, "message": "Job is already complete"}
+
+    previous_status = job.status
+    job.status = JobState.SUCCESS.value
+    notification = Notifications(
+        f"Job: {job.job_id} force-completed",
+        f"'{job.title}' marked complete (was: {previous_status})",
+    )
+    db.session.add(notification)
+    db.session.commit()
+    return {"success": True, "message": f"Job marked complete (was: {previous_status})"}
+
+
 @router.post('/jobs/{job_id}/tvdb-match')
 def tvdb_match(job_id: int, body: dict):
     """Run TVDB episode matching for a job.

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -210,6 +210,51 @@ class TestSkipAndFinalize:
         assert sample_job.status == "success"
 
 
+class TestForceComplete:
+    """Test POST /api/v1/jobs/<id>/force-complete endpoint."""
+
+    def test_force_complete_waiting_transcode(self, client, sample_job, app_context):
+        """TRANSCODE_WAITING job should be marked SUCCESS without moving files."""
+        from arm.ripper.utils import database_updater
+        from arm.database import db
+        database_updater({"status": "waiting_transcode"}, sample_job)
+
+        response = client.post(f'/api/v1/jobs/{sample_job.job_id}/force-complete')
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert "waiting_transcode" in data["message"]
+        db.session.refresh(sample_job)
+        assert sample_job.status == "success"
+
+    def test_force_complete_already_success(self, client, sample_job, app_context):
+        """Already-complete job should return success without error."""
+        from arm.ripper.utils import database_updater
+        database_updater({"status": "success"}, sample_job)
+
+        response = client.post(f'/api/v1/jobs/{sample_job.job_id}/force-complete')
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert "already" in data["message"].lower()
+
+    def test_force_complete_not_found(self, client):
+        """Non-existent job should return 404."""
+        response = client.post('/api/v1/jobs/99999/force-complete')
+        assert response.status_code == 404
+
+    def test_force_complete_failed_job(self, client, sample_job, app_context):
+        """Even a failed job can be force-completed."""
+        from arm.ripper.utils import database_updater
+        from arm.database import db
+        database_updater({"status": "fail"}, sample_job)
+
+        response = client.post(f'/api/v1/jobs/{sample_job.job_id}/force-complete')
+        assert response.status_code == 200
+        db.session.refresh(sample_job)
+        assert sample_job.status == "success"
+
+
 class TestApiJobLog:
     """Test GET /api/v1/jobs/<id>/log endpoint."""
 


### PR DESCRIPTION
## Summary

Adds `POST /api/v1/jobs/{job_id}/force-complete` — marks a job as SUCCESS without moving files.

Unlike `skip-and-finalize` (which runs `finalize_output` to move raw files), force-complete just updates the status. Use when the transcoder already processed the job but the callback to ARM failed.

## Test plan

- [x] 4 new tests (waiting_transcode, already_success, not_found, failed_job)
- [x] All existing tests pass