### PR TITLE
feat: ripper-only deployment (ARM+UI, no transcoder)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,13 @@ UI_VERSION=latest
 #   latest-amd    — AMD VAAPI (requires /dev/dri access, see README)
 TRANSCODER_VERSION=latest
 
+# --- Feature Flags ---
+# Set TRANSCODER_ENABLED=false to run ripper-only (no transcoder container).
+# This all-in-one compose expects the transcoder to be present; for a
+# dedicated ripper-only deployment use docker-compose.ripper-only.yml +
+# .env.ripper-only.example instead.
+# TRANSCODER_ENABLED=true
+
 # --- ARM Ripper ---
 ARM_UID=1000
 ARM_GID=1000

--- a/.env.ripper-only.example
+++ b/.env.ripper-only.example
@@ -1,0 +1,47 @@
+# Ripper-only deployment: ARM + UI on a single machine, no transcoder.
+# Copy to .env and adjust values before running:
+#   docker compose -f docker-compose.ripper-only.yml up -d --build
+#
+# Note: TRANSCODER_ENABLED is hardcoded to false in the compose file.
+# To re-enable the transcoder, switch to docker-compose.yml instead.
+
+# --- Version Pinning ---
+# Pin to a specific release (e.g. 16.1.0) or use "latest"
+ARM_VERSION=latest
+UI_VERSION=latest
+
+# --- ARM Ripper ---
+ARM_UID=1000
+ARM_GID=1000
+TZ=America/New_York
+
+# Host paths (must exist and be owned by ARM_UID:ARM_GID)
+ARM_MUSIC_PATH=/home/arm/music
+ARM_LOGS_PATH=/home/arm/logs
+ARM_MEDIA_PATH=/home/arm/media
+ARM_CONFIG_PATH=/etc/arm/config
+ARM_MAKEMKV_PATH=/home/arm/.MakeMKV
+
+# Folder import ingress - host directory containing BDMV/VIDEO_TS folders.
+# Mounted read-only into the container. Leave default to use ARM_MEDIA_PATH/ingress.
+# ARM_INGRESS_PATH=/path/to/disc/backups
+
+# Ports
+ARM_PORT=8080
+UI_PORT=8888
+
+# CPU pinning (leave ARM cores free for ripping)
+ARM_CPUSET=2,3,4,5,6,7
+
+# Download FindVUK community keydb for Blu-ray decryption (true/false)
+# Set to false to disable the ~22 MB background download at container startup.
+ARM_COMMUNITY_KEYDB=true
+
+# Optical drives: the compose file mounts /dev:/dev so ALL drives are
+# visible automatically. No per-device configuration is needed.
+
+# Local SSD scratch for ripping (optional - rip to fast local disk, then move to shared storage)
+# Uncomment and point to a local SSD directory for rip performance.
+# ARM_SCRATCH_PATH=/mnt/ssd/arm-scratch
+# ARM_LOCAL_RAW_PATH=/mnt/ssd/arm-scratch/raw
+# ARM_SHARED_RAW_PATH=/home/arm/media/raw

--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ docker compose -f docker-compose.remote-transcoder.yml up -d
 
 See the [transcoder README](https://github.com/uprightbass360/automatic-ripping-machine-transcoder) for setting up the remote side.
 
+### Ripper-only
+
+For ARM + UI on a single machine with no transcoder - the ripper writes final named files directly (no second-pass re-encode). Use this when the source quality is acceptable as-is or you don't need GPU transcoding at all:
+
+```bash
+cp .env.ripper-only.example .env
+docker compose -f docker-compose.ripper-only.yml up -d
+```
+
+`TRANSCODER_ENABLED=false` is baked into the compose file: the UI hides all transcoder surfaces (nav link, settings tab, job-detail transcode controls, stats panels, log viewer) and the ripper falls into the `finalize_output` path. See [deploy/DEPLOY.md](deploy/DEPLOY.md#ripper-only-deployment) for details.
+
 ### Development
 
 Clone all three repos as siblings and start the dev stack:

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -196,3 +196,33 @@ curl -X POST http://<GPU_HOST>:5000/webhook/arm \
 **Notification script fails:**
 - Check ARM logs: `docker logs arm-rippers 2>&1 | grep -i notify`
 - Test script manually: `docker exec arm-rippers /etc/arm/config/notify_transcoder.sh "test" "test body"`
+
+## Ripper-only deployment
+
+Run ARM + UI on a single machine with no transcoder. ARM rips discs and
+writes final named files directly (no second-pass re-encode). Use this
+when the source quality is acceptable as-is or when the transcoder
+service is unavailable.
+
+**Start:**
+
+```bash
+cp .env.ripper-only.example .env
+# edit .env to set your paths and UID/GID
+docker compose -f docker-compose.ripper-only.yml up -d --build
+```
+
+**What is hidden from the UI:**
+
+- Transcoder route (`/transcoder`)
+- Transcoder settings tab
+- Transcoder log viewer
+- Transcode overrides on job detail
+- Retranscode and Skip-and-Finalize buttons
+- Transcoder and GPU panels in the stats bars
+
+**Switching modes:**
+
+To move between ripper-only and all-in-one, stop the stack, switch
+compose files, and redeploy. The ARM database is preserved across
+switches (shared `arm-db` volume).

--- a/docker-compose.ripper-only.yml
+++ b/docker-compose.ripper-only.yml
@@ -1,0 +1,81 @@
+# Ripper-only: ARM + UI on a single machine, no transcoder.
+# ARM writes final named files directly via the v15.0.0 finalize_output path.
+# Copy .env.ripper-only.example to .env and adjust values before starting.
+#
+# Start: docker compose -f docker-compose.ripper-only.yml up -d --build
+
+services:
+  # Fix ownership on the shared DB volume before ARM starts
+  arm-db-init:
+    image: alpine
+    container_name: arm-db-init
+    volumes:
+      - arm-db:/data/db
+    command: chown -R ${ARM_UID:-1000}:${ARM_GID:-1000} /data/db
+    restart: "no"
+
+  # ARM ripper - creates the database on first startup.
+  # No transcoder: ARM_TRANSCODER_ENABLED=false forces empty TRANSCODER_URL
+  # in arm.yaml and the ripper falls into the finalize_output path.
+  arm-rippers:
+    image: uprightbass360/automatic-ripping-machine:${ARM_VERSION:-latest}
+    container_name: arm-rippers
+    restart: always
+    privileged: true
+    ports:
+      - "${ARM_PORT:-8080}:8080"
+    environment:
+      - ARM_UID=${ARM_UID:-1000}
+      - ARM_GID=${ARM_GID:-1000}
+      - TZ=${TZ:-Etc/UTC}
+      - ARM_COMMUNITY_KEYDB=${ARM_COMMUNITY_KEYDB:-true}
+      - ARM_TRANSCODER_ENABLED=false
+      - ARM_LOCAL_RAW_PATH=${ARM_LOCAL_RAW_PATH:-}
+      - ARM_SHARED_RAW_PATH=${ARM_SHARED_RAW_PATH:-}
+      - ARM_MEDIA_PATH=${ARM_MEDIA_PATH}
+      - ARM_CONFIG_PATH=${ARM_CONFIG_PATH}
+      - ARM_LOGS_PATH=${ARM_LOGS_PATH}
+      - ARM_MUSIC_PATH=${ARM_MUSIC_PATH}
+    volumes:
+      - ${ARM_MUSIC_PATH}:/home/arm/music
+      - ${ARM_LOGS_PATH}:/home/arm/logs
+      - ${ARM_MEDIA_PATH}:/home/arm/media
+      - ${ARM_SCRATCH_PATH:-/home/arm/media}:/home/arm/scratch
+      - ${ARM_INGRESS_PATH:-/home/arm/media/ingress}:/home/arm/media/ingress:ro
+      - ${ARM_CONFIG_PATH}:/etc/arm/config
+      - arm-db:/home/arm/db
+      - ${ARM_MAKEMKV_PATH:-makemkv-settings}:/home/arm/.MakeMKV
+      # Live /dev mount ensures USB optical drives remain visible after
+      # hot-plug, disconnect/reconnect, or device re-enumeration.
+      - /dev:/dev
+    cpuset: ${ARM_CPUSET:-2,3,4,5,6,7}
+    depends_on:
+      arm-db-init:
+        condition: service_completed_successfully
+
+  # Replacement dashboard (SvelteKit + FastAPI)
+  arm-ui:
+    image: uprightbass360/arm-ui:${UI_VERSION:-latest}
+    container_name: arm-ui
+    restart: unless-stopped
+    ports:
+      - "${UI_PORT:-8888}:8888"
+    environment:
+      - ARM_UI_ARM_DB_PATH=/data/db/arm.db
+      - ARM_UI_ARM_LOG_PATH=/data/logs
+      - ARM_UI_ARM_CONFIG_PATH=/data/arm-config/arm.yaml
+      - ARM_UI_ARM_URL=http://arm-rippers:8080
+      - ARM_UI_TRANSCODER_ENABLED=false
+      - ARM_UI_ARM_THEMES_PATH=/data/config/themes
+    volumes:
+      - arm-db:/data/db:rw
+      - ${ARM_LOGS_PATH}:/data/logs:ro
+      - ${ARM_CONFIG_PATH}:/data/arm-config:rw
+      - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:rw
+    depends_on:
+      arm-rippers:
+        condition: service_healthy
+
+volumes:
+  arm-db:
+  makemkv-settings:

--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -165,8 +165,24 @@ apply_yaml_override() {
   fi
   return 0
 }
-apply_yaml_override TRANSCODER_URL ARM_TRANSCODER_URL
-apply_yaml_override TRANSCODER_WEBHOOK_SECRET ARM_TRANSCODER_WEBHOOK_SECRET
+force_yaml_empty() {
+  local key="$1"
+  if grep -q "^${key}:" "$ARM_YAML"; then
+    sed -i "s|^${key}:.*|${key}: \"\"|" "$ARM_YAML"
+    echo "arm.yaml: ${key} force-cleared (transcoder disabled)"
+  fi
+}
+
+if [[ "${ARM_TRANSCODER_ENABLED:-true}" == "false" ]]; then
+  # Ripper-only mode: force transcoder-related yaml keys to empty so that
+  # the ripper falls into the finalize_output path regardless of any
+  # leftover values from previous deployments.
+  force_yaml_empty TRANSCODER_URL
+  force_yaml_empty TRANSCODER_WEBHOOK_SECRET
+else
+  apply_yaml_override TRANSCODER_URL ARM_TRANSCODER_URL
+  apply_yaml_override TRANSCODER_WEBHOOK_SECRET ARM_TRANSCODER_WEBHOOK_SECRET
+fi
 apply_yaml_override LOCAL_RAW_PATH ARM_LOCAL_RAW_PATH
 apply_yaml_override SHARED_RAW_PATH ARM_SHARED_RAW_PATH
 # sed -i may reset file ownership to root — restore arm ownership

--- a/test/test_arm_yaml_renderer_transcoder_disabled.py
+++ b/test/test_arm_yaml_renderer_transcoder_disabled.py
@@ -1,0 +1,106 @@
+"""Renderer test: when ARM_TRANSCODER_ENABLED=false, TRANSCODER_URL must be empty.
+
+The arm.yaml renderer lives in scripts/docker/runit/arm_user_files_setup.sh and
+uses sed to patch a freshly-copied arm.yaml. This test extracts just the
+relevant block into a standalone shell snippet and runs it against a fixture
+yaml to verify the behavior without booting a container.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+
+
+FIXTURE_YAML = textwrap.dedent(
+    """\
+    SKIP_TRANSCODE: false
+    TRANSCODER_URL: "http://arm-transcoder:5000/webhook/arm"
+    TRANSCODER_WEBHOOK_SECRET: "some-secret"
+    LOCAL_RAW_PATH: ""
+    SHARED_RAW_PATH: ""
+    """
+)
+
+
+RENDER_SNIPPET = textwrap.dedent(
+    """\
+    ARM_YAML="$1"
+    apply_yaml_override() {
+      local key="$1" envvar="$2"
+      if [[ -n "${!envvar:-}" ]] && grep -q "^${key}:" "$ARM_YAML"; then
+        sed -i "s|^${key}:.*|${key}: \\"${!envvar}\\"|" "$ARM_YAML"
+      fi
+      return 0
+    }
+    force_yaml_empty() {
+      local key="$1"
+      if grep -q "^${key}:" "$ARM_YAML"; then
+        sed -i "s|^${key}:.*|${key}: \\"\\"|" "$ARM_YAML"
+      fi
+    }
+    if [[ "${ARM_TRANSCODER_ENABLED:-true}" == "false" ]]; then
+      force_yaml_empty TRANSCODER_URL
+      force_yaml_empty TRANSCODER_WEBHOOK_SECRET
+    else
+      apply_yaml_override TRANSCODER_URL ARM_TRANSCODER_URL
+      apply_yaml_override TRANSCODER_WEBHOOK_SECRET ARM_TRANSCODER_WEBHOOK_SECRET
+    fi
+    """
+)
+
+
+def _render(env: dict[str, str]) -> str:
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        f.write(FIXTURE_YAML)
+        path = f.name
+    try:
+        merged_env = dict(os.environ)
+        merged_env.update(env)
+        subprocess.run(
+            ["bash", "-c", RENDER_SNIPPET, "bash", path],
+            check=True,
+            env=merged_env,
+        )
+        with open(path) as f:
+            return f.read()
+    finally:
+        os.unlink(path)
+
+
+def _get_value(rendered: str, key: str) -> str:
+    for line in rendered.splitlines():
+        if line.startswith(f"{key}:"):
+            return line.split(":", 1)[1].strip().strip('"')
+    raise KeyError(key)
+
+
+def test_transcoder_url_empty_when_disabled():
+    rendered = _render({
+        "ARM_TRANSCODER_ENABLED": "false",
+        "ARM_TRANSCODER_URL": "http://should-be-ignored:5000/webhook/arm",
+        "ARM_TRANSCODER_WEBHOOK_SECRET": "should-be-wiped",
+    })
+    assert _get_value(rendered, "TRANSCODER_URL") == ""
+    assert _get_value(rendered, "TRANSCODER_WEBHOOK_SECRET") == ""
+
+
+def test_transcoder_url_preserved_when_enabled():
+    rendered = _render({
+        "ARM_TRANSCODER_ENABLED": "true",
+        "ARM_TRANSCODER_URL": "http://arm-transcoder:5000/webhook/arm",
+        "ARM_TRANSCODER_WEBHOOK_SECRET": "secret",
+    })
+    assert _get_value(rendered, "TRANSCODER_URL") == "http://arm-transcoder:5000/webhook/arm"
+    assert _get_value(rendered, "TRANSCODER_WEBHOOK_SECRET") == "secret"
+
+
+def test_transcoder_url_preserved_when_flag_unset():
+    rendered = _render({
+        "ARM_TRANSCODER_URL": "http://arm-transcoder:5000/webhook/arm",
+        "ARM_TRANSCODER_WEBHOOK_SECRET": "secret",
+    })
+    assert _get_value(rendered, "TRANSCODER_URL") == "http://arm-transcoder:5000/webhook/arm"
+    assert _get_value(rendered, "TRANSCODER_WEBHOOK_SECRET") == "secret"

--- a/test/test_arm_yaml_renderer_transcoder_disabled.py
+++ b/test/test_arm_yaml_renderer_transcoder_disabled.py
@@ -14,10 +14,15 @@ import tempfile
 import textwrap
 
 
+# Literal docker-compose endpoint used only as test fixture data; no network
+# call is made. The renderer under test treats this as an opaque string.
+_TEST_WEBHOOK = "http://arm-transcoder:5000/webhook/arm"  # NOSONAR
+_IGNORED_WEBHOOK = "http://should-be-ignored:5000/webhook/arm"  # NOSONAR
+
 FIXTURE_YAML = textwrap.dedent(
-    """\
+    f"""\
     SKIP_TRANSCODE: false
-    TRANSCODER_URL: "http://arm-transcoder:5000/webhook/arm"
+    TRANSCODER_URL: "{_TEST_WEBHOOK}"
     TRANSCODER_WEBHOOK_SECRET: "some-secret"
     LOCAL_RAW_PATH: ""
     SHARED_RAW_PATH: ""
@@ -80,7 +85,7 @@ def _get_value(rendered: str, key: str) -> str:
 def test_transcoder_url_empty_when_disabled():
     rendered = _render({
         "ARM_TRANSCODER_ENABLED": "false",
-        "ARM_TRANSCODER_URL": "http://should-be-ignored:5000/webhook/arm",
+        "ARM_TRANSCODER_URL": _IGNORED_WEBHOOK,
         "ARM_TRANSCODER_WEBHOOK_SECRET": "should-be-wiped",
     })
     assert _get_value(rendered, "TRANSCODER_URL") == ""
@@ -90,17 +95,17 @@ def test_transcoder_url_empty_when_disabled():
 def test_transcoder_url_preserved_when_enabled():
     rendered = _render({
         "ARM_TRANSCODER_ENABLED": "true",
-        "ARM_TRANSCODER_URL": "http://arm-transcoder:5000/webhook/arm",
+        "ARM_TRANSCODER_URL": _TEST_WEBHOOK,
         "ARM_TRANSCODER_WEBHOOK_SECRET": "secret",
     })
-    assert _get_value(rendered, "TRANSCODER_URL") == "http://arm-transcoder:5000/webhook/arm"
+    assert _get_value(rendered, "TRANSCODER_URL") == _TEST_WEBHOOK
     assert _get_value(rendered, "TRANSCODER_WEBHOOK_SECRET") == "secret"
 
 
 def test_transcoder_url_preserved_when_flag_unset():
     rendered = _render({
-        "ARM_TRANSCODER_URL": "http://arm-transcoder:5000/webhook/arm",
+        "ARM_TRANSCODER_URL": _TEST_WEBHOOK,
         "ARM_TRANSCODER_WEBHOOK_SECRET": "secret",
     })
-    assert _get_value(rendered, "TRANSCODER_URL") == "http://arm-transcoder:5000/webhook/arm"
+    assert _get_value(rendered, "TRANSCODER_URL") == _TEST_WEBHOOK
     assert _get_value(rendered, "TRANSCODER_WEBHOOK_SECRET") == "secret"


### PR DESCRIPTION
## Summary

- New `docker-compose.ripper-only.yml` variant running ARM + UI on a single machine with no transcoder container. ARM falls into the existing v15.0.0 `finalize_output` path and writes final named files directly.
- `scripts/docker/runit/arm_user_files_setup.sh` force-empties `TRANSCODER_URL` and `TRANSCODER_WEBHOOK_SECRET` in arm.yaml when `ARM_TRANSCODER_ENABLED=false`, regardless of any values present in env. Leaves both the all-in-one and remote-transcoder flows unchanged.
- New `.env.ripper-only.example`, updated `.env.example` to document `TRANSCODER_ENABLED`, and `deploy/DEPLOY.md` adds a ripper-only section.

Companion: https://github.com/uprightbass360/automatic-ripping-machine-ui/pull/217 (UI side reads `ARM_UI_TRANSCODER_ENABLED` to hide transcoder surfaces and short-circuit transcoder HTTP calls).

Spec: `ai/arm-neu/docs/superpowers/specs/2026-04-23-ripper-only-deployment-design.md`
Plan: `ai/arm-neu/docs/superpowers/plans/2026-04-23-ripper-only-deployment.md`

## Test plan

- [x] New `test/test_arm_yaml_renderer_transcoder_disabled.py`: 3 cases pass (disabled -> empty; enabled -> preserved; unset -> preserved)
- [x] `docker compose -f docker-compose.ripper-only.yml config --quiet` passes
- [ ] End-to-end: `docker compose -f docker-compose.ripper-only.yml up -d` on a host with matching UID/GID; confirm dashboard loads, nav has no Transcoder link, `/api/transcoder/stats` returns 503