### PR TITLE
chore: scrub stale SessionCleanupMiddleware references

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -414,9 +414,11 @@ def _with_session_cleanup(fn, *args):
     """Run *fn* and ensure the executor thread's scoped session is released.
 
     asyncio.to_thread runs callables on executor threads whose scoped
-    sessions are NOT cleaned up by SessionCleanupMiddleware (which targets
-    the event-loop thread).  This wrapper prevents stale sessions from
-    accumulating on reused executor threads.
+    sessions are NOT cleaned up by the per-endpoint wrapper installed in
+    arm.app._install_session_cleanup (that wrapper targets the sync handler
+    callable that FastAPI dispatches into the threadpool, not callables
+    handed off to to_thread from inside an async handler). This wrapper
+    prevents stale sessions from accumulating on reused executor threads.
     """
     try:
         return fn(*args)

--- a/test/test_retry_session.py
+++ b/test/test_retry_session.py
@@ -2,7 +2,8 @@
 
 Verifies that db.session.commit() transparently retries when the
 database is locked, rolls back on non-lock errors, respects the
-timeout, and that the middleware proactively clears stale sessions.
+timeout, and that an explicit rollback() clears stale session state
+(the same primitive the per-endpoint cleanup wrapper relies on).
 """
 import threading
 import time
@@ -380,8 +381,13 @@ class TestDatabaseAdderSimplified:
         assert found is not None
 
 
-class TestMiddlewareProactiveRollback:
-    """Test that rollback clears stale session state."""
+class TestProactiveRollback:
+    """Test that rollback clears stale session state.
+
+    The per-endpoint session cleanup wrapper (arm.app._wrap_sync_endpoint)
+    relies on this primitive: a poisoned session can be rescued by
+    calling rollback() before the next operation.
+    """
 
     def test_rollback_clears_pending_error(self, retry_db):
         """Simulate bad session state and verify rollback recovers it."""


### PR DESCRIPTION
## Summary

Documentation-only cleanup after #261 deleted \`SessionCleanupMiddleware\`. Two text references survived the rename:

1. **\`arm/api/v1/jobs.py\`** — \`_with_session_cleanup\` docstring still pointed at the deleted middleware. Updated to reference \`_install_session_cleanup\` and to explain why the helper is still needed (the per-endpoint wrapper covers the sync-handler thread, but \`asyncio.to_thread\` callables run on a separate executor thread that the wrapper does not touch).
2. **\`test/test_retry_session.py\`** — module docstring and \`TestMiddlewareProactiveRollback\` class name said \"middleware\". The tests don't actually exercise middleware (they exercise \`rollback()\` directly). Renamed the class and updated the docstring.

## Audit notes (other things I checked, all clean)

- Walked every \`db.session.remove()\` call site - all of them are either inside the deleted middleware (gone), inside the per-endpoint wrapper, inside \`asyncio.to_thread\` callables, or inside background ripper threads. None redundant.
- \`_disc_dir_exists\` / \`_find_disc_dir\` / \`_listdir_safe\` in \`arm/models/job.py\` (added by #260) - all three are used.
- \`Request\` import in \`arm/api/v1/settings.py\` - still used.
- The transcoder's regex constants, the arm-ui's \`.responsive-table\` CSS, the mobile drawer state, and the FPS plumbing - all confirmed in use.

## Test plan
- [x] No behaviour change
- [x] 1956/1956 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)