### PR TITLE
fix(compose): persist UI image cache across container restarts

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,6 +41,7 @@ services:
       - ./dev-data/logs:/data/logs:ro
       - ./dev-data/config:/data/arm-config:rw
       - ./dev-data/config/themes:/data/config/themes:rw
+      - ./dev-data/cache/images:/data/cache/images:rw
       - ./dev-data/hb-presets:/data/hb-presets:ro
 
   arm-transcoder:

--- a/docker-compose.remote-transcoder.yml
+++ b/docker-compose.remote-transcoder.yml
@@ -88,11 +88,13 @@ services:
       - ARM_UI_ARM_HB_PRESETS_PATH=/data/hb-presets/presets.json
       - ARM_UI_TRANSCODER_API_KEY=${TRANSCODER_API_KEY:-}
       - ARM_UI_ARM_THEMES_PATH=/data/config/themes
+      - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
       - arm-db:/data/db:ro
       - ${ARM_LOGS_PATH}:/data/logs:ro
       - ${ARM_CONFIG_PATH}:/data/arm-config:rw
       - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:rw
+      - ui-image-cache:/data/cache/images:rw
       - hb-presets:/data/hb-presets:ro
     depends_on:
       arm-rippers:
@@ -104,3 +106,4 @@ volumes:
   arm-db:
   makemkv-settings:
   hb-presets:
+  ui-image-cache:

--- a/docker-compose.ripper-only.yml
+++ b/docker-compose.ripper-only.yml
@@ -67,11 +67,13 @@ services:
       - ARM_UI_ARM_URL=http://arm-rippers:8080
       - ARM_UI_TRANSCODER_ENABLED=false
       - ARM_UI_ARM_THEMES_PATH=/data/config/themes
+      - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
       - arm-db:/data/db:rw
       - ${ARM_LOGS_PATH}:/data/logs:ro
       - ${ARM_CONFIG_PATH}:/data/arm-config:rw
       - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:rw
+      - ui-image-cache:/data/cache/images:rw
     depends_on:
       arm-rippers:
         condition: service_healthy
@@ -79,3 +81,4 @@ services:
 volumes:
   arm-db:
   makemkv-settings:
+  ui-image-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,11 +98,13 @@ services:
       - ARM_UI_ARM_HB_PRESETS_PATH=/data/hb-presets/presets.json
       - ARM_UI_TRANSCODER_API_KEY=${TRANSCODER_API_KEY:-}
       - ARM_UI_ARM_THEMES_PATH=/data/config/themes
+      - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
       - arm-db:/data/db:rw
       - ${ARM_LOGS_PATH}:/data/logs:ro
       - ${ARM_CONFIG_PATH}:/data/arm-config:rw
       - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:rw
+      - ui-image-cache:/data/cache/images:rw
       - hb-presets:/data/hb-presets:ro
     depends_on:
       arm-rippers:
@@ -191,3 +193,4 @@ volumes:
   transcoder-db:
   transcoder-logs:
   hb-presets:
+  ui-image-cache:


### PR DESCRIPTION
## Summary

The \`arm-ui\` service uses \`/data/cache/images\` for cached poster / metadata art (OMDb, TMDb, MusicBrainz). All four ARM-neu compose files mounted volumes for the DB, logs, config, themes, and HB presets but had **no volume for the image cache** - so every container restart wiped the cache and caused a re-fetch storm against the metadata APIs on the next dashboard load.

## Changes

Adds \`ARM_UI_IMAGE_CACHE_PATH=/data/cache/images\` (matches the env's default, but explicit makes the intent obvious) and a \`ui-image-cache\` named volume across:

- \`docker-compose.yml\` (all-in-one)
- \`docker-compose.ripper-only.yml\`
- \`docker-compose.remote-transcoder.yml\`
- \`docker-compose.dev.yml\` (uses \`./dev-data/cache/images\` bind mount to match the dev overlay's bind-mount-everything pattern)

## How this was found

Spotted while polishing the arm-ui README's config table (https://github.com/uprightbass360/automatic-ripping-machine-ui/pull/227) - the env var was documented but no compose file actually persisted it.

## Test plan
- [ ] \`docker compose up -d --build\` then \`docker compose down\` then back \`up\`; confirm cached images survive
- [ ] \`docker volume ls\` shows \`<project>_ui-image-cache\`
- [ ] No regression on the three other compose modes