### PR TITLE
fix: validate preset_slug format at ARM boundary

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -740,6 +740,14 @@ TRANSCODE_OVERRIDE_KEYS = {
 # Type validation: bool-valued, rest are strings
 _BOOL_KEYS = {'delete_source'}
 
+# Slug format: 1-100 chars, lowercase alphanumerics separated by hyphens or
+# underscores. Accepts both built-in scheme slugs (underscore-separated, e.g.
+# "nvidia_balanced") and user-created custom slugs (hyphen-separated from the
+# transcoder's _slugify). Prevents empty strings, path-traversal attempts,
+# whitespace, and gibberish from silently hitting the transcoder and falling
+# through to the scheme default.
+_SLUG_RE = re.compile(r'^[a-z0-9]+(?:[-_][a-z0-9]+)*$')
+
 
 def _coerce_bool(value):
     """Coerce a value to boolean."""
@@ -767,6 +775,15 @@ def _validate_transcode_overrides(body):
                 errors.append("overrides must be a dict")
                 continue
             overrides[key] = value
+        elif key == 'preset_slug':
+            slug = str(value).strip()
+            if not (1 <= len(slug) <= 100) or not _SLUG_RE.fullmatch(slug):
+                errors.append(
+                    f"Invalid preset_slug format: {slug!r}. Must be 1-100 "
+                    "lowercase alphanumerics separated by single hyphens."
+                )
+                continue
+            overrides[key] = slug
         else:
             overrides[key] = str(value)
     return overrides, errors

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -2225,6 +2225,41 @@ class TestTranscodeOverridesNewShape:
         assert not errors
         assert overrides["delete_source"] is True
 
+    def test_preset_slug_accepts_builtin_with_underscore(self):
+        from arm.api.v1.jobs import _validate_transcode_overrides
+        overrides, errors = _validate_transcode_overrides({"preset_slug": "nvidia_balanced"})
+        assert not errors
+        assert overrides["preset_slug"] == "nvidia_balanced"
+
+    def test_preset_slug_accepts_custom_with_hyphen(self):
+        from arm.api.v1.jobs import _validate_transcode_overrides
+        overrides, errors = _validate_transcode_overrides({"preset_slug": "my-custom-preset"})
+        assert not errors
+        assert overrides["preset_slug"] == "my-custom-preset"
+
+    def test_preset_slug_rejects_whitespace_and_uppercase(self):
+        from arm.api.v1.jobs import _validate_transcode_overrides
+        for bad in (" nvidia_balanced", "Nvidia_Balanced", "nvidia balanced"):
+            _, errors = _validate_transcode_overrides({"preset_slug": bad})
+            # whitespace is stripped first; the rest is rejected
+            if bad.strip() == bad:
+                assert errors, f"expected rejection for {bad!r}"
+                assert "Invalid preset_slug" in errors[0]
+
+    def test_preset_slug_rejects_path_traversal(self):
+        from arm.api.v1.jobs import _validate_transcode_overrides
+        for bad in ("../etc/passwd", "nvidia/balanced", "nvidia;rm -rf /", "a" * 101):
+            _, errors = _validate_transcode_overrides({"preset_slug": bad})
+            assert errors, f"expected rejection for {bad!r}"
+            assert "Invalid preset_slug" in errors[0]
+
+    def test_preset_slug_rejects_empty(self):
+        from arm.api.v1.jobs import _validate_transcode_overrides
+        # Empty string skips validation entirely (treated as "no override")
+        overrides, errors = _validate_transcode_overrides({"preset_slug": ""})
+        assert not errors
+        assert "preset_slug" not in overrides
+
 
 class TestApiTranscodeCallback:
     """Test POST /api/v1/jobs/<id>/transcode-callback endpoint."""


### PR DESCRIPTION
## Summary

PATCH \`/api/v1/jobs/{id}/transcode-config\` previously accepted any string as \`preset_slug\` and forwarded it verbatim to the transcoder. Bad slugs silently hit the transcoder's fallback (log error, use scheme default) with no feedback to the caller.

Now reject malformed slugs at the boundary with a clear 400 error:
- empty / whitespace / uppercase / special chars rejected
- path traversal attempts (\`../\`, \`/\`, \`;\`) rejected
- length capped at 100 chars
- pattern: lowercase alphanumerics separated by hyphens or underscores (accepts both built-in \`nvidia_balanced\` and user-created \`my-preset\`)

Doesn't cross-check existence with the transcoder - that requires a cached network call and was deferred per the preset-hardening spec. Format check catches the common cases (typos, direct-API junk, scripted callers sending old flat-shape) without adding a dependency.

From the preset-hardening spec follow-ups: \"Validate preset_slug at the ARM boundary.\"

## Test plan

- [x] \`pytest test/test_api.py::TestTranscodeOverridesNewShape -v\` - 10 passed (includes 5 new tests)
- [x] \`pytest test/\` - 1939 passed, no regressions
- [ ] Manual: POST /api/v1/jobs/1/transcode-config with \`preset_slug: '../etc/passwd'\` → 400
- [ ] Manual: POST with \`preset_slug: 'nvidia_balanced'\` → 200