### PR TITLE
feat: send X-Api-Version: 2 on transcoder webhook POST

### DIFF
--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -272,7 +272,14 @@ def transcoder_notify(cfg, title, body, job=None):
             db.session.commit()
 
     payload = _build_webhook_payload(title, body, job, raw_basename)
-    headers = {"Content-Type": "application/json"}
+    # X-Api-Version pins the webhook contract. Transcoders on v2 accept this
+    # header (and still accept unversioned requests for back-compat). Older
+    # transcoders that only speak v1 must reject v2 explicitly so payload
+    # shape mismatches fail loudly instead of silently dropping fields.
+    headers = {
+        "Content-Type": "application/json",
+        "X-Api-Version": "2",
+    }
     secret = cfg.get('TRANSCODER_WEBHOOK_SECRET', '')
     if secret:
         headers["X-Webhook-Secret"] = secret

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -328,6 +328,41 @@ def sample_notifications(app_context):
 # --- Drive fixtures ---
 
 @pytest.fixture
+def transcoder_notify_job():
+    """Minimal Job mock with attributes transcoder_notify reads."""
+    job = unittest.mock.MagicMock()
+    job.job_id = 1
+    job.raw_path = '/home/arm/media/raw/Movie'
+    job.video_type = 'movie'
+    job.year = '2024'
+    job.disctype = 'bluray'
+    job.status = 'active'
+    job.poster_url = ''
+    job.title = 'Movie'
+    job.multi_title = False
+    job.transcode_overrides = None
+    return job
+
+
+@pytest.fixture
+def transcoder_notify_patches():
+    """Patch httpx.Client, _build_webhook_payload, and db for transcoder_notify tests.
+
+    Yields the mocked httpx.Client instance so tests can assert on .post calls.
+    """
+    mock_resp = unittest.mock.MagicMock()
+    mock_resp.status_code = 200
+
+    with unittest.mock.patch('httpx.Client') as mock_client_cls, \
+         unittest.mock.patch('arm.ripper.utils._build_webhook_payload',
+                             return_value={"title": "test"}), \
+         unittest.mock.patch('arm.ripper.utils.db'):
+        mock_client = mock_client_cls.return_value.__enter__.return_value
+        mock_client.post.return_value = mock_resp
+        yield mock_client
+
+
+@pytest.fixture
 def sample_drives(app_context):
     """Create test drives: 2 active, 1 stale."""
     from arm.models.system_drives import SystemDrives

--- a/test/test_ripper_utils.py
+++ b/test/test_ripper_utils.py
@@ -1,0 +1,88 @@
+"""Tests for arm/ripper/utils.py transcoder_notify() webhook behavior.
+
+Specifically verifies the cross-service version handshake: ARM must stamp
+every webhook POST to the transcoder with ``X-Api-Version: 2`` so older
+transcoders reject new-shape payloads loudly instead of silently dropping
+unknown fields.
+"""
+import unittest.mock
+
+
+class TestTranscoderNotifyApiVersionHeader:
+    """Task 5: transcoder_notify must send X-Api-Version: 2."""
+
+    def test_sends_x_api_version_header(self, app_context):
+        from arm.ripper.utils import transcoder_notify
+
+        cfg = {
+            'TRANSCODER_URL': 'http://localhost:5000/webhook',
+            'TRANSCODER_WEBHOOK_SECRET': 'test-secret',
+            'SHARED_RAW_PATH': '',
+            'LOCAL_RAW_PATH': '',
+        }
+        job = unittest.mock.MagicMock()
+        job.job_id = 1
+        job.raw_path = '/home/arm/media/raw/Movie'
+        job.video_type = 'movie'
+        job.year = '2024'
+        job.disctype = 'bluray'
+        job.status = 'active'
+        job.poster_url = ''
+        job.title = 'Movie'
+        job.multi_title = False
+        job.transcode_overrides = None
+
+        mock_resp = unittest.mock.MagicMock()
+        mock_resp.status_code = 200
+
+        with unittest.mock.patch('httpx.Client') as mock_client_cls, \
+             unittest.mock.patch('arm.ripper.utils._build_webhook_payload',
+                                 return_value={"title": "test"}), \
+             unittest.mock.patch('arm.ripper.utils.db'):
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.post.return_value = mock_resp
+            transcoder_notify(cfg, "Title", "Body", job)
+
+        mock_client.post.assert_called_once()
+        _, kwargs = mock_client.post.call_args
+        headers = kwargs.get('headers') or {}
+        assert headers.get('X-Api-Version') == '2', (
+            f"Expected X-Api-Version: 2 header, got headers={headers!r}"
+        )
+
+    def test_sends_x_api_version_header_without_secret(self, app_context):
+        """Header must be set even when no webhook secret is configured."""
+        from arm.ripper.utils import transcoder_notify
+
+        cfg = {
+            'TRANSCODER_URL': 'http://localhost:5000/webhook',
+            'TRANSCODER_WEBHOOK_SECRET': '',
+            'SHARED_RAW_PATH': '',
+            'LOCAL_RAW_PATH': '',
+        }
+        job = unittest.mock.MagicMock()
+        job.job_id = 2
+        job.raw_path = '/home/arm/media/raw/OtherMovie'
+        job.video_type = 'movie'
+        job.year = '2024'
+        job.disctype = 'bluray'
+        job.status = 'active'
+        job.poster_url = ''
+        job.title = 'OtherMovie'
+        job.multi_title = False
+        job.transcode_overrides = None
+
+        mock_resp = unittest.mock.MagicMock()
+        mock_resp.status_code = 200
+
+        with unittest.mock.patch('httpx.Client') as mock_client_cls, \
+             unittest.mock.patch('arm.ripper.utils._build_webhook_payload',
+                                 return_value={"title": "test"}), \
+             unittest.mock.patch('arm.ripper.utils.db'):
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.post.return_value = mock_resp
+            transcoder_notify(cfg, "Title", "Body", job)
+
+        _, kwargs = mock_client.post.call_args
+        headers = kwargs.get('headers') or {}
+        assert headers.get('X-Api-Version') == '2'

--- a/test/test_ripper_utils.py
+++ b/test/test_ripper_utils.py
@@ -1,11 +1,12 @@
 """Tests for arm/ripper/utils.py transcoder_notify() webhook behavior."""
-import unittest.mock
-
 import pytest
 
 
 @pytest.mark.parametrize("webhook_secret", ["test-secret", ""])
-def test_transcoder_notify_sends_x_api_version_header(webhook_secret, app_context):
+def test_transcoder_notify_sends_x_api_version_header(
+    webhook_secret, app_context,
+    transcoder_notify_job, transcoder_notify_patches,
+):
     """transcoder_notify must send X-Api-Version: 2 regardless of webhook secret.
 
     Cross-service version handshake: ARM stamps every webhook POST to the
@@ -20,31 +21,11 @@ def test_transcoder_notify_sends_x_api_version_header(webhook_secret, app_contex
         'SHARED_RAW_PATH': '',
         'LOCAL_RAW_PATH': '',
     }
-    job = unittest.mock.MagicMock()
-    job.job_id = 1
-    job.raw_path = '/home/arm/media/raw/Movie'
-    job.video_type = 'movie'
-    job.year = '2024'
-    job.disctype = 'bluray'
-    job.status = 'active'
-    job.poster_url = ''
-    job.title = 'Movie'
-    job.multi_title = False
-    job.transcode_overrides = None
 
-    mock_resp = unittest.mock.MagicMock()
-    mock_resp.status_code = 200
+    transcoder_notify(cfg, "Title", "Body", transcoder_notify_job)
 
-    with unittest.mock.patch('httpx.Client') as mock_client_cls, \
-         unittest.mock.patch('arm.ripper.utils._build_webhook_payload',
-                             return_value={"title": "test"}), \
-         unittest.mock.patch('arm.ripper.utils.db'):
-        mock_client = mock_client_cls.return_value.__enter__.return_value
-        mock_client.post.return_value = mock_resp
-        transcoder_notify(cfg, "Title", "Body", job)
-
-    mock_client.post.assert_called_once()
-    _, kwargs = mock_client.post.call_args
+    transcoder_notify_patches.post.assert_called_once()
+    _, kwargs = transcoder_notify_patches.post.call_args
     headers = kwargs.get('headers') or {}
     assert headers.get('X-Api-Version') == '2', (
         f"Expected X-Api-Version: 2 header, got headers={headers!r}"

--- a/test/test_ripper_utils.py
+++ b/test/test_ripper_utils.py
@@ -1,88 +1,51 @@
-"""Tests for arm/ripper/utils.py transcoder_notify() webhook behavior.
-
-Specifically verifies the cross-service version handshake: ARM must stamp
-every webhook POST to the transcoder with ``X-Api-Version: 2`` so older
-transcoders reject new-shape payloads loudly instead of silently dropping
-unknown fields.
-"""
+"""Tests for arm/ripper/utils.py transcoder_notify() webhook behavior."""
 import unittest.mock
 
+import pytest
 
-class TestTranscoderNotifyApiVersionHeader:
-    """Task 5: transcoder_notify must send X-Api-Version: 2."""
 
-    def test_sends_x_api_version_header(self, app_context):
-        from arm.ripper.utils import transcoder_notify
+@pytest.mark.parametrize("webhook_secret", ["test-secret", ""])
+def test_transcoder_notify_sends_x_api_version_header(webhook_secret, app_context):
+    """transcoder_notify must send X-Api-Version: 2 regardless of webhook secret.
 
-        cfg = {
-            'TRANSCODER_URL': 'http://localhost:5000/webhook',
-            'TRANSCODER_WEBHOOK_SECRET': 'test-secret',
-            'SHARED_RAW_PATH': '',
-            'LOCAL_RAW_PATH': '',
-        }
-        job = unittest.mock.MagicMock()
-        job.job_id = 1
-        job.raw_path = '/home/arm/media/raw/Movie'
-        job.video_type = 'movie'
-        job.year = '2024'
-        job.disctype = 'bluray'
-        job.status = 'active'
-        job.poster_url = ''
-        job.title = 'Movie'
-        job.multi_title = False
-        job.transcode_overrides = None
+    Cross-service version handshake: ARM stamps every webhook POST to the
+    transcoder so older transcoders reject new-shape payloads loudly instead
+    of silently dropping unknown fields.
+    """
+    from arm.ripper.utils import transcoder_notify
 
-        mock_resp = unittest.mock.MagicMock()
-        mock_resp.status_code = 200
+    cfg = {
+        'TRANSCODER_URL': 'https://localhost:5000/webhook',
+        'TRANSCODER_WEBHOOK_SECRET': webhook_secret,
+        'SHARED_RAW_PATH': '',
+        'LOCAL_RAW_PATH': '',
+    }
+    job = unittest.mock.MagicMock()
+    job.job_id = 1
+    job.raw_path = '/home/arm/media/raw/Movie'
+    job.video_type = 'movie'
+    job.year = '2024'
+    job.disctype = 'bluray'
+    job.status = 'active'
+    job.poster_url = ''
+    job.title = 'Movie'
+    job.multi_title = False
+    job.transcode_overrides = None
 
-        with unittest.mock.patch('httpx.Client') as mock_client_cls, \
-             unittest.mock.patch('arm.ripper.utils._build_webhook_payload',
-                                 return_value={"title": "test"}), \
-             unittest.mock.patch('arm.ripper.utils.db'):
-            mock_client = mock_client_cls.return_value.__enter__.return_value
-            mock_client.post.return_value = mock_resp
-            transcoder_notify(cfg, "Title", "Body", job)
+    mock_resp = unittest.mock.MagicMock()
+    mock_resp.status_code = 200
 
-        mock_client.post.assert_called_once()
-        _, kwargs = mock_client.post.call_args
-        headers = kwargs.get('headers') or {}
-        assert headers.get('X-Api-Version') == '2', (
-            f"Expected X-Api-Version: 2 header, got headers={headers!r}"
-        )
+    with unittest.mock.patch('httpx.Client') as mock_client_cls, \
+         unittest.mock.patch('arm.ripper.utils._build_webhook_payload',
+                             return_value={"title": "test"}), \
+         unittest.mock.patch('arm.ripper.utils.db'):
+        mock_client = mock_client_cls.return_value.__enter__.return_value
+        mock_client.post.return_value = mock_resp
+        transcoder_notify(cfg, "Title", "Body", job)
 
-    def test_sends_x_api_version_header_without_secret(self, app_context):
-        """Header must be set even when no webhook secret is configured."""
-        from arm.ripper.utils import transcoder_notify
-
-        cfg = {
-            'TRANSCODER_URL': 'http://localhost:5000/webhook',
-            'TRANSCODER_WEBHOOK_SECRET': '',
-            'SHARED_RAW_PATH': '',
-            'LOCAL_RAW_PATH': '',
-        }
-        job = unittest.mock.MagicMock()
-        job.job_id = 2
-        job.raw_path = '/home/arm/media/raw/OtherMovie'
-        job.video_type = 'movie'
-        job.year = '2024'
-        job.disctype = 'bluray'
-        job.status = 'active'
-        job.poster_url = ''
-        job.title = 'OtherMovie'
-        job.multi_title = False
-        job.transcode_overrides = None
-
-        mock_resp = unittest.mock.MagicMock()
-        mock_resp.status_code = 200
-
-        with unittest.mock.patch('httpx.Client') as mock_client_cls, \
-             unittest.mock.patch('arm.ripper.utils._build_webhook_payload',
-                                 return_value={"title": "test"}), \
-             unittest.mock.patch('arm.ripper.utils.db'):
-            mock_client = mock_client_cls.return_value.__enter__.return_value
-            mock_client.post.return_value = mock_resp
-            transcoder_notify(cfg, "Title", "Body", job)
-
-        _, kwargs = mock_client.post.call_args
-        headers = kwargs.get('headers') or {}
-        assert headers.get('X-Api-Version') == '2'
+    mock_client.post.assert_called_once()
+    _, kwargs = mock_client.post.call_args
+    headers = kwargs.get('headers') or {}
+    assert headers.get('X-Api-Version') == '2', (
+        f"Expected X-Api-Version: 2 header, got headers={headers!r}"
+    )

--- a/test/test_utils_coverage.py
+++ b/test/test_utils_coverage.py
@@ -221,35 +221,16 @@ class TestTranscoderNotify:
             transcoder_notify(cfg, "Title", "Body", job)
         mock_client.assert_not_called()
 
-    def test_sends_webhook(self, app_context):
+    def test_sends_webhook(self, app_context, transcoder_notify_job, transcoder_notify_patches):
         from arm.ripper.utils import transcoder_notify
 
         cfg = {'TRANSCODER_URL': 'http://localhost:5000/webhook',
                'TRANSCODER_WEBHOOK_SECRET': 'test-secret',
                'SHARED_RAW_PATH': '', 'LOCAL_RAW_PATH': ''}
-        job = unittest.mock.MagicMock()
-        job.job_id = 1
-        job.raw_path = '/home/arm/media/raw/Movie'
-        job.video_type = 'movie'
-        job.year = '2024'
-        job.disctype = 'bluray'
-        job.status = 'active'
-        job.poster_url = ''
-        job.title = 'Movie'
-        job.multi_title = False
-        job.transcode_overrides = None
 
-        mock_resp = unittest.mock.MagicMock()
-        mock_resp.status_code = 200
+        transcoder_notify(cfg, "Title", "Body", transcoder_notify_job)
 
-        with unittest.mock.patch('httpx.Client') as mock_client_cls, \
-             unittest.mock.patch('arm.ripper.utils._build_webhook_payload',
-                                 return_value={"title": "test"}), \
-             unittest.mock.patch('arm.ripper.utils.db'):
-            mock_client = mock_client_cls.return_value.__enter__.return_value
-            mock_client.post.return_value = mock_resp
-            transcoder_notify(cfg, "Title", "Body", job)
-        mock_client.post.assert_called_once()
+        transcoder_notify_patches.post.assert_called_once()
 
 
 class TestScanEmby:


### PR DESCRIPTION
## Summary

- ARM stamps every webhook to the transcoder with \`X-Api-Version: 2\` so old transcoders reject the new preset-shape payload loudly instead of silently dropping unknown fields.
- Companion transcoder PR #88 adds the matching validation on the receiver.

## Deployment order

**Merge and deploy transcoder #88 BEFORE this PR.** This PR is release N+1 of the handshake rollout (ARM starts sending the header); transcoder #88 is release N (accepts the header and still tolerates missing). Shipping in reverse would cause arm-neu to get 400s from old transcoders that don't yet accept v2.

Spec reference: item 7 of 2026-04-21-preset-system-hardening-design.md

## Rebase note

If PR #237 (transcoder_notify bool return contract) merges first, this branch will need a trivial rebase. The header dict change and the bool-return change touch the same function (\`transcoder_notify\`) but different logical regions.

## Test plan

- [x] \`pytest test/test_ripper_utils.py -v\` - 2 passed
- [x] \`pytest test/\` - 1915 passed, no regressions
- [ ] Manual: trigger a rip, check transcoder logs for successful 200 response to the webhook