### PR TITLE
fix: skip-and-finalize rejects TRANSCODE_ACTIVE state

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -970,17 +970,24 @@ def transcode_callback(job_id: int, body: dict):
 def skip_and_finalize(job_id: int):
     """Skip transcoding and finalize a job's output directly.
 
-    Only allowed when the job is in TRANSCODE_WAITING or TRANSCODE_ACTIVE state.
-    Moves ripped files to the final output path and marks the job as SUCCESS.
+    Only allowed when the job is in TRANSCODE_WAITING. Actively transcoding
+    jobs must be abandoned first - running finalize_output against files the
+    transcoder is still reading causes corrupt output.
     """
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
 
-    allowed = {JobState.TRANSCODE_WAITING.value, JobState.TRANSCODE_ACTIVE.value}
-    if job.status not in allowed:
+    if job.status != JobState.TRANSCODE_WAITING.value:
         return JSONResponse(
-            {"success": False, "error": f"Job is in '{job.status}' state, expected transcode_waiting or transcode_active"},
+            {
+                "success": False,
+                "error": (
+                    f"Job is in '{job.status}' state, expected transcode_waiting. "
+                    "Skip-and-finalize is only valid when the job is waiting for transcode. "
+                    "To stop an active transcode, abandon the job first."
+                ),
+            },
             status_code=409,
         )
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -4,6 +4,8 @@ import unittest.mock
 import pytest
 from fastapi.testclient import TestClient
 
+from arm.models.job import JobState
+
 
 @pytest.fixture
 def client(app_context):
@@ -194,20 +196,40 @@ class TestSkipAndFinalize:
         data = response.json()
         assert data["success"] is False
 
-    def test_skip_and_finalize_transcoding_active(self, client, sample_job, app_context):
-        """TRANSCODE_ACTIVE job should also finalize successfully."""
-        from arm.ripper.utils import database_updater
+    def test_skip_and_finalize_transcoding_active_rejected(self, client, sample_job, app_context):
+        """Skip-and-finalize MUST reject TRANSCODE_ACTIVE to avoid racing the live transcoder."""
         from arm.database import db
-        database_updater({"status": "transcoding"}, sample_job)
+        sample_job.status = JobState.TRANSCODE_ACTIVE.value
+        db.session.commit()
 
-        with unittest.mock.patch('arm.ripper.naming.finalize_output'):
-            response = client.post(f'/api/v1/jobs/{sample_job.job_id}/skip-and-finalize')
+        response = client.post(f'/api/v1/jobs/{sample_job.job_id}/skip-and-finalize')
 
-        assert response.status_code == 200
+        assert response.status_code == 409
         data = response.json()
-        assert data["success"] is True
-        db.session.refresh(sample_job)
-        assert sample_job.status == "success"
+        assert data['success'] is False
+        assert 'transcode_waiting' in data['error'].lower()
+        # Hint at abandon for the user's actual need
+        assert 'abandon' in data['error'].lower()
+        # Job status must not have changed
+        assert sample_job.status == JobState.TRANSCODE_ACTIVE.value
+
+    @pytest.mark.parametrize("state", [
+        JobState.VIDEO_RIPPING.value,
+        JobState.TRANSCODE_ACTIVE.value,
+        JobState.SUCCESS.value,
+        JobState.FAILURE.value,
+        JobState.MANUAL_WAIT_STARTED.value,
+    ])
+    def test_skip_and_finalize_rejects_non_waiting_states(self, client, sample_job, app_context, state):
+        """Only TRANSCODE_WAITING is allowed - everything else 409s."""
+        from arm.database import db
+        sample_job.status = state
+        db.session.commit()
+
+        response = client.post(f'/api/v1/jobs/{sample_job.job_id}/skip-and-finalize')
+
+        assert response.status_code == 409
+        assert sample_job.status == state  # unchanged
 
 
 class TestForceComplete:


### PR DESCRIPTION
## Summary

- Narrows `skip_and_finalize` allowlist to `TRANSCODE_WAITING` only. Previously accepted `TRANSCODE_ACTIVE`, which raced `finalize_output` against a live transcoder reading the same files (corrupt output possible).
- 409 response message points users at abandon for the actively-transcoding case.
- Companion UI change adds a confirmation dialog: see arm-ui PR.

Spec reference: item 2 of 2026-04-21-preset-system-hardening-design.md

## Test plan

- [x] `pytest test/test_api.py::TestSkipAndFinalize` - 9 passed
- [x] `pytest test/` - 1918 passed, no regressions
- [x] Parametrized rejection test covers VIDEO_RIPPING, TRANSCODE_ACTIVE, SUCCESS, FAILURE, MANUAL_WAIT_STARTED
- [ ] Manual: attempt skip-and-finalize on an actively transcoding job, confirm 409 with abandon hint