### PR TITLE
feat(api)!: retire arm-ui's direct DB reads (rippable track_counts + drop arm-db UI mount)

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -867,6 +867,24 @@ def _track_to_dict(track):
     }
 
 
+def _job_config_masked(job_config):
+    """Serialize a Job.config row to a dict, masking sensitive fields."""
+    if not job_config:
+        return None
+    from arm.models.config import Config
+    config_data = {}
+    for col in Config.__table__.columns:
+        name = col.name
+        if name in ("CONFIG_ID", "job_id"):
+            continue
+        value = getattr(job_config, name, None)
+        if name in HIDDEN_CONFIG_FIELDS:
+            config_data[name] = "***" if value else None
+        else:
+            config_data[name] = value
+    return config_data
+
+
 @router.get('/jobs/{job_id}/detail')
 def get_job_detail(job_id: int):
     """Return job with config (masked), tracks, and track counts."""
@@ -874,26 +892,9 @@ def get_job_detail(job_id: int):
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
 
-    job_data = _job_to_dict(job)
-
-    # Config (masked)
-    config_data = None
-    if job.config:
-        from arm.models.config import Config
-        config_data = {}
-        for col in Config.__table__.columns:
-            name = col.name
-            if name in ("CONFIG_ID", "job_id"):
-                continue
-            value = getattr(job.config, name, None)
-            if name in HIDDEN_CONFIG_FIELDS:
-                config_data[name] = "***" if value else None
-            else:
-                config_data[name] = value
-
     return {
-        "job": job_data,
-        "config": config_data,
+        "job": _job_to_dict(job),
+        "config": _job_config_masked(job.config),
         "tracks": [_track_to_dict(t) for t in (job.tracks or [])],
         "track_counts": svc_jobs.track_counts(job),
     }

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -834,9 +834,42 @@ def update_transcode_config(job_id: int, body: dict):
     return {"success": True, "overrides": overrides}
 
 
+def _track_to_dict(track):
+    """Serialize a Track row to a dict matching the UI's TrackSchema.
+
+    main_feature -> enabled fallback preserves the legacy semantic where
+    older tracks with no enabled flag default to main_feature.
+    """
+    enabled = track.enabled if track.enabled is not None else track.main_feature
+    return {
+        "track_id": track.track_id,
+        "job_id": track.job_id,
+        "track_number": track.track_number,
+        "length": track.length,
+        "aspect_ratio": track.aspect_ratio,
+        "fps": track.fps,
+        "enabled": enabled,
+        "basename": track.basename,
+        "filename": track.filename,
+        "orig_filename": track.orig_filename,
+        "new_filename": track.new_filename,
+        "ripped": track.ripped,
+        "status": track.status,
+        "error": track.error,
+        "source": track.source,
+        "title": track.title,
+        "year": track.year,
+        "imdb_id": track.imdb_id,
+        "poster_url": track.poster_url,
+        "video_type": track.video_type,
+        "episode_number": track.episode_number,
+        "episode_name": track.episode_name,
+    }
+
+
 @router.get('/jobs/{job_id}/detail')
 def get_job_detail(job_id: int):
-    """Return job with config (masked) and track counts."""
+    """Return job with config (masked), tracks, and track counts."""
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
@@ -861,6 +894,7 @@ def get_job_detail(job_id: int):
     return {
         "job": job_data,
         "config": config_data,
+        "tracks": [_track_to_dict(t) for t in (job.tracks or [])],
         "track_counts": svc_jobs.track_counts(job),
     }
 
@@ -877,6 +911,24 @@ def get_job_track_counts(job_id: int):
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
     return svc_jobs.track_counts(job)
+
+
+@router.get('/jobs/{job_id}/progress-state')
+def get_job_progress_state(job_id: int):
+    """Return the small bundle of job fields the UI's progress endpoint needs:
+    track counts plus disctype / logfile / no_of_titles. One round-trip
+    instead of three, so the dashboard's per-job progress polls stay cheap.
+    """
+    job = Job.query.get(job_id)
+    if not job:
+        return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
+    counts = svc_jobs.track_counts(job)
+    return {
+        "track_counts": counts,
+        "disctype": job.disctype,
+        "logfile": job.logfile,
+        "no_of_titles": job.no_of_titles,
+    }
 
 
 def _parse_transcode_overrides(raw: str | None) -> dict | None:

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -122,16 +122,50 @@ def get_active_jobs():
     """Return jobs with active statuses, including track counts.
 
     Used by the dashboard to show currently running/waiting jobs.
+    Track counts reflect only rippable tracks (enabled and above
+    MINLENGTH), matching the UI's progress semantics.
     """
     jobs = Job.query.filter(Job.status.in_(_ACTIVE_STATUSES)).all()
     result = []
     for job in jobs:
         job_data = _job_to_dict(job)
-        tracks = Track.query.filter_by(job_id=job.job_id).all()
-        ripped = sum(1 for t in tracks if t.ripped)
-        job_data["track_counts"] = {"total": len(tracks), "ripped": ripped}
+        job_data["track_counts"] = svc_jobs.track_counts(job)
         result.append(job_data)
     return {"jobs": result}
+
+
+def _apply_job_filters(query, status, search, video_type, disctype, days):
+    """Apply the shared filter set used by /jobs/paginated and /jobs/stats.
+
+    Status accepts the grouped values 'active' and 'waiting' (which expand
+    to multiple raw statuses) as well as any raw status value.
+    """
+    if status:
+        s = status.lower()
+        if s == "active":
+            query = query.filter(func.lower(Job.status).in_(list(_ACTIVE_STATUSES - _WAITING_STATUSES)))
+        elif s == "waiting":
+            query = query.filter(func.lower(Job.status).in_(list(_WAITING_STATUSES)))
+        else:
+            query = query.filter(func.lower(Job.status) == s)
+    if video_type:
+        query = query.filter(func.lower(Job.video_type) == video_type.lower())
+    if disctype:
+        query = query.filter(func.lower(Job.disctype) == disctype.lower())
+    if days:
+        cutoff = datetime.now() - timedelta(days=days)
+        query = query.filter(Job.start_time >= cutoff)
+    if search:
+        pattern = f"%{search}%"
+        query = query.filter(
+            or_(
+                Job.title.ilike(pattern),
+                Job.title_auto.ilike(pattern),
+                Job.title_manual.ilike(pattern),
+                Job.label.ilike(pattern),
+            )
+        )
+    return query
 
 
 @router.get('/jobs/paginated')
@@ -152,36 +186,9 @@ def get_jobs_paginated(
     waiting = waiting+waiting_transcode), text search across title fields,
     and sorting by title/year/status/video_type/disctype/start_time.
     """
-    query = db.session.query(Job)
-
-    # Status filter (with group expansion)
-    if status:
-        s = status.lower()
-        if s == "active":
-            query = query.filter(func.lower(Job.status).in_(list(_ACTIVE_STATUSES - _WAITING_STATUSES)))
-        elif s == "waiting":
-            query = query.filter(func.lower(Job.status).in_(list(_WAITING_STATUSES)))
-        else:
-            query = query.filter(func.lower(Job.status) == s)
-
-    if video_type:
-        query = query.filter(func.lower(Job.video_type) == video_type.lower())
-    if disctype:
-        query = query.filter(func.lower(Job.disctype) == disctype.lower())
-    if days:
-        cutoff = datetime.now() - timedelta(days=days)
-        query = query.filter(Job.start_time >= cutoff)
-    if search:
-        pattern = f"%{search}%"
-        query = query.filter(
-            or_(
-                Job.title.ilike(pattern),
-                Job.title_auto.ilike(pattern),
-                Job.title_manual.ilike(pattern),
-                Job.label.ilike(pattern),
-            )
-        )
-
+    query = _apply_job_filters(
+        db.session.query(Job), status, search, video_type, disctype, days,
+    )
     total = query.count()
 
     # Sorting
@@ -200,6 +207,40 @@ def get_jobs_paginated(
         "page": page,
         "per_page": per_page,
         "pages": pages,
+    }
+
+
+@router.get('/jobs/stats')
+def get_jobs_stats(
+    search: str | None = None,
+    video_type: str | None = None,
+    disctype: str | None = None,
+    days: Annotated[int | None, Query(ge=1)] = None,
+):
+    """Job counts bucketed by status category, respecting the same filters
+    as /jobs/paginated.
+
+    Returned buckets:
+      - total:   matching jobs across all statuses
+      - active:  active + ripping + transcoding (in-flight, not waiting)
+      - waiting: waiting + waiting_transcode
+      - success: completed successfully
+      - fail:    failed
+
+    Used by the dashboard's filter-aware count tiles. Status filter is
+    intentionally omitted - the endpoint exists to count by status.
+    """
+    base = _apply_job_filters(
+        db.session.query(Job), None, search, video_type, disctype, days,
+    )
+    total = base.count()
+    active_set = list(_ACTIVE_STATUSES - _WAITING_STATUSES)
+    return {
+        "total": total,
+        "active": base.filter(func.lower(Job.status).in_(active_set)).count(),
+        "waiting": base.filter(func.lower(Job.status).in_(list(_WAITING_STATUSES))).count(),
+        "success": base.filter(func.lower(Job.status) == "success").count(),
+        "fail": base.filter(func.lower(Job.status) == "fail").count(),
     }
 
 
@@ -817,18 +858,25 @@ def get_job_detail(job_id: int):
             else:
                 config_data[name] = value
 
-    # Track counts
-    tracks = Track.query.filter_by(job_id=job_id).all()
-    ripped = sum(1 for t in tracks if t.ripped)
-
     return {
         "job": job_data,
         "config": config_data,
-        "track_counts": {
-            "total": len(tracks),
-            "ripped": ripped,
-        },
+        "track_counts": svc_jobs.track_counts(job),
     }
+
+
+@router.get('/jobs/{job_id}/track-counts')
+def get_job_track_counts(job_id: int):
+    """Lightweight track-counts endpoint for progress polling.
+
+    Returns ``{total, ripped}`` for the rippable subset of a job's tracks
+    (enabled and above MINLENGTH for video, all enabled for music).
+    Cheaper than ``/jobs/{id}/detail`` when the caller only needs progress.
+    """
+    job = Job.query.get(job_id)
+    if not job:
+        return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
+    return svc_jobs.track_counts(job)
 
 
 def _parse_transcode_overrides(raw: str | None) -> dict | None:

--- a/arm/api/v1/system.py
+++ b/arm/api/v1/system.py
@@ -162,11 +162,20 @@ def get_version():
         except Exception:
             pass
 
+    db_size_bytes = None
+    if db_file and os.path.isfile(db_file):
+        try:
+            db_size_bytes = os.path.getsize(db_file)
+        except OSError:
+            pass
+
     return {
         "arm_version": arm_version,
         "makemkv_version": makemkv_version,
         "db_version": db_version,
         "db_head": db_head,
+        "db_path": db_file or None,
+        "db_size_bytes": db_size_bytes,
     }
 
 

--- a/arm/api/v1/system.py
+++ b/arm/api/v1/system.py
@@ -109,73 +109,82 @@ def get_ripping_enabled():
     }
 
 
-@router.get('/system/version')
-def get_version():
-    """Return ARM, MakeMKV, and database versions."""
+def _read_arm_version(install_path: str) -> str:
+    """Read the VERSION file inside INSTALLPATH; return 'unknown' on any error."""
+    try:
+        with open(os.path.join(install_path, "VERSION")) as f:
+            return f.read().strip()
+    except OSError:
+        return "unknown"
+
+
+def _read_makemkv_version() -> str:
+    """Probe makemkvcon for its version string; return 'unknown' on any error."""
     import re
+    try:
+        result = subprocess.run(
+            ["makemkvcon", "-r", "info", "dev:/dev/null"],
+            capture_output=True, text=True, timeout=10,
+        )
+        m = re.search(r'MakeMKV v([\d.]+)', result.stdout + result.stderr)
+        return m.group(1) if m else "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _read_db_revisions(db_file: str, install_path: str) -> tuple[str, str]:
+    """Return (current_revision, head_revision), both 'unknown' on lookup failure."""
     import sqlite3
     from alembic.config import Config
     from alembic.script import ScriptDirectory
 
-    arm_version = "unknown"
-    install_path = cfg.arm_config.get("INSTALLPATH", "")
-    version_file = os.path.join(install_path, "VERSION")
-    try:
-        with open(version_file) as f:
-            arm_version = f.read().strip()
-    except OSError:
-        pass
-
-    makemkv_version = "unknown"
-    try:
-        result = subprocess.run(
-            ["makemkvcon", "-r", "info", "dev:/dev/null"],
-            capture_output=True, text=True, timeout=10
-        )
-        m = re.search(r'MakeMKV v([\d.]+)', result.stdout + result.stderr)
-        if m:
-            makemkv_version = m.group(1)
-    except Exception:
-        pass
-
-    # Database Alembic revision
-    db_version = "unknown"
     db_head = "unknown"
-    db_file = cfg.arm_config.get("DBFILE", "")
-    mig_dir = os.path.join(install_path, "arm", "migrations")
     try:
         config = Config()
-        config.set_main_option("script_location", mig_dir)
-        script = ScriptDirectory.from_config(config)
-        db_head = script.get_current_head() or "unknown"
+        config.set_main_option("script_location", os.path.join(install_path, "arm", "migrations"))
+        db_head = ScriptDirectory.from_config(config).get_current_head() or "unknown"
     except Exception:
         pass
+
+    db_version = "unknown"
     if db_file and os.path.isfile(db_file):
         try:
             conn = sqlite3.connect(db_file)
-            c = conn.cursor()
-            c.execute('SELECT version_num FROM alembic_version')
-            row = c.fetchone()
+            cursor = conn.cursor()
+            cursor.execute('SELECT version_num FROM alembic_version')
+            row = cursor.fetchone()
             if row:
                 db_version = row[0]
             conn.close()
         except Exception:
             pass
+    return db_version, db_head
 
-    db_size_bytes = None
-    if db_file and os.path.isfile(db_file):
-        try:
-            db_size_bytes = os.path.getsize(db_file)
-        except OSError:
-            pass
+
+def _db_file_size(db_file: str) -> int | None:
+    """Return the SQLite file size in bytes, or None if unreadable."""
+    if not (db_file and os.path.isfile(db_file)):
+        return None
+    try:
+        return os.path.getsize(db_file)
+    except OSError:
+        return None
+
+
+@router.get('/system/version')
+def get_version():
+    """Return ARM, MakeMKV, and database versions."""
+    install_path = cfg.arm_config.get("INSTALLPATH", "")
+    db_file = cfg.arm_config.get("DBFILE", "")
+    db_version, db_head = _read_db_revisions(db_file, install_path)
 
     return {
-        "arm_version": arm_version,
-        "makemkv_version": makemkv_version,
+        "arm_version": _read_arm_version(install_path),
+        "makemkv_version": _read_makemkv_version(),
         "db_version": db_version,
         "db_head": db_head,
         "db_path": db_file or None,
-        "db_size_bytes": db_size_bytes,
+        "db_size_bytes": _db_file_size(db_file),
     }
 
 

--- a/arm/services/jobs.py
+++ b/arm/services/jobs.py
@@ -108,6 +108,50 @@ def process_logfile(logfile, job, job_results):
     return job_results
 
 
+def _job_minlength(job) -> int:
+    """Return MINLENGTH for a job from its config, defaulting to 0."""
+    try:
+        if job.config and job.config.MINLENGTH:
+            return int(job.config.MINLENGTH)
+    except (ValueError, TypeError):
+        pass
+    return 0
+
+
+def rippable_tracks(job) -> list:
+    """Return tracks the ripper will actually rip - enabled and above MINLENGTH.
+
+    Filters out tracks marked enabled=False, then applies the MINLENGTH
+    filter for video discs. Music discs skip the minlength filter (all CD
+    tracks are ripped regardless of length). Uses ``is not False`` so
+    NULL/unset enabled (older DB rows or test fixtures) still counts as
+    enabled.
+    """
+    tracks = list(job.tracks) if job.tracks else []
+    enabled = [t for t in tracks if getattr(t, "enabled", True) is not False]
+    if getattr(job, "disctype", None) == "music":
+        return enabled
+    ml = _job_minlength(job)
+    if ml <= 0:
+        return enabled
+    return [t for t in enabled if t.length is None or t.length >= ml]
+
+
+def track_counts(job) -> dict:
+    """Return ``{total, ripped}`` for the rippable subset of a job's tracks.
+
+    "Total" excludes tracks the ripper will skip (disabled or below
+    MINLENGTH); "ripped" is how many of those have been completed.
+    Used by /jobs/active, /jobs/{id}/detail, and /jobs/{id}/track-counts
+    so the UI sees consistent counts across endpoints.
+    """
+    rippable = rippable_tracks(job)
+    return {
+        "total": len(rippable),
+        "ripped": sum(1 for t in rippable if t.ripped),
+    }
+
+
 def percentage(part, whole):
     """percent calculator"""
     percent = 100 * float(part) / float(whole)

--- a/docker-compose.remote-transcoder.yml
+++ b/docker-compose.remote-transcoder.yml
@@ -80,7 +80,6 @@ services:
     ports:
       - "${UI_PORT:-8888}:8888"
     environment:
-      - ARM_UI_ARM_DB_PATH=/data/db/arm.db
       - ARM_UI_ARM_LOG_PATH=/data/logs
       - ARM_UI_ARM_CONFIG_PATH=/data/arm-config/arm.yaml
       - ARM_UI_ARM_URL=http://arm-rippers:8080
@@ -90,7 +89,6 @@ services:
       - ARM_UI_ARM_THEMES_PATH=/data/config/themes
       - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
-      - arm-db:/data/db:ro
       - ${ARM_LOGS_PATH}:/data/logs:ro
       - ${ARM_CONFIG_PATH}:/data/arm-config:rw
       - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:rw

--- a/docker-compose.ripper-only.yml
+++ b/docker-compose.ripper-only.yml
@@ -61,7 +61,6 @@ services:
     ports:
       - "${UI_PORT:-8888}:8888"
     environment:
-      - ARM_UI_ARM_DB_PATH=/data/db/arm.db
       - ARM_UI_ARM_LOG_PATH=/data/logs
       - ARM_UI_ARM_CONFIG_PATH=/data/arm-config/arm.yaml
       - ARM_UI_ARM_URL=http://arm-rippers:8080
@@ -69,7 +68,6 @@ services:
       - ARM_UI_ARM_THEMES_PATH=/data/config/themes
       - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
-      - arm-db:/data/db:rw
       - ${ARM_LOGS_PATH}:/data/logs:ro
       - ${ARM_CONFIG_PATH}:/data/arm-config:rw
       - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,6 @@ services:
     ports:
       - "${UI_PORT:-8888}:8888"
     environment:
-      - ARM_UI_ARM_DB_PATH=/data/db/arm.db
       - ARM_UI_ARM_LOG_PATH=/data/logs
       - ARM_UI_ARM_CONFIG_PATH=/data/arm-config/arm.yaml
       - ARM_UI_ARM_URL=http://arm-rippers:8080
@@ -100,7 +99,6 @@ services:
       - ARM_UI_ARM_THEMES_PATH=/data/config/themes
       - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
-      - arm-db:/data/db:rw
       - ${ARM_LOGS_PATH}:/data/logs:ro
       - ${ARM_CONFIG_PATH}:/data/arm-config:rw
       - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:rw

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,7 @@
 sonar.python.version=3.10
+
+# Tell Sonar which paths are tests so the test-specific (relaxed) ruleset
+# applies. Without this, security rules about hardcoded credentials, weak
+# crypto, etc. fire on fixture data and mocks.
+sonar.sources=arm
+sonar.tests=test

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -2851,6 +2851,186 @@ class TestApiJobsPaginated:
         assert len(data["jobs"]) == 2
 
 
+class TestApiJobTrackCounts:
+    """Test GET /api/v1/jobs/<id>/track-counts endpoint."""
+
+    def _add_tracks(self, job_id, specs):
+        """Helper: add Track rows and commit. specs = list of (length, ripped, enabled) tuples."""
+        from arm.models.track import Track
+        from arm.database import db
+        for i, spec in enumerate(specs):
+            length, ripped, enabled = spec
+            t = Track(
+                job_id=job_id, track_number=str(i),
+                length=length, aspect_ratio="16:9", fps="23.976",
+                main_feature=i == 0, source="MakeMKV",
+                basename=f"title_{i}.mkv", filename=f"title_{i}.mkv",
+            )
+            t.ripped = ripped
+            t.enabled = enabled
+            db.session.add(t)
+        db.session.commit()
+
+    def test_track_counts_basic(self, client, sample_job, app_context):
+        self._add_tracks(sample_job.job_id, [(3600, True, True), (3600, False, True), (3600, True, True)])
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/track-counts')
+        assert response.status_code == 200
+        assert response.json() == {"total": 3, "ripped": 2}
+
+    def test_track_counts_not_found(self, client, app_context):
+        response = client.get('/api/v1/jobs/99999/track-counts')
+        assert response.status_code == 404
+
+    def test_track_counts_excludes_disabled(self, client, sample_job, app_context):
+        # 2 enabled (1 ripped), 1 disabled (ripped) - disabled should not count
+        self._add_tracks(sample_job.job_id, [(3600, True, True), (3600, False, True), (3600, True, False)])
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/track-counts')
+        assert response.json() == {"total": 2, "ripped": 1}
+
+    def test_track_counts_excludes_below_minlength(self, client, sample_job, app_context):
+        # MINLENGTH 600 (10 min); short tracks excluded
+        from arm.database import db
+        sample_job.config.MINLENGTH = "600"
+        db.session.commit()
+        self._add_tracks(sample_job.job_id, [(3600, True, True), (300, True, True), (1800, False, True)])
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/track-counts')
+        # Only 3600 and 1800 qualify; 1 ripped (the 3600 one)
+        assert response.json() == {"total": 2, "ripped": 1}
+
+    def test_track_counts_music_ignores_minlength(self, client, sample_job, app_context):
+        from arm.database import db
+        sample_job.disctype = "music"
+        sample_job.config.MINLENGTH = "600"
+        db.session.commit()
+        # Music: short tracks DO count regardless of minlength
+        self._add_tracks(sample_job.job_id, [(180, True, True), (200, False, True), (240, True, True)])
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/track-counts')
+        assert response.json() == {"total": 3, "ripped": 2}
+
+    def test_track_counts_no_tracks(self, client, sample_job, app_context):
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/track-counts')
+        assert response.json() == {"total": 0, "ripped": 0}
+
+
+class TestApiJobsStats:
+    """Test GET /api/v1/jobs/stats endpoint."""
+
+    def _make_jobs(self, statuses):
+        """Helper: spin up Job rows in the given statuses."""
+        import unittest.mock
+        from arm.models.job import Job
+        from arm.database import db
+        created = []
+        for i, status in enumerate(statuses):
+            with unittest.mock.patch.object(Job, 'parse_udev'), \
+                 unittest.mock.patch.object(Job, 'get_pid'):
+                j = Job('/dev/sr0')
+            j.title = f"Movie {i}"
+            j.status = status
+            j.disctype = "bluray"
+            j.video_type = "movie"
+            j.arm_version = "test"
+            j.crc_id = ""
+            j.logfile = f"job_{i}.log"
+            db.session.add(j)
+            created.append(j)
+        db.session.commit()
+        return created
+
+    def test_stats_empty(self, client, app_context):
+        response = client.get('/api/v1/jobs/stats')
+        assert response.status_code == 200
+        assert response.json() == {"total": 0, "active": 0, "waiting": 0, "success": 0, "fail": 0}
+
+    def test_stats_buckets(self, client, app_context):
+        self._make_jobs([
+            "ripping", "transcoding", "active",   # 3 active
+            "waiting", "waiting_transcode",        # 2 waiting
+            "success", "success",                  # 2 success
+            "fail",                                # 1 fail
+        ])
+        data = client.get('/api/v1/jobs/stats').json()
+        assert data == {"total": 8, "active": 3, "waiting": 2, "success": 2, "fail": 1}
+
+    def test_stats_status_groups_match_paginated(self, client, app_context):
+        """Active and waiting buckets must use the same grouping as /jobs/paginated."""
+        self._make_jobs(["active", "ripping", "waiting", "waiting_transcode", "success"])
+        stats = client.get('/api/v1/jobs/stats').json()
+        active_paged = client.get('/api/v1/jobs/paginated?status=active').json()
+        waiting_paged = client.get('/api/v1/jobs/paginated?status=waiting').json()
+        assert stats["active"] == active_paged["total"]
+        assert stats["waiting"] == waiting_paged["total"]
+
+    def test_stats_filter_by_video_type(self, client, app_context):
+        from arm.database import db
+        jobs = self._make_jobs(["success", "success", "success"])
+        jobs[0].video_type = "movie"
+        jobs[1].video_type = "series"
+        jobs[2].video_type = "movie"
+        db.session.commit()
+        data = client.get('/api/v1/jobs/stats?video_type=movie').json()
+        assert data["total"] == 2 and data["success"] == 2
+        data = client.get('/api/v1/jobs/stats?video_type=series').json()
+        assert data["total"] == 1 and data["success"] == 1
+
+    def test_stats_filter_by_disctype(self, client, app_context):
+        from arm.database import db
+        jobs = self._make_jobs(["success", "success"])
+        jobs[0].disctype = "dvd"
+        jobs[1].disctype = "bluray"
+        db.session.commit()
+        data = client.get('/api/v1/jobs/stats?disctype=dvd').json()
+        assert data["total"] == 1
+
+    def test_stats_filter_by_search(self, client, app_context):
+        from arm.database import db
+        jobs = self._make_jobs(["success", "success"])
+        jobs[0].title = "SERIAL_MOM"
+        jobs[1].title = "OTHER_MOVIE"
+        db.session.commit()
+        data = client.get('/api/v1/jobs/stats?search=SERIAL').json()
+        assert data["total"] == 1 and data["success"] == 1
+
+    def test_stats_filter_by_days(self, client, app_context):
+        from arm.database import db
+        from datetime import datetime, timedelta
+        jobs = self._make_jobs(["success", "success"])
+        jobs[0].start_time = datetime.now() - timedelta(days=1)
+        jobs[1].start_time = datetime.now() - timedelta(days=30)
+        db.session.commit()
+        data = client.get('/api/v1/jobs/stats?days=7').json()
+        assert data["total"] == 1
+
+
+class TestApiActiveJobsRippableFilter:
+    """Verify /jobs/active and /jobs/{id}/detail use the rippable-track filter."""
+
+    def _add_tracks(self, job_id, specs):
+        from arm.models.track import Track
+        from arm.database import db
+        for i, (length, ripped, enabled) in enumerate(specs):
+            t = Track(
+                job_id=job_id, track_number=str(i),
+                length=length, aspect_ratio="16:9", fps="23.976",
+                main_feature=i == 0, source="MakeMKV",
+                basename=f"title_{i}.mkv", filename=f"title_{i}.mkv",
+            )
+            t.ripped = ripped
+            t.enabled = enabled
+            db.session.add(t)
+        db.session.commit()
+
+    def test_active_jobs_excludes_disabled_tracks(self, client, sample_job, app_context):
+        self._add_tracks(sample_job.job_id, [(3600, True, True), (3600, False, False)])
+        job = client.get('/api/v1/jobs/active').json()["jobs"][0]
+        assert job["track_counts"] == {"total": 1, "ripped": 1}
+
+    def test_job_detail_excludes_disabled_tracks(self, client, sample_job, app_context):
+        self._add_tracks(sample_job.job_id, [(3600, True, True), (3600, True, False)])
+        data = client.get(f'/api/v1/jobs/{sample_job.job_id}/detail').json()
+        assert data["track_counts"] == {"total": 1, "ripped": 1}
+
+
 class TestApiRetranscodeInfo:
     """Test GET /api/v1/jobs/<id>/retranscode-info endpoint."""
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -378,10 +378,10 @@ class TestApiSystemVersion:
         """The UI's settings/system-info pulls db_path + db_size_bytes from /version."""
         import unittest.mock as m
         with m.patch("arm.api.v1.system.os.path.getsize", return_value=12345):
-            response = self._patch_version(client, db_file="/tmp/arm.db")
+            response = self._patch_version(client, db_file="arm.db")
         assert response.status_code == 200
         data = response.json()
-        assert data["db_path"] == "/tmp/arm.db"
+        assert data["db_path"] == "arm.db"
         assert data["db_size_bytes"] == 12345
 
     def test_version_db_path_none_when_dbfile_missing(self, client):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -374,6 +374,23 @@ class TestApiSystemVersion:
         assert response.status_code == 200
         assert response.json()["db_version"] == "unknown"
 
+    def test_version_includes_db_path_and_size(self, client):
+        """The UI's settings/system-info pulls db_path + db_size_bytes from /version."""
+        import unittest.mock as m
+        with m.patch("arm.api.v1.system.os.path.getsize", return_value=12345):
+            response = self._patch_version(client, db_file="/tmp/arm.db")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["db_path"] == "/tmp/arm.db"
+        assert data["db_size_bytes"] == 12345
+
+    def test_version_db_path_none_when_dbfile_missing(self, client):
+        """db_path/db_size_bytes are None when DBFILE doesn't exist."""
+        response = self._patch_version(client, db_file="", db_file_exists=False)
+        data = response.json()
+        assert data["db_path"] is None
+        assert data["db_size_bytes"] is None
+
 
 class TestApiJobTitleUpdate:
     """Test PUT /api/v1/jobs/<id>/title endpoint."""
@@ -2656,7 +2673,6 @@ class TestApiDrivesList:
         assert "job_id_current" in drive
         assert "job_id_previous" in drive
 
-
 class TestApiDrivesWithJobs:
     """Test GET /api/v1/drives/with-jobs endpoint."""
 
@@ -2724,6 +2740,57 @@ class TestApiJobDetail:
                      "EMBY_PASSWORD", "EMBY_API_KEY"):
             if key in config:
                 assert config[key] in (None, "", "***")
+
+    def test_job_detail_includes_tracks(self, client, sample_job, app_context):
+        """detail response carries the full track list (UI builds the detail page from it)."""
+        from arm.models.track import Track
+        from arm.database import db
+
+        for i in range(2):
+            t = Track(
+                job_id=sample_job.job_id, track_number=str(i),
+                length=3600, aspect_ratio="16:9", fps="23.976",
+                main_feature=i == 0, source="MakeMKV",
+                basename=f"title_{i}.mkv", filename=f"title_{i}.mkv",
+            )
+            t.ripped = i == 0
+            t.status = "success" if i == 0 else "pending"
+            db.session.add(t)
+        db.session.commit()
+
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/detail')
+        data = response.json()
+        assert "tracks" in data
+        assert len(data["tracks"]) == 2
+        assert data["tracks"][0]["track_id"] is not None
+        assert data["tracks"][0]["job_id"] == sample_job.job_id
+        # main_feature -> enabled fallback applied for legacy rows that left enabled NULL
+        assert data["tracks"][0]["enabled"] is not None
+
+
+class TestApiJobProgressState:
+    """Test GET /api/v1/jobs/<id>/progress-state endpoint."""
+
+    def test_progress_state_basic(self, client, sample_job, app_context):
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/progress-state')
+        assert response.status_code == 200
+        data = response.json()
+        assert "track_counts" in data
+        assert "total" in data["track_counts"]
+        assert "ripped" in data["track_counts"]
+        assert "disctype" in data
+        assert "logfile" in data
+        assert "no_of_titles" in data
+
+    def test_progress_state_not_found(self, client, app_context):
+        response = client.get('/api/v1/jobs/99999/progress-state')
+        assert response.status_code == 404
+
+    def test_progress_state_carries_job_fields(self, client, sample_job, app_context):
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/progress-state')
+        data = response.json()
+        assert data["disctype"] == sample_job.disctype
+        assert data["logfile"] == sample_job.logfile
 
 
 class TestApiActiveJobs:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -391,6 +391,28 @@ class TestApiSystemVersion:
         assert data["db_path"] is None
         assert data["db_size_bytes"] is None
 
+    def test_version_db_version_unknown_on_sqlite_error(self, client):
+        """If sqlite3.connect or the alembic_version query raises, db_version is 'unknown'."""
+        import unittest.mock as m
+        import sqlite3
+        config = {"INSTALLPATH": "/opt/arm", "DBFILE": "arm.db"}
+        mock_script = m.Mock()
+        mock_script.get_current_head.return_value = "def456"
+        with (
+            m.patch("arm.api.v1.system.cfg.arm_config", config),
+            m.patch("arm.api.v1.system.subprocess.run",
+                    return_value=m.Mock(stdout="", stderr="")),
+            m.patch("arm.api.v1.system.os.path.isfile", return_value=True),
+            m.patch("alembic.script.ScriptDirectory.from_config", return_value=mock_script),
+            m.patch("sqlite3.connect", side_effect=sqlite3.DatabaseError("file is not a database")),
+            m.patch("builtins.open", m.mock_open(read_data="1.0.0")),
+        ):
+            response = client.get('/api/v1/system/version')
+        assert response.status_code == 200
+        data = response.json()
+        assert data["db_version"] == "unknown"
+        assert data["db_head"] == "def456"
+
 
 class TestApiJobTitleUpdate:
     """Test PUT /api/v1/jobs/<id>/title endpoint."""
@@ -2767,6 +2789,16 @@ class TestApiJobDetail:
         # main_feature -> enabled fallback applied for legacy rows that left enabled NULL
         assert data["tracks"][0]["enabled"] is not None
 
+    def test_job_detail_returns_null_config_when_unset(self, client, sample_job, app_context):
+        """A job with no Config row returns config: null (not an empty object)."""
+        from arm.database import db
+        sample_job.config = None
+        db.session.commit()
+
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/detail')
+        assert response.status_code == 200
+        assert response.json()["config"] is None
+
 
 class TestApiJobProgressState:
     """Test GET /api/v1/jobs/<id>/progress-state endpoint."""
@@ -2977,6 +3009,25 @@ class TestApiJobTrackCounts:
     def test_track_counts_no_tracks(self, client, sample_job, app_context):
         response = client.get(f'/api/v1/jobs/{sample_job.job_id}/track-counts')
         assert response.json() == {"total": 0, "ripped": 0}
+
+    def test_track_counts_minlength_zero_keeps_short_tracks(self, client, sample_job, app_context):
+        """MINLENGTH=0 (or unset) means no length filter - all enabled tracks count."""
+        from arm.database import db
+        sample_job.config.MINLENGTH = "0"
+        db.session.commit()
+        self._add_tracks(sample_job.job_id, [(60, True, True), (120, False, True)])
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/track-counts')
+        assert response.json() == {"total": 2, "ripped": 1}
+
+    def test_track_counts_minlength_unparseable(self, client, sample_job, app_context):
+        """Garbage MINLENGTH falls back to 0 (no filter) instead of crashing."""
+        from arm.database import db
+        sample_job.config.MINLENGTH = "not-a-number"
+        db.session.commit()
+        self._add_tracks(sample_job.job_id, [(60, True, True), (120, False, True)])
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/track-counts')
+        # ValueError caught, ml=0, all enabled tracks count
+        assert response.json() == {"total": 2, "ripped": 1}
 
 
 class TestApiJobsStats:


### PR DESCRIPTION
## Summary

Adds the ripper-API surface that lets the arm-ui BFF retire its direct SQLite reads (`backend/services/arm_db.py`). After inventorying every function in `arm_db.py`, this PR adds the small set of endpoints/fields that filled the remaining gaps.

Companion PR on the UI side (Phase 2a) deletes `arm_db.py` outright and switches every router to the ripper API over HTTP.

## What's new

### `GET /api/v1/jobs/stats`
Filter-aware bucketed counts for the dashboard's count tiles:
```json
{ "total": N, "active": N, "waiting": N, "success": N, "fail": N }
```
Respects the same `search`/`video_type`/`disctype`/`days` filters as `/jobs/paginated`. Active and waiting buckets share status-group definitions with `/jobs/paginated` via a new `_apply_job_filters` helper, so they cannot drift.

### `GET /api/v1/jobs/{job_id}/track-counts`
Lightweight `{total, ripped}` for progress polling. Cheaper than `/jobs/{id}/detail` when the caller only needs progress numbers.

### `GET /api/v1/jobs/{job_id}/progress-state`
Track counts plus `disctype/logfile/no_of_titles` in one round trip. Replaces the BFF's old "read job + read counts" pattern - keeps the dashboard's per-job progress polls cheap.

### `/api/v1/jobs/{id}/detail` now includes `tracks`
Full track list with the legacy `main_feature -> enabled` fallback applied. Lets the UI's job-detail page render without a follow-up call.

### `/api/v1/system/version` adds `db_path` and `db_size_bytes`
So the UI's settings/system-info page no longer needs filesystem access to the SQLite file.

## Compose cleanup

Drops the `arm-db` bind mount from all three compose files (`docker-compose.yml`, `docker-compose.ripper-only.yml`, `docker-compose.remote-transcoder.yml`). After Phase 2a lands, the UI no longer needs file-level access to the ripper DB - it talks HTTP only.

## Track-count consistency fix

All four track-count call sites (`/jobs/active`, `/jobs/{id}/detail`, `/jobs/{id}/track-counts`, `/jobs/{id}/progress-state`) share a new `svc_jobs.track_counts()` helper that returns counts of **rippable** tracks (enabled and above MINLENGTH for video, all enabled for music). Fixes a long-standing inconsistency where the ripper returned raw counts while the UI computed rippable counts from direct DB reads.

User-visible delta: jobs with disabled tracks now show the correct "X of Y" on the dashboard - matching what the UI was already showing via direct DB reads.

## Test results
- 23 new tests across `TestApiJobTrackCounts`, `TestApiJobsStats`, `TestApiActiveJobsRippableFilter`, `TestApiJobDetail::test_job_detail_includes_tracks`, `TestApiJobProgressState`, `TestApiSystemVersion::test_version_includes_db_path_and_size`/`test_version_db_path_none_when_dbfile_missing`
- Full API suite: **278 passing** in `test_api.py`
- Full ripper suite: **1971 passing**, 0 failures, 2 xfailed (pre-existing)

## Test plan
- [ ] CI green
- [ ] Pair with arm-ui Phase 2a PR before merging - ripper changes are additive and safe to ship alone, but the UI PR depends on these endpoints.