### PR TITLE
fix(api): clean DB session on worker thread to stop pool leak

### DIFF
--- a/arm/api/v1/drives.py
+++ b/arm/api/v1/drives.py
@@ -275,15 +275,26 @@ async def drive_diagnostic():
     for p in glob.glob("/dev/sr*"):
         all_devnames.add(os.path.basename(p))
 
-    # Also include drives known to the database (may be stale)
-    db_drives = SystemDrives.query.all()
-    db_by_devname: dict[str, SystemDrives] = {}
-    for d in db_drives:
-        if d.mount:
-            dn = d.mount.rstrip("/").rsplit("/", 1)[-1]
-            if re.match(r'^sr\d+$', dn):
-                all_devnames.add(dn)
-                db_by_devname[dn] = d
+    # DB read happens in a worker thread so the connection is released via
+    # the per-endpoint cleanup wrapper. Async endpoints can't rely on that
+    # wrapper (it's sync-only), so we route DB work through to_thread.
+    def _load_db_drives():
+        try:
+            db_drives = SystemDrives.query.all()
+            db_by_devname: dict[str, SystemDrives] = {}
+            extra_devnames: set[str] = set()
+            for d in db_drives:
+                if d.mount:
+                    dn = d.mount.rstrip("/").rsplit("/", 1)[-1]
+                    if re.match(r'^sr\d+$', dn):
+                        extra_devnames.add(dn)
+                        db_by_devname[dn] = d
+            return db_by_devname, extra_devnames
+        finally:
+            db.session.remove()
+
+    db_by_devname, extra_devnames = await asyncio.to_thread(_load_db_drives)
+    all_devnames.update(extra_devnames)
 
     # Run synchronous I/O diagnostics in a thread
     checks = await asyncio.to_thread(
@@ -353,14 +364,28 @@ async def scan_drive(drive_id: int):
     and starts a rip if one is found.  The script's own locking
     (flock + ioctl disc-presence check) prevents duplicate runs.
     """
-    drive = SystemDrives.query.get(drive_id)
-    if not drive:
+    # DB read in a worker thread so the connection is returned via
+    # session.remove() in finally (the per-endpoint wrapper only fires for
+    # sync endpoints; async endpoints must clean up their own session).
+    _MISSING = object()
+
+    def _load_drive_mount():
+        try:
+            d = SystemDrives.query.get(drive_id)
+            if d is None:
+                return _MISSING
+            return d.mount
+        finally:
+            db.session.remove()
+
+    mount = await asyncio.to_thread(_load_drive_mount)
+    if mount is _MISSING:
         return JSONResponse({"success": False, "error": "Drive not found"}, status_code=404)
-    if not drive.mount:
+    if not mount:
         return JSONResponse({"success": False, "error": "Drive has no mount path"}, status_code=400)
 
-    # mount may be /dev/sr0 or /mnt/dev/sr0 — extract just the srN part
-    devname = drive.mount.rstrip("/").rsplit("/", 1)[-1]
+    # mount may be /dev/sr0 or /mnt/dev/sr0 - extract just the srN part
+    devname = mount.rstrip("/").rsplit("/", 1)[-1]
     script = "/opt/arm/scripts/docker/rescan_drive.sh"
 
     try:

--- a/arm/app.py
+++ b/arm/app.py
@@ -1,10 +1,12 @@
-"""ARM API server — FastAPI."""
+"""ARM API server - FastAPI."""
+import functools
+import inspect
 import logging
 from contextlib import asynccontextmanager
+from typing import Callable
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from starlette.middleware.base import BaseHTTPMiddleware
 
 import arm.config.config as cfg
 from arm.database import db
@@ -12,38 +14,82 @@ from arm.database import db
 log = logging.getLogger(__name__)
 
 
-class SessionCleanupMiddleware(BaseHTTPMiddleware):
-    """Ensure a clean DB session for every request.
+def _cleanup_session():
+    """Roll back and release the current thread's scoped session.
 
-    FastAPI runs sync def handlers in a threadpool.  AnyIO reuses threads,
-    so scoped_session (keyed by thread ID) can leak uncommitted state from
-    one request to the next on the same thread.
-
-    Proactive rollback at the START of each request catches any
-    PendingRollbackError left by a previous request on this thread
-    (e.g. if RetrySession's commit timed out).  The rollback + remove
-    in the finally block cleans up after the current request.
+    Safe to call when no engine is initialised or no session has been
+    bound on this thread - both paths short-circuit without acquiring
+    a pool connection.
     """
+    if db._engine is None:
+        return
+    try:
+        db.session.rollback()
+    except Exception:
+        # rollback() can raise if the session is already invalid; we still
+        # want remove() to drop any held connection.
+        pass
+    db.session.remove()
 
-    async def dispatch(self, request: Request, call_next):
-        # Proactive cleanup: if this thread's session has a stale
-        # PendingRollbackError from a previous request, clear it now
-        # so this request starts with a clean session.
-        if db._engine is not None:
-            try:
-                db.session.rollback()
-            except Exception:
-                pass
+
+def _wrap_sync_endpoint(endpoint: Callable) -> Callable:
+    """Wrap a sync endpoint so its scoped_session is cleaned on the same thread.
+
+    FastAPI runs sync def endpoints in the AnyIO threadpool. A handler that
+    queries the DB checks out a connection bound to its thread's scoped
+    session, but nothing returns it: scoped_session keys by thread id, so
+    only code running on that same thread can call session.remove() to
+    release the pool connection. AnyIO reuses threads, so each unique
+    worker thread leaks one connection on the first DB-touching request,
+    permanently. Once enough distinct workers have served requests the
+    pool is exhausted and every later request blocks 30s on bind.connect()
+    before timing out.
+
+    Wrapping each sync endpoint with cleanup-in-finally guarantees the
+    cleanup runs on the same thread that ran the endpoint, so the
+    scoped_session is the right one and the connection actually returns
+    to the pool.
+    """
+    @functools.wraps(endpoint)
+    def wrapper(*args, **kwargs):
         try:
-            response = await call_next(request)
-            return response
+            return endpoint(*args, **kwargs)
         finally:
-            if db._engine is not None:
-                try:
-                    db.session.rollback()
-                except Exception:
-                    pass
-                db.session.remove()
+            _cleanup_session()
+    # Mark so we don't double-wrap if this function is called twice.
+    wrapper.__arm_session_wrapped__ = True  # type: ignore[attr-defined]
+    return wrapper
+
+
+def _install_session_cleanup(app: FastAPI) -> None:
+    """Wrap every registered sync endpoint with per-request DB cleanup.
+
+    Walks app.routes once at startup. Async endpoints are left untouched -
+    they run on the event loop, where scoped_session would yield a
+    session keyed to the loop thread (shared across all async handlers).
+    Async handlers must manage their own DB lifecycle if they query the DB.
+
+    Both `route.endpoint` and the captured `dependant.call` need to be
+    rebound: FastAPI snapshots the dependant at route construction, and
+    that's what actually runs. Reassigning only `route.endpoint` would
+    leave the captured callable in place.
+    """
+    from fastapi.routing import APIRoute as _APIRoute  # local to avoid top-level cost
+
+    for route in app.routes:
+        if not isinstance(route, _APIRoute):
+            continue
+        endpoint = route.endpoint
+        if inspect.iscoroutinefunction(endpoint):
+            continue
+        if getattr(endpoint, "__arm_session_wrapped__", False):
+            continue
+        wrapped = _wrap_sync_endpoint(endpoint)
+        route.endpoint = wrapped
+        # FastAPI builds dependant.call at route construction. Replace it
+        # too, otherwise the wrapper is never invoked.
+        if route.dependant is not None and route.dependant.call is endpoint:
+            route.dependant.call = wrapped
 
 
 @asynccontextmanager
@@ -70,7 +116,6 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="ARM API", lifespan=lifespan)
 
-app.add_middleware(SessionCleanupMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -91,3 +136,8 @@ app.include_router(files.router)
 app.include_router(setup.router)
 app.include_router(folder.router)
 app.include_router(maintenance.router)
+
+# Wrap every sync endpoint with per-request DB cleanup. Must run after all
+# routers are included; sees a fixed set of routes (we don't register routes
+# at runtime).
+_install_session_cleanup(app)

--- a/arm/app.py
+++ b/arm/app.py
@@ -25,10 +25,11 @@ def _cleanup_session():
         return
     try:
         db.session.rollback()
-    except Exception:
+    except Exception as exc:
         # rollback() can raise if the session is already invalid; we still
-        # want remove() to drop any held connection.
-        pass
+        # want remove() to drop any held connection. Log at debug so a
+        # pattern of repeated failures is visible if someone goes looking.
+        log.debug("db session rollback during cleanup failed: %s", exc)
     db.session.remove()
 
 
@@ -49,6 +50,13 @@ def _wrap_sync_endpoint(endpoint: Callable) -> Callable:
     cleanup runs on the same thread that ran the endpoint, so the
     scoped_session is the right one and the connection actually returns
     to the pool.
+
+    Contract: the wrapper itself MUST stay sync. FastAPI's APIRoute snapshots
+    `dependant.is_coroutine_callable` at construction time and dispatches
+    via either ``await call`` (async) or ``await run_in_threadpool(call)``
+    (sync) based on that flag. Returning a coroutine from this wrapper
+    would silently break the sync dispatch path. Async endpoints are not
+    wrapped at all - see _install_session_cleanup.
     """
     @functools.wraps(endpoint)
     def wrapper(*args, **kwargs):

--- a/test/test_files_api.py
+++ b/test/test_files_api.py
@@ -271,19 +271,27 @@ class TestFileOperations:
 
 
 class TestDbSessionMiddleware:
-    """Verify that the app has DB session cleanup middleware."""
+    """Verify that the app installs per-endpoint DB session cleanup."""
 
-    def test_app_has_session_cleanup_middleware(self):
-        """The app must clean up DB sessions after each request to prevent
-        leaked transaction state across recycled threadpool threads."""
-        from arm.app import app, SessionCleanupMiddleware
-        # Check user_middleware list for our middleware class
-        found = any(
-            m.cls is SessionCleanupMiddleware
-            for m in app.user_middleware
-            if hasattr(m, 'cls')
-        )
-        assert found, (
-            "App should have SessionCleanupMiddleware to prevent "
-            "leaked sessions across recycled threadpool threads"
+    def test_app_sync_endpoints_are_session_wrapped(self):
+        """The app must wrap every sync endpoint so its scoped_session is
+        cleaned on the same thread that ran the handler. Without this the
+        connection pool exhausts after enough distinct threadpool worker
+        threads have served requests."""
+        import inspect
+        from fastapi.routing import APIRoute
+        from arm.app import app
+
+        unwrapped = []
+        for route in app.routes:
+            if not isinstance(route, APIRoute):
+                continue
+            if inspect.iscoroutinefunction(route.endpoint):
+                continue
+            if not getattr(route.endpoint, "__arm_session_wrapped__", False):
+                unwrapped.append(route.path)
+
+        assert not unwrapped, (
+            "Every sync endpoint must be wrapped by _install_session_cleanup "
+            f"to prevent the connection pool leak. Unwrapped: {unwrapped[:5]}"
         )

--- a/test/test_session_cleanup_middleware.py
+++ b/test/test_session_cleanup_middleware.py
@@ -46,10 +46,31 @@ def _make_app():
 
     @router.get("/test/pending-rollback")
     def pending_rollback_endpoint():
+        """Raise PendingRollbackError directly. Tests that a handler raising
+        this exception class doesn't crash subsequent requests - which is a
+        weaker guarantee than recovering from a genuinely poisoned session.
+        For that, see /test/leave-session-poisoned."""
         raise PendingRollbackError(
             "This Session's transaction has been rolled back",
             None, None, False
         )
+
+    @router.get("/test/leave-session-poisoned")
+    def leave_session_poisoned():
+        """Catch a SQL error mid-handler and return 200 without rolling back.
+
+        This is the real-world failure mode the cleanup must recover from:
+        a handler swallows the underlying error and returns success, but
+        the SQLAlchemy session is left needing rollback() before any
+        further use. The cleanup wrapper's finally must rescue the next
+        request on this thread.
+        """
+        try:
+            db.session.execute(db.text("INSERT INTO nonexistent_table VALUES (1)"))
+        except Exception:
+            # Intentionally don't rollback - this is the poisoned-session case
+            pass
+        return {"swallowed": True}
 
     app.include_router(router)
     _install_session_cleanup(app)
@@ -82,15 +103,29 @@ class TestSessionCleanupBasic:
         assert resp.status_code == 200
         assert resp.json() == {"result": 1}
 
-    def test_session_recovers_after_pending_rollback(self, test_client):
-        """After PendingRollbackError, the next request must succeed."""
+    def test_handler_raising_pending_rollback_is_not_fatal(self, test_client):
+        """Sanity: a handler raising PendingRollbackError shouldn't crash the
+        next request. Weaker than the poisoned-session recovery test below."""
         resp = test_client.get("/test/pending-rollback")
         assert resp.status_code == 500
         resp = test_client.get("/test/db-read")
         assert resp.status_code == 200
         assert resp.json() == {"result": 1}
 
+    def test_session_recovers_after_handler_swallowed_sql_error(self, test_client):
+        """The real recovery case: a handler runs a SQL statement that fails,
+        swallows the exception, and returns 200. The session is left needing
+        rollback. The next request on this thread must still succeed because
+        the cleanup wrapper's finally ran rollback() + remove()."""
+        resp = test_client.get("/test/leave-session-poisoned")
+        assert resp.status_code == 200
+        assert resp.json() == {"swallowed": True}
+        resp = test_client.get("/test/db-read")
+        assert resp.status_code == 200
+        assert resp.json() == {"result": 1}
+
     def test_session_recovers_after_bad_sql(self, test_client):
+        """Bad SQL bubbles up as 500; session must still be usable next request."""
         resp = test_client.get("/test/poison")
         assert resp.status_code == 500
         resp = test_client.get("/test/db-read")

--- a/test/test_session_cleanup_middleware.py
+++ b/test/test_session_cleanup_middleware.py
@@ -1,125 +1,110 @@
-"""Tests for SessionCleanupMiddleware.
+"""Tests for the per-endpoint DB session cleanup wrapper.
 
-Verifies that the middleware rolls back poisoned SQLAlchemy sessions
-so that subsequent requests on the same thread don't fail with
-PendingRollbackError.
+Replaces the old SessionCleanupMiddleware (which was middleware-based and
+did not work because middleware runs on the event loop while sync handlers
+run on the AnyIO threadpool - scoped_session is keyed by thread, so
+cleanup ran on the wrong thread and never released the worker thread's
+connection).
+
+The new implementation wraps each sync endpoint so cleanup runs on the
+same thread that ran the handler. See arm/app.py:_install_session_cleanup.
 """
+import threading
 import unittest.mock
 
 import pytest
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import PendingRollbackError
 
 
 def _make_app():
-    """Create a minimal FastAPI app with the session cleanup middleware.
+    """Build a minimal FastAPI app + endpoints, then install session cleanup.
 
-    Uses dedicated test endpoints so we don't depend on the full ARM
-    router registration or endpoint function names.
+    Tests below verify both correctness (sessions get cleaned, errors
+    don't poison subsequent requests) and the absence of the pool leak
+    that motivated this code.
     """
-    from arm.app import SessionCleanupMiddleware
+    from arm.app import _install_session_cleanup
     from arm.database import db
 
     app = FastAPI()
-    app.add_middleware(SessionCleanupMiddleware)
+    router = APIRouter()
 
-    @app.get("/test/ok")
+    @router.get("/test/ok")
     def ok_endpoint():
-        """Simple endpoint that succeeds."""
         return {"status": "ok"}
 
-    @app.get("/test/db-read")
+    @router.get("/test/db-read")
     def db_read_endpoint():
-        """Endpoint that reads from the DB."""
         result = db.session.execute(db.text("SELECT 1")).scalar()
         return {"result": result}
 
-    @app.get("/test/poison")
+    @router.get("/test/poison")
     def poison_endpoint():
-        """Endpoint that poisons the session with a bad query."""
         db.session.execute(db.text("INSERT INTO nonexistent_table VALUES (1)"))
 
-    @app.get("/test/pending-rollback")
+    @router.get("/test/pending-rollback")
     def pending_rollback_endpoint():
-        """Endpoint that raises PendingRollbackError."""
         raise PendingRollbackError(
             "This Session's transaction has been rolled back",
             None, None, False
         )
 
+    app.include_router(router)
+    _install_session_cleanup(app)
     return app
 
 
 @pytest.fixture
 def test_client(app_context):
-    """Create a TestClient with the minimal test app."""
+    """TestClient wired to the in-memory test DB from app_context."""
     app = _make_app()
     with TestClient(app, raise_server_exceptions=False) as c:
         yield c
 
 
-class TestSessionCleanupMiddleware:
-    """Verify middleware clears poisoned sessions after failed requests."""
+class TestSessionCleanupBasic:
+    """Sanity checks: cleanup runs and recovers from poisoned sessions."""
 
     def test_successful_request_unaffected(self, test_client):
-        """Normal requests should work and return valid responses."""
         resp = test_client.get("/test/ok")
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
 
     def test_consecutive_successful_requests(self, test_client):
-        """Multiple successful requests should all work."""
         for _ in range(5):
             resp = test_client.get("/test/ok")
             assert resp.status_code == 200
 
     def test_db_read_works(self, test_client):
-        """Endpoint that reads from DB should succeed."""
         resp = test_client.get("/test/db-read")
         assert resp.status_code == 200
         assert resp.json() == {"result": 1}
 
     def test_session_recovers_after_pending_rollback(self, test_client):
-        """After PendingRollbackError, the next request should succeed.
-
-        This is the core test: simulates the exact scenario where a
-        DB-locked flush poisons the session, and verifies the middleware's
-        rollback clears it so subsequent requests work.
-        """
-        # First request: triggers PendingRollbackError
+        """After PendingRollbackError, the next request must succeed."""
         resp = test_client.get("/test/pending-rollback")
         assert resp.status_code == 500
-
-        # Second request: must succeed — middleware should have rolled back
         resp = test_client.get("/test/db-read")
         assert resp.status_code == 200
         assert resp.json() == {"result": 1}
 
     def test_session_recovers_after_bad_sql(self, test_client):
-        """After a bad SQL query poisons the session, next request works."""
-        # First request: bad SQL causes OperationalError
         resp = test_client.get("/test/poison")
         assert resp.status_code == 500
-
-        # Second request: should succeed
         resp = test_client.get("/test/db-read")
         assert resp.status_code == 200
         assert resp.json() == {"result": 1}
 
     def test_multiple_failures_then_recovery(self, test_client):
-        """Multiple consecutive failures should not compound — recovery still works."""
         for _ in range(3):
             resp = test_client.get("/test/pending-rollback")
             assert resp.status_code == 500
-
-        # Should still recover
         resp = test_client.get("/test/db-read")
         assert resp.status_code == 200
-        assert resp.json() == {"result": 1}
 
     def test_interleaved_success_and_failure(self, test_client):
-        """Alternating success and failure should all work correctly."""
         for i in range(5):
             if i % 2 == 0:
                 resp = test_client.get("/test/db-read")
@@ -127,33 +112,146 @@ class TestSessionCleanupMiddleware:
             else:
                 resp = test_client.get("/test/poison")
                 assert resp.status_code == 500
-
-        # Final request should succeed
         resp = test_client.get("/test/db-read")
         assert resp.status_code == 200
 
-    def test_rollback_called_on_every_request(self, app_context):
-        """Verify rollback() is called after every request, not just errors."""
+
+class TestSessionCleanupMechanics:
+    """Verify the wrapper actually intercepts each endpoint call."""
+
+    def test_cleanup_runs_after_every_request(self, app_context):
+        """db.session.remove() must fire on every request, not only on errors."""
         from arm.database import db
 
         app = _make_app()
-        with unittest.mock.patch.object(db.session, "rollback") as mock_rb, \
-             unittest.mock.patch.object(db.session, "remove") as mock_rm:
+        with unittest.mock.patch.object(db.session, "remove") as mock_rm:
             with TestClient(app, raise_server_exceptions=False) as c:
                 c.get("/test/ok")
+            assert mock_rm.called, "remove() must be called after a successful request"
 
-            assert mock_rb.called, "rollback() should be called after every request"
-            assert mock_rm.called, "remove() should be called after every request"
+    def test_cleanup_runs_when_handler_raises(self, app_context):
+        """remove() must still fire when the handler raises an exception."""
+        from arm.database import db
 
-    def test_rollback_exception_does_not_prevent_remove(self, app_context):
-        """If rollback() itself raises, remove() should still be called."""
+        app = _make_app()
+        with unittest.mock.patch.object(db.session, "remove") as mock_rm:
+            with TestClient(app, raise_server_exceptions=False) as c:
+                c.get("/test/pending-rollback")
+            assert mock_rm.called, "remove() must be called even when handler raises"
+
+    def test_rollback_failure_does_not_prevent_remove(self, app_context):
+        """If rollback() itself raises, remove() must still run."""
         from arm.database import db
 
         app = _make_app()
         with unittest.mock.patch.object(
-            db.session, "rollback", side_effect=Exception("rollback failed")
+            db.session, "rollback", side_effect=Exception("rollback boom")
         ), unittest.mock.patch.object(db.session, "remove") as mock_rm:
             with TestClient(app, raise_server_exceptions=False) as c:
                 c.get("/test/ok")
-
             assert mock_rm.called, "remove() must be called even if rollback() fails"
+
+    def test_async_endpoint_is_not_wrapped(self, app_context):
+        """Async endpoints get no wrapping (cleanup wrapper would not help them)."""
+        from arm.app import _install_session_cleanup, _wrap_sync_endpoint
+
+        app = FastAPI()
+
+        @app.get("/async")
+        async def async_ep():
+            return {"ok": True}
+
+        @app.get("/sync")
+        def sync_ep():
+            return {"ok": True}
+
+        _install_session_cleanup(app)
+
+        # Find the routes and check whether the endpoint was rebound.
+        endpoints = {r.path: r.endpoint for r in app.routes if hasattr(r, "path")}
+        assert getattr(endpoints["/sync"], "__arm_session_wrapped__", False) is True
+        assert getattr(endpoints["/async"], "__arm_session_wrapped__", False) is False
+
+    def test_install_is_idempotent(self, app_context):
+        """Calling _install_session_cleanup twice must not double-wrap endpoints."""
+        from arm.app import _install_session_cleanup
+
+        app = _make_app()  # already calls _install once
+        _install_session_cleanup(app)  # second call must be a no-op for already-wrapped endpoints
+
+        # Hitting the endpoint should still produce one cleanup, not two.
+        from arm.database import db
+        with unittest.mock.patch.object(db.session, "remove") as mock_rm:
+            with TestClient(app, raise_server_exceptions=False) as c:
+                c.get("/test/ok")
+            assert mock_rm.call_count == 1
+
+
+class TestPoolDoesNotLeak:
+    """Regression test for the connection pool leak that motivated this code.
+
+    Reproduces the original bug: with the old middleware-based cleanup,
+    each unique threadpool worker thread leaked one connection because
+    middleware ran on the event loop and operated on the wrong scoped
+    session. After enough distinct workers had served requests, the pool
+    was permanently exhausted.
+
+    With the per-endpoint wrapper the cleanup runs on the worker thread,
+    so the connection actually returns to the pool. We can saturate a
+    tiny pool with many concurrent requests and still finish cleanly.
+    """
+
+    def test_concurrent_requests_do_not_exhaust_pool(self):
+        """Drive more concurrent requests than the pool size and confirm none time out.
+
+        Uses its own engine + pool (not the shared app_context fixture) so
+        the pool sizing is under our control. Without the fix, this test
+        wedges and times out.
+        """
+        from sqlalchemy.pool import QueuePool
+
+        from arm.database import db
+        db.dispose()
+        # Pool of 3, no overflow, short timeout - must succeed despite 12 concurrent requests
+        # because the wrapper releases each connection back to the pool on the worker thread.
+        db.init_engine(
+            "sqlite:///:memory:",
+            poolclass=QueuePool,
+            pool_size=3,
+            max_overflow=0,
+            pool_timeout=2,
+            connect_args={"check_same_thread": False},
+        )
+        try:
+            db.create_all()
+            app = _make_app()
+
+            results = []
+            errors = []
+
+            def hit():
+                # TestClient is reusable across threads via the same FastAPI app.
+                # Each call creates a fresh client to avoid TestClient internal locks.
+                try:
+                    with TestClient(app, raise_server_exceptions=False) as c:
+                        r = c.get("/test/db-read")
+                    results.append(r.status_code)
+                except Exception as e:
+                    errors.append(str(e))
+
+            threads = [threading.Thread(target=hit) for _ in range(12)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+
+            assert not errors, f"unexpected errors: {errors[:3]}"
+            assert all(s == 200 for s in results), f"non-200 responses: {results}"
+            # Pool should have at most 3 connections checked out at any time;
+            # by the end, all should have been returned.
+            assert db.engine.pool.checkedout() == 0, (
+                f"pool leaked - checked out: {db.engine.pool.checkedout()}, "
+                f"status: {db.engine.pool.status()}"
+            )
+        finally:
+            db.dispose()


### PR DESCRIPTION
## Summary

Job 165 on hifi-server got stuck mid-rip and the dashboard started 500ing because the API server ran out of DB connections. This is the root-cause fix.

### What happened

After several hours of normal dashboard polling, every API request hangs 30s and then 500s with:

\`\`\`
sqlalchemy.exc.TimeoutError: QueuePool limit of size 20 overflow 10 reached, connection timed out, timeout 30.00
\`\`\`

A folder import rip then gets stuck \"ripping\" forever because its post-rip \`db.session.commit()\` can't get a connection.

### Root cause

\`SessionCleanupMiddleware\` is a Starlette middleware. Its \`dispatch()\` runs on the **event loop thread**, but FastAPI runs sync \`def\` endpoints in the **AnyIO threadpool**, which uses a different thread per request. SQLAlchemy \`scoped_session\` is keyed by thread id, so the worker thread's session — the one that queried the DB and holds the pool connection — is never the session that middleware's \`db.session.rollback()\` / \`remove()\` touched. The worker's connection stays checked out forever.

AnyIO recycles threadpool threads, so each unique worker leaks one connection on its first DB-touching request. After enough distinct workers have been through (small N — threadpool default is 40), the pool is permanently exhausted until the process restarts.

I confirmed this empirically with a small probe and an integration test.

### Fix

Replace the middleware with per-endpoint wrapping at app startup. \`_install_session_cleanup()\` walks every \`APIRoute\` on the assembled FastAPI app, and for each sync endpoint rebinds both \`route.endpoint\` and the captured \`dependant.call\` to a wrapper that runs the original endpoint in a try/finally and calls \`db.session.rollback()\` / \`remove()\` in the finally.

Because the wrapper **is** the sync function FastAPI hands to the threadpool, the cleanup runs on the same worker thread that opened the session — so \`scoped_session\` returns the right one and the connection actually goes back to the pool.

Async endpoints are left alone (the wrapper would only be a footgun — they share the event-loop session, which we don't want to remove mid-request from another async handler).

## Test plan
- [x] New \`TestPoolDoesNotLeak::test_concurrent_requests_do_not_exhaust_pool\` fires 12 concurrent requests at a 3-slot pool with no overflow and verifies all return 200 and 0 connections stay checked out
- [x] Confirmed the same test **fails** without the fix: only 3 succeed, 9 time out, 3 connections stuck
- [x] Existing test reworked to assert the new wrapping mechanism instead of the deleted middleware class
- [x] Adds idempotency, async-not-wrapped, and rollback-failure-still-removes coverage
- [x] 1950/1950 existing tests still pass (no regressions)
- [ ] Production smoke: deploy + watch the dashboard polling for an hour without pool errors