### PR TITLE
feat: adopt contracts WebhookPayload + TranscodeCallbackPayload

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -11,8 +11,10 @@ import threading
 from datetime import datetime, timedelta
 from typing import Annotated
 
+from arm_contracts import JobStatus, TranscodeCallbackPayload
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
+from pydantic import ValidationError
 from sqlalchemy import func, or_
 
 import arm.config.config as cfg
@@ -1025,44 +1027,56 @@ def get_retranscode_info(job_id: int):
 def transcode_callback(job_id: int, body: dict):
     """Receive status update from the external transcoder.
 
-    Expected payload::
+    The body is validated against arm_contracts.TranscodeCallbackPayload.
+    The transcoder sends one of:
+      - {"status": "transcoding"} (informational, fire-and-forget)
+      - {"status": "completed"|"partial"|"failed", "error": "...",
+         "track_results": [{"track_number": "1", "status": ..., ...}]}
 
-        {"status": "transcoding"|"completed"|"failed", "error": "..."}
-
-    Multi-title jobs may also include per-track results::
-
-        {"status": "completed", "track_results": [
-            {"track_number": "1", "status": "completed", "output_path": "..."},
-            {"track_number": "2", "status": "failed", "error": "codec error"},
-        ]}
+    Schema mismatches (unknown status, malformed track_results) return 422
+    with field-level errors instead of being silently dropped.
     """
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
-    status = body.get("status")
 
-    if status == "transcoding":
+    try:
+        payload = TranscodeCallbackPayload.model_validate(body)
+    except ValidationError as exc:
+        return JSONResponse(
+            {
+                "success": False,
+                "error": "Invalid callback payload",
+                "errors": [
+                    {"loc": list(e["loc"]), "msg": e["msg"], "type": e["type"]}
+                    for e in exc.errors()
+                ],
+            },
+            status_code=422,
+        )
+
+    if payload.status == JobStatus.transcoding:
         job.status = JobState.TRANSCODE_ACTIVE.value
-    elif status == "completed":
+    elif payload.status == JobStatus.completed:
         job.status = JobState.SUCCESS.value
         notification = Notifications(
             f"Job: {job.job_id} transcode complete",
             f"'{job.title}' transcoding finished successfully"
         )
         db.session.add(notification)
-    elif status == "partial":
+    elif payload.status == JobStatus.partial:
         # Some tracks succeeded, some failed
         job.status = JobState.SUCCESS.value
-        error_msg = body.get("error", "Some tracks failed to transcode")
+        error_msg = payload.error or "Some tracks failed to transcode"
         job.errors = error_msg
         notification = Notifications(
             f"Job: {job.job_id} transcode partial",
             f"'{job.title}' transcoding completed with errors: {error_msg}"
         )
         db.session.add(notification)
-    elif status == "failed":
+    elif payload.status == JobStatus.failed:
         job.status = JobState.FAILURE.value
-        error_msg = body.get("error", "Transcode failed")
+        error_msg = payload.error or "Transcode failed"
         job.errors = error_msg
         notification = Notifications(
             f"Job: {job.job_id} transcode failed",
@@ -1070,24 +1084,30 @@ def transcode_callback(job_id: int, body: dict):
         )
         db.session.add(notification)
     else:
+        # Other JobStatus members (pending/processing/cancelled) aren't
+        # produced by the transcoder for this endpoint, but they validate
+        # against the enum. Return 422 so observability catches the drift.
         return JSONResponse(
-            {"success": False, "error": f"Unknown status: {status}"},
-            status_code=400,
+            {
+                "success": False,
+                "error": (
+                    f"Status '{payload.status}' is not a valid callback "
+                    "outcome for this endpoint"
+                ),
+            },
+            status_code=422,
         )
 
     # Update per-track status from transcoder results
-    track_results = body.get("track_results")
-    if track_results and isinstance(track_results, list):
+    if payload.track_results:
         track_map = {str(t.track_number): t for t in job.tracks}
-        for tr in track_results:
-            track_num = str(tr.get("track_number", ""))
-            track = track_map.get(track_num)
+        for tr in payload.track_results:
+            track = track_map.get(str(tr.track_number))
             if track:
-                tr_status = tr.get("status", "")
-                if tr_status == "completed":
+                if tr.status == JobStatus.completed:
                     track.status = "transcoded"
-                elif tr_status == "failed":
-                    track.status = f"transcode_failed: {tr.get('error', '')[:200]}"
+                elif tr.status == JobStatus.failed:
+                    track.status = f"transcode_failed: {(tr.error or '')[:200]}"
 
     db.session.commit()
     return {"success": True, "job_id": job.job_id, "status": job.status}

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -189,67 +189,86 @@ def _move_to_shared_storage(cfg, raw_basename, job=None):
 def _build_webhook_payload(title, body, job, raw_basename):
     """Build the JSON payload for the transcoder webhook.
 
+    Returns a plain dict (the JSON body) but constructs it via the typed
+    arm_contracts.WebhookPayload model so any field-shape drift surfaces
+    here instead of as a 422 from the transcoder. The transcoder's
+    contracts model accepts the same wire shape verbatim.
+
     Includes pre-rendered naming from ARM's naming engine so the transcoder
-    doesn't need its own naming logic — ARM is the single source of truth
+    doesn't need its own naming logic - ARM is the single source of truth
     for folder/file naming patterns configured in arm.yaml.
     """
-    from arm.ripper.naming import render_folder, render_title, render_all_tracks, clean_for_filename
+    from arm_contracts import WebhookPayload, WebhookTrackMeta
+    from arm.ripper.naming import (
+        clean_for_filename, render_all_tracks, render_folder, render_title,
+    )
 
-    payload = {"title": title, "body": body, "type": "info"}
-    if raw_basename:
-        payload["path"] = raw_basename
-    if job is not None:
-        config_dict = cfg.arm_config if hasattr(cfg, 'arm_config') else None
-        payload["job_id"] = str(job.job_id)
-        payload["video_type"] = str(job.video_type or '')
-        payload["year"] = str(job.year or '')
-        payload["disctype"] = str(job.disctype or '')
-        payload["status"] = str(job.status or '')
-        payload["poster_url"] = str(job.poster_url or '')
-        # Pre-rendered names from ARM's naming engine (arm.yaml patterns)
-        # render_folder may contain '/' for nested dirs (e.g. "Title/Season 01")
-        # — it already sanitizes each segment, so don't strip slashes here.
-        payload["folder_name"] = render_folder(job, config_dict)
-        payload["title_name"] = clean_for_filename(render_title(job, config_dict))
-        # Route through _parse_transcode_overrides so corrupt/legacy rows are
-        # dropped with a WARN rather than shipped to the transcoder, which
-        # would 422 the webhook (see automatic-ripping-machine-transcoder
-        # PR #96 for the webhook parse-boundary check).
-        from arm.api.v1.jobs import _parse_transcode_overrides
-        overrides = _parse_transcode_overrides(job.transcode_overrides)
-        if overrides is not None:
-            payload["config_overrides"] = overrides
-        # Always include per-track manifest with pre-rendered filenames.
-        # ARM is the single source of truth for naming — the transcoder
-        # uses these names directly and never invents its own.
-        # render_all_tracks handles duplicate detection and custom filenames.
-        if getattr(job, 'multi_title', False):
-            payload["multi_title"] = True
-        rendered = render_all_tracks(job, config_dict)
-        # Build a lookup from track_number → rendered result
-        rendered_map = {r["track_number"]: r for r in rendered}
-        tracks_meta = []
-        for track in job.tracks:
-            r = rendered_map.get(str(track.track_number or ''), {})
-            tracks_meta.append({
-                "track_number": str(track.track_number or ''),
-                # Prefer episode_name for series tracks — track.title can be stale
-                # if the user corrected episodes via the UI after auto-match.
-                "title": str(getattr(track, 'episode_name', '') or track.title or job.title or ''),
-                "year": str(track.year or job.year or ''),
-                "video_type": str(track.video_type or job.video_type or ''),
-                "filename": str(track.filename or ''),
-                "has_custom_title": bool(track.title) or bool(getattr(track, 'custom_filename', None)),
-                "folder_name": r.get("rendered_folder", ''),
-                # clean_for_filename is idempotent; render_track_title already
-                # sanitizes custom_filename but raw pattern output needs it here.
-                "title_name": clean_for_filename(r.get("rendered_title", '')) if r.get("rendered_title") else '',
-                "episode_number": str(getattr(track, 'episode_number', '') or ''),
-                "episode_name": str(getattr(track, 'episode_name', '') or ''),
-            })
-        if tracks_meta:
-            payload["tracks"] = tracks_meta
-    return payload
+    if job is None:
+        # Notification-only path (no job context). Title/body/type only.
+        # WebhookPayload requires job_id, so we hand-build the dict here -
+        # the typed model is only meaningful for the job-bound transcode
+        # webhook the transcoder actually receives.
+        payload = {"title": title, "body": body, "type": "info"}
+        if raw_basename:
+            payload["path"] = raw_basename
+        return payload
+
+    config_dict = cfg.arm_config if hasattr(cfg, 'arm_config') else None
+    # Route through _parse_transcode_overrides so corrupt/legacy rows are
+    # dropped with a WARN rather than shipped to the transcoder, which
+    # would 422 the webhook (see automatic-ripping-machine-transcoder
+    # PR #96 for the webhook parse-boundary check).
+    from arm.api.v1.jobs import _parse_transcode_overrides
+    overrides_dict = _parse_transcode_overrides(job.transcode_overrides)
+
+    # Pre-rendered names from ARM's naming engine. render_folder may contain
+    # '/' for nested dirs (e.g. "Title/Season 01") - it already sanitizes
+    # each segment, so don't strip slashes here.
+    rendered = render_all_tracks(job, config_dict)
+    rendered_map = {r["track_number"]: r for r in rendered}
+    tracks_meta = []
+    for track in job.tracks:
+        r = rendered_map.get(str(track.track_number or ''), {})
+        # Prefer episode_name for series tracks - track.title can be stale
+        # if the user corrected episodes via the UI after auto-match.
+        title_str = (
+            getattr(track, 'episode_name', '') or track.title or job.title or ''
+        )
+        # clean_for_filename is idempotent; render_track_title already
+        # sanitizes custom_filename but raw pattern output needs it here.
+        rendered_title = r.get("rendered_title", '')
+        track_title_name = clean_for_filename(rendered_title) if rendered_title else ''
+        tracks_meta.append(WebhookTrackMeta(
+            track_number=str(track.track_number or ''),
+            title=str(title_str),
+            year=str(track.year or job.year or ''),
+            video_type=str(track.video_type or job.video_type or ''),
+            filename=str(track.filename or ''),
+            has_custom_title=bool(track.title) or bool(getattr(track, 'custom_filename', None)),
+            folder_name=r.get("rendered_folder", ''),
+            title_name=track_title_name,
+            episode_number=str(getattr(track, 'episode_number', '') or ''),
+            episode_name=str(getattr(track, 'episode_name', '') or ''),
+        ))
+
+    payload = WebhookPayload(
+        title=title,
+        body=body,
+        type="info",
+        path=raw_basename or None,
+        job_id=str(job.job_id),  # WebhookPayload coerces str -> int.
+        video_type=str(job.video_type or ''),
+        year=str(job.year or ''),
+        disctype=str(job.disctype or ''),
+        status=str(job.status or ''),
+        poster_url=str(job.poster_url or ''),
+        folder_name=render_folder(job, config_dict),
+        title_name=clean_for_filename(render_title(job, config_dict)),
+        config_overrides=overrides_dict,  # Pydantic coerces dict -> TranscodeJobConfig.
+        multi_title=True if getattr(job, 'multi_title', False) else None,
+        tracks=tracks_meta if tracks_meta else None,
+    )
+    return payload.model_dump(exclude_none=True, mode="json")
 
 
 def transcoder_notify(cfg, title, body, job=None) -> bool:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -2366,11 +2366,13 @@ class TestApiTranscodeCallback:
         assert response.status_code == 404
 
     def test_callback_unknown_status(self, client, sample_job, app_context):
+        # Pydantic enum validation now rejects unknown statuses with 422
+        # (structured) before the handler runs.
         response = client.post(
             f'/api/v1/jobs/{sample_job.job_id}/transcode-callback',
             json={"status": "invalid_status"}
         )
-        assert response.status_code == 400
+        assert response.status_code == 422
 
     def test_callback_transcoding(self, client, sample_job, app_context):
         response = client.post(

--- a/test/test_coverage_gaps_2.py
+++ b/test/test_coverage_gaps_2.py
@@ -66,7 +66,9 @@ class TestBuildWebhookPayload:
         assert payload["title"] == "Rip done"
         assert payload["body"] == "body text"
         assert payload["path"] == "SERIAL_MOM"
-        assert payload["job_id"] == str(sample_job.job_id)
+        # arm_contracts.WebhookPayload coerces job_id to int on the wire
+        # (contract decision; transcoder receiver accepts the int form).
+        assert payload["job_id"] == sample_job.job_id
         assert payload["video_type"] == "movie"
         assert payload["year"] == "1994"
         # multi_title flag not set when job.multi_title is False
@@ -301,14 +303,21 @@ class TestTranscodeCallback:
         t1 = Track.query.filter_by(job_id=job.job_id, track_number='1').first()
         assert t1.status == original_status
 
-    def test_unknown_status_returns_400(self, app_context, sample_job, client):
-        """Unknown status value returns 400."""
+    def test_unknown_status_returns_422(self, app_context, sample_job, client):
+        """Unknown status value returns 422 with structured field-level errors.
+
+        Pydantic enum validation rejects values outside JobStatus before
+        the handler runs; the structured response makes the field name
+        explicit so callers can fix their callback shape.
+        """
         resp = client.post(
             f"/api/v1/jobs/{sample_job.job_id}/transcode-callback",
             json={"status": "banana"},
         )
-        assert resp.status_code == 400
-        assert "Unknown status" in resp.json()["error"]
+        assert resp.status_code == 422
+        body = resp.json()
+        assert body["error"] == "Invalid callback payload"
+        assert any(e["loc"] == ["status"] for e in body["errors"])
 
     def test_nonexistent_job_returns_404(self, app_context, client):
         """Callback for nonexistent job returns 404."""


### PR DESCRIPTION
## Summary
Wires arm-neu up to the typed cross-service models that landed in **arm-contracts v0.3.0** (webhook + callback) plus the **v0.4.0** addition of `JobStatus.transcoding`. Wire shape is unchanged - drift between this repo and the transcoder now surfaces in submodule-lockstep CI instead of as a 422 in production.

This is the producer + consumer arm-neu side of the cross-service contract that the transcoder adopted in [transcoder PR #120](https://github.com/uprightbass360/automatic-ripping-machine-transcoder/pull/120).

## Producer side: `arm/ripper/utils.py:_build_webhook_payload`
- Constructs the transcoder webhook through `arm_contracts.WebhookPayload` + `WebhookTrackMeta` instead of an ad-hoc dict.
- Wire shape unchanged with one nuance: `job_id` now dumps as `int` rather than `str` - the contract already does this coercion and the transcoder receiver accepts it (see `contracts/tests/fixtures/webhook_payload.json` for the canonical shape).
- The notification-only branch (`job is None`) keeps a plain dict since it has no `job_id` and the typed model would reject it; that path doesn't hit the transcoder anyway.

## Consumer side: `arm/api/v1/jobs.py:transcode_callback`
- Validates the inbound body against `arm_contracts.TranscodeCallbackPayload`.
- Status comparison switches from string literals to `JobStatus` enum members. Uses `JobStatus.transcoding` (callback-wire-only enum member added in contracts v0.4.0) for the informational heartbeat.
- Schema mismatches (unknown status, malformed track_results) return **422** with field-level errors instead of plain 400 - matches the routing change shipped in transcoder PR #120 for symmetry.

## Submodule
`components/contracts` bumped to **v0.4.0**.

## Test plan
- [x] All 1981 backend tests pass locally
- [x] Companion transcoder PR #124 bumps the transcoder's contracts submodule to v0.4.0 in lockstep
- [ ] CI green
- [ ] Manual: end-to-end disc rip on hifi-server with this build, confirm transcoder webhook + callback round-trip works as before

## Compatibility
- Producer: existing transcoders accept the wire shape (job_id flip from str-int is a no-op since the contract has accepted both since v0.3.0)
- Consumer: requires transcoder to be running with contracts v0.3.0+ on the wire (which it has been since the v17.3.0 release)