### PR TITLE
fix: consolidate post-rip status writes, fix SKIP_TRANSCODE stuck-job bug

### DIFF
--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -51,21 +51,22 @@ def _post_rip_handoff(job):
         job.status = JobState.SUCCESS.value
         db.session.commit()
     else:
-        # Hand off to transcoder. Status is TRANSCODE_WAITING on success;
-        # FAILURE if the webhook send raises (unreachable, 5xx, etc.).
-        try:
-            utils.transcoder_notify(
-                cfg.arm_config, constants.NOTIFY_TITLE,
-                f"{job.title} rip complete.", job,
-            )
+        # Hand off to transcoder. transcoder_notify returns False on any
+        # transport failure, non-2xx response, or auth failure - it logs
+        # the specific cause internally. Status is TRANSCODE_WAITING on
+        # success; FAILURE on handoff failure (not TRANSCODE_WAITING -
+        # a failed handoff should not look like a pending one).
+        if utils.transcoder_notify(
+            cfg.arm_config, constants.NOTIFY_TITLE,
+            f"{job.title} rip complete.", job,
+        ):
             job.status = JobState.TRANSCODE_WAITING.value
-        except Exception as exc:
-            logging.error("Transcoder handoff failed for job %s: %s", job.job_id, exc)
+        else:
             job.status = JobState.FAILURE.value
-            job.errors = f"Transcoder handoff failed: {exc}"
+            job.errors = "Transcoder handoff failed (see transcoder logs)"
         db.session.commit()
 
-    if job.config.NOTIFY_RIP:
+    if job.config.NOTIFY_RIP and job.status != JobState.FAILURE.value:
         utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete.")
 
 

--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -18,16 +18,20 @@ from arm.models.job import JobState  # noqa E402
 
 
 def _post_rip_handoff(job):
-    """Decide whether to hand off to the transcoder or finalize locally.
+    """Single source of truth for post-rip job status.
 
-    Decision logic:
-      1. If TRANSCODER_URL is empty → finalize locally (no transcoder at all).
-      2. If the per-job config has SKIP_TRANSCODE set (not None) → use it.
-      3. Otherwise fall back to the global SKIP_TRANSCODE (default False).
+    Handles all four terminal outcomes:
+      A. SKIP_TRANSCODE=true (per-job or global) -> finalize locally, SUCCESS
+      B. No TRANSCODER_URL configured -> finalize locally, SUCCESS
+      C. Handoff succeeds -> TRANSCODE_WAITING (transcoder callback sets final)
+      D. Handoff fails -> FAILURE (not TRANSCODE_WAITING - failed handoff should
+         not look like a pending one)
 
-    When skipping: finalize output, set SUCCESS, commit.
-    When not skipping: fire the transcoder webhook.
-    Always handles NOTIFY_RIP notification.
+    Decision precedence for skip:
+      1. Per-job config.SKIP_TRANSCODE (if not None)
+      2. Global SKIP_TRANSCODE (default False)
+
+    Always fires NOTIFY_RIP when enabled.
     """
     import arm.config.config as cfg
     from arm.ripper.naming import finalize_output
@@ -47,10 +51,19 @@ def _post_rip_handoff(job):
         job.status = JobState.SUCCESS.value
         db.session.commit()
     else:
-        utils.transcoder_notify(
-            cfg.arm_config, constants.NOTIFY_TITLE,
-            f"{job.title} rip complete.", job,
-        )
+        # Hand off to transcoder. Status is TRANSCODE_WAITING on success;
+        # FAILURE if the webhook send raises (unreachable, 5xx, etc.).
+        try:
+            utils.transcoder_notify(
+                cfg.arm_config, constants.NOTIFY_TITLE,
+                f"{job.title} rip complete.", job,
+            )
+            job.status = JobState.TRANSCODE_WAITING.value
+        except Exception as exc:
+            logging.error("Transcoder handoff failed for job %s: %s", job.job_id, exc)
+            job.status = JobState.FAILURE.value
+            job.errors = f"Transcoder handoff failed: {exc}"
+        db.session.commit()
 
     if job.config.NOTIFY_RIP:
         utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete.")

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -442,15 +442,10 @@ if __name__ == "__main__":
             job.errors = str(error)
         # Possibly add cleanup section here for failed job files
     else:
-        if job:
-            # If external transcoder is configured and this was a video disc,
-            # mark as waiting_transcode — the transcoder callback will set
-            # the final status (success/fail) when it finishes.
-            if (job.disctype in ("dvd", "bluray", "bluray4k")
-                    and cfg.arm_config.get("TRANSCODER_URL")):
-                job.status = JobState.TRANSCODE_WAITING.value
-            else:
-                job.status = JobState.SUCCESS.value
+        # Success path: _post_rip_handoff has already committed the correct
+        # terminal status (SUCCESS / TRANSCODE_WAITING / FAILURE). Nothing
+        # to do here.
+        pass
     finally:
         if job:
             final_status = job.status

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -249,16 +249,26 @@ def _build_webhook_payload(title, body, job, raw_basename):
     return payload
 
 
-def transcoder_notify(cfg, title, body, job=None):
+def transcoder_notify(cfg, title, body, job=None) -> bool:
     """Send a webhook notification to the arm-transcoder service.
+
     If LOCAL_RAW_PATH and SHARED_RAW_PATH are both set, moves the job's
-    raw directory from local to shared storage before notifying."""
+    raw directory from local to shared storage before notifying.
+
+    Returns:
+        bool: True if the webhook was delivered with an HTTP 2xx response.
+            False on any failure: missing job, missing TRANSCODER_URL,
+            auth failure (401/403), any non-2xx status, or transport
+            exception. Specific failure causes are logged internally so
+            operators can diagnose from the ripper logs; the boolean
+            lets callers branch on outcome without re-catching exceptions.
+    """
     if job is None or getattr(job, 'job_id', None) is None:
-        return
+        return False
 
     transcoder_url = cfg.get('TRANSCODER_URL', '')
     if not transcoder_url:
-        return
+        return False
 
     raw_basename = os.path.basename(str(job.raw_path)) if job.raw_path else ''
     _move_to_shared_storage(cfg, raw_basename, job)
@@ -285,10 +295,17 @@ def transcoder_notify(cfg, title, body, job=None):
                 f"Transcoder webhook auth failed (HTTP {resp.status_code}). "
                 "Check TRANSCODER_WEBHOOK_SECRET matches WEBHOOK_SECRET on the transcoder."
             )
-        else:
+            return False
+        if 200 <= resp.status_code < 300:
             logging.info(f"Transcoder webhook sent (HTTP {resp.status_code})")
+            return True
+        logging.error(
+            f"Transcoder webhook failed (HTTP {resp.status_code})"
+        )
+        return False
     except Exception as e:
         logging.error(f"Failed sending transcoder webhook: {e}")
+        return False
 
 
 def notify_entry(job):

--- a/test/test_post_rip_handoff.py
+++ b/test/test_post_rip_handoff.py
@@ -4,7 +4,10 @@ Covers the four post-rip outcomes:
   A. SKIP_TRANSCODE=true + transcoder configured -> SUCCESS + finalize_output
   B. SKIP_TRANSCODE=false + transcoder configured -> TRANSCODE_WAITING + webhook
   C. No transcoder configured -> SUCCESS + finalize_output
-  D. Webhook send fails -> FAILURE
+  D. transcoder_notify returns False -> FAILURE
+
+Also covers NOTIFY_RIP gating: 'rip complete' notification fires only
+on non-failure outcomes.
 
 These tests exercise the helper directly without patching it in isolation,
 catching the dual-writer bug in arm/ripper/main.py.
@@ -59,6 +62,7 @@ def test_skip_false_with_transcoder_configured_sets_waiting(
     only fires the webhook but does not write TRANSCODE_WAITING.
     """
     mock_job.config.SKIP_TRANSCODE = False
+    mock_notify.return_value = True
 
     _post_rip_handoff(mock_job)
 
@@ -88,20 +92,60 @@ def test_no_transcoder_configured_sets_success(
 @patch("arm.ripper.naming.finalize_output")
 @patch("arm.ripper.arm_ripper.db")
 @patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": False})
-def test_webhook_failure_sets_failure_status(
+def test_transcoder_notify_returns_false_sets_failure(
     mock_db, mock_finalize, mock_notify, mock_job,
 ):
-    """Outcome D: webhook send raises -> job marked FAILURE, not WAITING.
+    """Outcome D: transcoder_notify returns False -> job marked FAILURE.
 
-    A failed handoff should not look like a pending one.
+    transcoder_notify swallows its own transport exceptions and returns
+    False on failure; the caller branches on the return value.
     """
     mock_job.config.SKIP_TRANSCODE = False
-    mock_notify.side_effect = Exception("transcoder unreachable")
+    mock_notify.return_value = False
 
     _post_rip_handoff(mock_job)
 
     assert mock_job.status == JobState.FAILURE.value
+    assert "Transcoder handoff failed" in (mock_job.errors or "")
     mock_finalize.assert_not_called()
+
+
+@patch("arm.ripper.arm_ripper.utils.notify")
+@patch("arm.ripper.arm_ripper.utils.transcoder_notify")
+@patch("arm.ripper.naming.finalize_output")
+@patch("arm.ripper.arm_ripper.db")
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": False})
+def test_notify_rip_skipped_on_handoff_failure(
+    mock_db, mock_finalize, mock_transcoder_notify, mock_notify, mock_job,
+):
+    """NOTIFY_RIP should not fire 'rip complete' when handoff failed."""
+    mock_job.config.SKIP_TRANSCODE = False
+    mock_job.config.NOTIFY_RIP = True
+    mock_transcoder_notify.return_value = False
+
+    _post_rip_handoff(mock_job)
+
+    assert mock_job.status == JobState.FAILURE.value
+    mock_notify.assert_not_called()
+
+
+@patch("arm.ripper.arm_ripper.utils.notify")
+@patch("arm.ripper.arm_ripper.utils.transcoder_notify")
+@patch("arm.ripper.naming.finalize_output")
+@patch("arm.ripper.arm_ripper.db")
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": False})
+def test_notify_rip_fires_on_successful_handoff(
+    mock_db, mock_finalize, mock_transcoder_notify, mock_notify, mock_job,
+):
+    """NOTIFY_RIP should fire on successful handoff (TRANSCODE_WAITING)."""
+    mock_job.config.SKIP_TRANSCODE = False
+    mock_job.config.NOTIFY_RIP = True
+    mock_transcoder_notify.return_value = True
+
+    _post_rip_handoff(mock_job)
+
+    assert mock_job.status == JobState.TRANSCODE_WAITING.value
+    mock_notify.assert_called_once()
 
 
 @patch("arm.ripper.arm_ripper.utils.transcoder_notify")

--- a/test/test_post_rip_handoff.py
+++ b/test/test_post_rip_handoff.py
@@ -1,0 +1,120 @@
+"""Tests for arm.ripper.arm_ripper._post_rip_handoff.
+
+Covers the four post-rip outcomes:
+  A. SKIP_TRANSCODE=true + transcoder configured -> SUCCESS + finalize_output
+  B. SKIP_TRANSCODE=false + transcoder configured -> TRANSCODE_WAITING + webhook
+  C. No transcoder configured -> SUCCESS + finalize_output
+  D. Webhook send fails -> FAILURE
+
+These tests exercise the helper directly without patching it in isolation,
+catching the dual-writer bug in arm/ripper/main.py.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from arm.ripper.arm_ripper import _post_rip_handoff
+from arm.models.job import JobState
+
+
+@pytest.fixture
+def mock_job():
+    """Return a minimal Job double."""
+    job = MagicMock()
+    job.title = "Test Movie"
+    job.config = MagicMock()
+    job.config.SKIP_TRANSCODE = None  # caller sets per-test
+    job.config.NOTIFY_RIP = False
+    job.status = JobState.VIDEO_RIPPING.value
+    return job
+
+
+@patch("arm.ripper.arm_ripper.utils.transcoder_notify")
+@patch("arm.ripper.naming.finalize_output")
+@patch("arm.ripper.arm_ripper.db")
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": False})
+def test_skip_true_with_transcoder_configured_sets_success(
+    mock_db, mock_finalize, mock_notify, mock_job,
+):
+    """Outcome A: SKIP_TRANSCODE=true wins over transcoder being configured."""
+    mock_job.config.SKIP_TRANSCODE = True
+
+    _post_rip_handoff(mock_job)
+
+    mock_finalize.assert_called_once_with(mock_job)
+    assert mock_job.status == JobState.SUCCESS.value
+    mock_notify.assert_not_called()  # no webhook when skipping
+
+
+@patch("arm.ripper.arm_ripper.utils.transcoder_notify")
+@patch("arm.ripper.naming.finalize_output")
+@patch("arm.ripper.arm_ripper.db")
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": False})
+def test_skip_false_with_transcoder_configured_sets_waiting(
+    mock_db, mock_finalize, mock_notify, mock_job,
+):
+    """Outcome B: webhook fires AND status is TRANSCODE_WAITING.
+
+    This is the test that fails today - the current implementation
+    only fires the webhook but does not write TRANSCODE_WAITING.
+    """
+    mock_job.config.SKIP_TRANSCODE = False
+
+    _post_rip_handoff(mock_job)
+
+    mock_finalize.assert_not_called()
+    mock_notify.assert_called_once()  # webhook fired
+    assert mock_job.status == JobState.TRANSCODE_WAITING.value
+
+
+@patch("arm.ripper.arm_ripper.utils.transcoder_notify")
+@patch("arm.ripper.naming.finalize_output")
+@patch("arm.ripper.arm_ripper.db")
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "", "SKIP_TRANSCODE": False})
+def test_no_transcoder_configured_sets_success(
+    mock_db, mock_finalize, mock_notify, mock_job,
+):
+    """Outcome C: empty TRANSCODER_URL -> finalize locally, SUCCESS."""
+    mock_job.config.SKIP_TRANSCODE = False
+
+    _post_rip_handoff(mock_job)
+
+    mock_finalize.assert_called_once_with(mock_job)
+    assert mock_job.status == JobState.SUCCESS.value
+    mock_notify.assert_not_called()
+
+
+@patch("arm.ripper.arm_ripper.utils.transcoder_notify")
+@patch("arm.ripper.naming.finalize_output")
+@patch("arm.ripper.arm_ripper.db")
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": False})
+def test_webhook_failure_sets_failure_status(
+    mock_db, mock_finalize, mock_notify, mock_job,
+):
+    """Outcome D: webhook send raises -> job marked FAILURE, not WAITING.
+
+    A failed handoff should not look like a pending one.
+    """
+    mock_job.config.SKIP_TRANSCODE = False
+    mock_notify.side_effect = Exception("transcoder unreachable")
+
+    _post_rip_handoff(mock_job)
+
+    assert mock_job.status == JobState.FAILURE.value
+    mock_finalize.assert_not_called()
+
+
+@patch("arm.ripper.arm_ripper.utils.transcoder_notify")
+@patch("arm.ripper.naming.finalize_output")
+@patch("arm.ripper.arm_ripper.db")
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": True})
+def test_global_skip_used_when_per_job_is_none(
+    mock_db, mock_finalize, mock_notify, mock_job,
+):
+    """Fallback: per-job config.SKIP_TRANSCODE=None -> global wins."""
+    mock_job.config.SKIP_TRANSCODE = None
+
+    _post_rip_handoff(mock_job)
+
+    mock_finalize.assert_called_once_with(mock_job)
+    assert mock_job.status == JobState.SUCCESS.value

--- a/test/test_post_rip_handoff.py
+++ b/test/test_post_rip_handoff.py
@@ -35,7 +35,7 @@ def mock_job():
 @patch("arm.ripper.arm_ripper.utils.transcoder_notify")
 @patch("arm.ripper.naming.finalize_output")
 @patch("arm.ripper.arm_ripper.db")
-@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": False})
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "https://transcoder", "SKIP_TRANSCODE": False})
 def test_skip_true_with_transcoder_configured_sets_success(
     mock_db, mock_finalize, mock_notify, mock_job,
 ):
@@ -52,7 +52,7 @@ def test_skip_true_with_transcoder_configured_sets_success(
 @patch("arm.ripper.arm_ripper.utils.transcoder_notify")
 @patch("arm.ripper.naming.finalize_output")
 @patch("arm.ripper.arm_ripper.db")
-@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": False})
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "https://transcoder", "SKIP_TRANSCODE": False})
 def test_skip_false_with_transcoder_configured_sets_waiting(
     mock_db, mock_finalize, mock_notify, mock_job,
 ):
@@ -91,7 +91,7 @@ def test_no_transcoder_configured_sets_success(
 @patch("arm.ripper.arm_ripper.utils.transcoder_notify")
 @patch("arm.ripper.naming.finalize_output")
 @patch("arm.ripper.arm_ripper.db")
-@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": False})
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "https://transcoder", "SKIP_TRANSCODE": False})
 def test_transcoder_notify_returns_false_sets_failure(
     mock_db, mock_finalize, mock_notify, mock_job,
 ):
@@ -114,7 +114,7 @@ def test_transcoder_notify_returns_false_sets_failure(
 @patch("arm.ripper.arm_ripper.utils.transcoder_notify")
 @patch("arm.ripper.naming.finalize_output")
 @patch("arm.ripper.arm_ripper.db")
-@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": False})
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "https://transcoder", "SKIP_TRANSCODE": False})
 def test_notify_rip_skipped_on_handoff_failure(
     mock_db, mock_finalize, mock_transcoder_notify, mock_notify, mock_job,
 ):
@@ -133,7 +133,7 @@ def test_notify_rip_skipped_on_handoff_failure(
 @patch("arm.ripper.arm_ripper.utils.transcoder_notify")
 @patch("arm.ripper.naming.finalize_output")
 @patch("arm.ripper.arm_ripper.db")
-@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": False})
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "https://transcoder", "SKIP_TRANSCODE": False})
 def test_notify_rip_fires_on_successful_handoff(
     mock_db, mock_finalize, mock_transcoder_notify, mock_notify, mock_job,
 ):
@@ -151,7 +151,7 @@ def test_notify_rip_fires_on_successful_handoff(
 @patch("arm.ripper.arm_ripper.utils.transcoder_notify")
 @patch("arm.ripper.naming.finalize_output")
 @patch("arm.ripper.arm_ripper.db")
-@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "http://transcoder", "SKIP_TRANSCODE": True})
+@patch("arm.config.config.arm_config", {"TRANSCODER_URL": "https://transcoder", "SKIP_TRANSCODE": True})
 def test_global_skip_used_when_per_job_is_none(
     mock_db, mock_finalize, mock_notify, mock_job,
 ):


### PR DESCRIPTION
## Summary

- Fixes the SKIP_TRANSCODE stuck-job bug from spec item 1 (2026-04-21 preset system hardening).
- The \`__main__\` else-branch in \`arm/ripper/main.py:444-453\` silently reverted SKIP_TRANSCODE=true jobs from SUCCESS back to TRANSCODE_WAITING. The else-branch is now a documented no-op; \`_post_rip_handoff\` is the single writer of post-rip status.
- Handles all four post-rip outcomes in one place: SUCCESS (skip or no transcoder), TRANSCODE_WAITING (handoff succeeded), FAILURE (handoff failed).
- Secondary fix caught in code review: \`utils.transcoder_notify\` now returns a bool instead of swallowing transport failures silently - the previous try/except in the caller was dead code. \`job.errors\` no longer interpolates exception strings (credential-leak risk if \`TRANSCODER_URL\` carried basic auth).
- \`NOTIFY_RIP\` gated on \`job.status != FAILURE\` so failed handoffs no longer send \"rip complete\" notifications.

## Test plan

- [x] \`pytest test/test_post_rip_handoff.py\` - 7 new tests covering all four outcomes plus NOTIFY_RIP gating
- [x] \`pytest test/\` - 1920 passing, no regressions
- [ ] Manual: trigger a rip with SKIP_TRANSCODE=true and TRANSCODER_URL configured; confirm final status is SUCCESS
- [ ] Manual: simulate transcoder unreachable; confirm final status is FAILURE with \`job.errors\` set (no URL leak)
- [ ] Manual: successful handoff path; confirm TRANSCODE_WAITING and NOTIFY_RIP fires