### PR TITLE
feat: port upstream enhancements (imdb_id naming + UDF stale-handle)

### DIFF
--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -19,6 +19,35 @@ from arm.models.track import Track  # noqa: F401
 from arm.models.config import Config  # noqa: F401
 
 
+def _listdir_safe(path):
+    """List a directory, returning [] on any OSError (stale handle, missing, etc.)."""
+    try:
+        return os.listdir(path)
+    except OSError:
+        return []
+
+
+def _find_disc_dir(mountpoint, name):
+    """Case-insensitive lookup of a top-level entry on the mount.
+
+    Returns the actual on-disk name (so the caller can join the path) or
+    None. Using os.listdir() instead of os.path.isdir() avoids os.stat()
+    on the directory entry, which fails with "stale file handle" on some
+    burned UDF DVD-Rs even though the kernel still lists the entry. See
+    upstream issue #1746 / PR #1747.
+    """
+    target = name.lower()
+    for entry in _listdir_safe(mountpoint):
+        if entry.lower() == target:
+            return entry
+    return None
+
+
+def _disc_dir_exists(mountpoint, name):
+    """True if a case-insensitive directory entry exists at the mount root."""
+    return _find_disc_dir(mountpoint, name) is not None
+
+
 class JobState(str, enum.Enum):
     """Possible states for Job.status.
 
@@ -259,25 +288,20 @@ class Job(db.Model):
         if self.disctype == "music":
             logging.debug("Disc is music.")
             self.label = music_brainz.main(self)
-        elif (os.path.isdir(self.mountpoint + "/AUDIO_TS")
-              and len(os.listdir(self.mountpoint + "/AUDIO_TS")) > 0) \
-            or (os.path.isdir(self.mountpoint + "/audio_ts")
-                and len(os.listdir(self.mountpoint + "/audio_ts")) > 0):
-            logging.debug(f"Found: {self.mountpoint}/AUDIO_TS")
+        elif (audio_ts := _find_disc_dir(self.mountpoint, "AUDIO_TS")) \
+                and _listdir_safe(os.path.join(self.mountpoint, audio_ts)):
+            logging.debug(f"Found: {self.mountpoint}/{audio_ts}")
             self.disctype = "data"
-        elif os.path.isdir(self.mountpoint + "/VIDEO_TS"):
+        elif _disc_dir_exists(self.mountpoint, "VIDEO_TS"):
             logging.debug(f"Found: {self.mountpoint}/VIDEO_TS")
             self.disctype = "dvd"
-        elif os.path.isdir(self.mountpoint + "/video_ts"):
-            logging.debug(f"Found: {self.mountpoint}/video_ts")
-            self.disctype = "dvd"
-        elif os.path.isdir(self.mountpoint + "/BDMV"):
-            logging.debug(f"Found: {self.mountpoint}/BDMV")
+        elif (bdmv := _find_disc_dir(self.mountpoint, "BDMV")):
+            logging.debug(f"Found: {self.mountpoint}/{bdmv}")
             # Detect UHD by reading the index.bdmv header version.
             # INDX0300 = UHD (AACS2), INDX0200 = standard Blu-ray.
-            # The old check (/CERTIFICATE/id.bdmv) is unreliable — that
+            # The old check (/CERTIFICATE/id.bdmv) is unreliable - that
             # file exists on most standard Blu-rays with BD-J content.
-            index_path = os.path.join(self.mountpoint, "BDMV", "index.bdmv")
+            index_path = os.path.join(self.mountpoint, bdmv, "index.bdmv")
             try:
                 with open(index_path, "rb") as f:
                     header = f.read(8)
@@ -290,7 +314,7 @@ class Job(db.Model):
             except OSError:
                 logging.debug("Could not read index.bdmv — assuming standard Blu-ray")
                 self.disctype = "bluray"
-        elif os.path.isdir(self.mountpoint + "/HVDVD_TS"):
+        elif _disc_dir_exists(self.mountpoint, "HVDVD_TS"):
             logging.debug(f"Found: {self.mountpoint}/HVDVD_TS")
             # do something here
         elif found_hvdvd_ts:

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -34,6 +34,7 @@ PATTERN_VARIABLES = {
     'video_type':   'Media type: movie, series, or music',
     'disc_number':  'Disc number in a multi-disc set',
     'disc_total':   'Total number of discs in the set',
+    'imdb_id':      'IMDb ID (e.g. tt0111161) for Jellyfin/Plex folder matching',
 }
 
 # Frozen set for fast validation — derived from PATTERN_VARIABLES
@@ -83,6 +84,7 @@ def _build_variables(job):
         'video_type': getattr(job, 'video_type', '') or '',
         'disc_number': str(getattr(job, 'disc_number', '') or ''),
         'disc_total': str(getattr(job, 'disc_total', '') or ''),
+        'imdb_id': getattr(job, 'imdb_id', '') or '',
     })
 
 
@@ -97,8 +99,9 @@ def clean_for_filename(s):
     s = re.sub(r'\s+', ' ', s)
     s = s.replace('&', 'and')
     s = s.replace('\\', ' - ')
-    s = re.sub(r'[^\w .()-]', '', s)
-    # Prevent path traversal — strip leading dots and collapse sequences
+    # Keep Jellyfin/Plex folder tags like [imdbid-tt1234567] legible on disk.
+    s = re.sub(r'[^\w .()\[\]-]', '', s)
+    # Prevent path traversal - strip leading dots and collapse sequences
     s = re.sub(r'\.{2,}', '.', s)
     return s.strip('. ')
 

--- a/test/test_disc_detection.py
+++ b/test/test_disc_detection.py
@@ -159,6 +159,43 @@ class TestGetDiscType:
         # So disctype should remain 'unknown'
         assert job.disctype == 'unknown'
 
+    def test_udf_stale_handle_isdir_returns_false_but_listdir_works(self, tmp_path, monkeypatch):
+        """Burned UDF DVD-R: os.path.isdir fails on stale handle, listdir still succeeds.
+
+        Regression guard for upstream issue #1746 / PR #1747 - ARM used to
+        fall through to disctype='data' because os.stat() on the VIDEO_TS
+        directory entry raised OSError even though the kernel listed it.
+        """
+        from unittest.mock import patch
+
+        job = self._make_job()
+        job.mountpoint = str(tmp_path)
+        # Set up the directory so listdir works, then sabotage os.path.isdir
+        # to simulate the stale-file-handle error path.
+        os.makedirs(tmp_path / 'VIDEO_TS')
+
+        def fake_isdir(path):
+            # Pretend *every* directory stat fails - mirrors the stale handle case.
+            return False
+
+        with patch('os.path.isdir', side_effect=fake_isdir):
+            job.get_disc_type(False)
+        assert job.disctype == 'dvd'
+
+    def test_bdmv_stale_handle_lowercase_bdmv(self, tmp_path, monkeypatch):
+        """BDMV detection is case-insensitive and survives os.path.isdir failure."""
+        from unittest.mock import patch
+
+        job = self._make_job()
+        job.mountpoint = str(tmp_path)
+        (tmp_path / 'bdmv').mkdir()  # lowercase on disc
+        # Make index.bdmv present so the header probe succeeds
+        (tmp_path / 'bdmv' / 'index.bdmv').write_bytes(b'INDX0200_')
+
+        with patch('os.path.isdir', side_effect=lambda p: False):
+            job.get_disc_type(False)
+        assert job.disctype == 'bluray'
+
     def test_music_disc_delegates_to_musicbrainz(self):
         """Music disc type delegates to music_brainz.main()."""
         job = self._make_job()

--- a/test/test_naming.py
+++ b/test/test_naming.py
@@ -686,3 +686,31 @@ def test_disc_total_in_folder_pattern():
     job.disc_total = 3
     cfg = {'MOVIE_FOLDER_PATTERN': '{title} ({year})/Disc {disc_number} of {disc_total}'}
     assert render_folder(job, cfg) == os.path.join('Dynasties (2018)', 'Disc 2 of 3')
+
+
+# ======================================================================
+# imdb_id pattern variable (upstream issue #1755)
+# ======================================================================
+
+
+def test_imdb_id_in_folder_pattern():
+    """imdb_id variable renders for Jellyfin/Plex-style folder tags."""
+    job = _make_job(title='The Shawshank Redemption', year='1994', video_type='movie')
+    job.imdb_id = 'tt0111161'
+    cfg = {'MOVIE_FOLDER_PATTERN': '{title} ({year}) [imdbid-{imdb_id}]'}
+    assert render_folder(job, cfg) == 'The Shawshank Redemption (1994) [imdbid-tt0111161]'
+
+
+def test_imdb_id_omitted_when_none():
+    """Missing imdb_id renders as empty string without crashing."""
+    job = _make_job(title='Untitled', year='2024', video_type='movie')
+    job.imdb_id = None
+    cfg = {'MOVIE_FOLDER_PATTERN': '{title} ({year}) [imdbid-{imdb_id}]'}
+    # Empty tag still renders; callers can wrap in conditional cleanup if they care.
+    assert render_folder(job, cfg) == 'Untitled (2024) [imdbid-]'
+
+
+def test_clean_for_filename_preserves_square_brackets():
+    """clean_for_filename keeps [] so [imdbid-ttXXXXXXX] tags survive."""
+    from arm.ripper.naming import clean_for_filename
+    assert clean_for_filename('Foo (2024) [imdbid-tt1234567]') == 'Foo (2024) [imdbid-tt1234567]'


### PR DESCRIPTION
## Summary

Two small ports from upstream:

### 1. \`{imdb_id}\` in naming patterns - upstream issue [#1755](https://github.com/automatic-ripping-machine/automatic-ripping-machine/issues/1755)
Lets users build Jellyfin/Plex-friendly folder tags like \`{title} ({year}) [imdbid-{imdb_id}]\`. Also broadens \`clean_for_filename\` to keep \`[]\` so the resulting folder name survives sanitization.

### 2. UDF DVD-R stale-handle fix - upstream PR [#1747](https://github.com/automatic-ripping-machine/automatic-ripping-machine/pull/1747)
\`get_disc_type()\` used \`os.path.isdir()\` to detect VIDEO_TS / BDMV / HVDVD_TS. On burned UDF DVD-Rs the kernel lists the directory entry but \`os.stat()\` fails with a stale file handle, so ARM falls through to \`disctype = 'data'\` and produces a raw ISO instead of invoking MakeMKV.

Switched to \`os.listdir()\`-based case-insensitive lookup via two helpers (\`_find_disc_dir\`, \`_listdir_safe\`). Side benefit: also handles mixed-case names (\`Bdmv\`, \`Video_TS\`).

## Test plan
- [x] \`test_imdb_id_in_folder_pattern\` covers the new naming variable
- [x] \`test_clean_for_filename_preserves_square_brackets\` locks in the sanitizer change
- [x] \`test_udf_stale_handle_isdir_returns_false_but_listdir_works\` simulates the stale-handle case via mocked \`os.path.isdir\`
- [x] \`test_bdmv_stale_handle_lowercase_bdmv\` covers case-insensitive BDMV detection during stale handles
- [x] All 1951 existing tests still pass
- [ ] Manual: rip a known burned DVD-R that previously fell through to data

🤖 Generated with [Claude Code](https://claude.com/claude-code)