### PR TITLE
feat: decouple arm-ui from ripper-side bind mounts

### DIFF
--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -10,7 +10,6 @@ ARM + UI on the **ripping host** and Transcoder on the **GPU host**.
 │                              │              │                              │
 │  arm-rippers  (rip discs)    │   webhook    │  arm-transcoder (GPU encode) │
 │  arm-ui       (dashboard)    │─────────────►│                              │
-│  arm-hb-presets              │              │                              │
 │  arm-db-init                 │              │                              │
 │                              │              │                              │
 │  /home/arm/media/raw/  ──────┤── NFS ──────►│  /mnt/media/raw/   (ro)      │

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,10 +21,6 @@ services:
       - ./dev-data/config:/etc/arm/config
       - ./dev-data/makemkv:/home/arm/.MakeMKV
 
-  arm-hb-presets:
-    volumes:
-      - ./dev-data/hb-presets:/data/hb-presets
-
   arm-ui:
     build: ${UI_SRC_PATH:-../automatic-ripping-machine-ui}
     command:
@@ -39,10 +35,11 @@ services:
       - ${UI_SRC_PATH:-../automatic-ripping-machine-ui}/backend:/app/backend:ro
       - ${UI_SRC_PATH:-../automatic-ripping-machine-ui}/frontend/build:/app/frontend/build:ro
       - ./dev-data/logs:/data/logs:ro
-      - ./dev-data/config:/data/arm-config:rw
-      - ./dev-data/config/themes:/data/config/themes:rw
       - ./dev-data/cache/images:/data/cache/images:rw
-      - ./dev-data/hb-presets:/data/hb-presets:ro
+      # Override the base file's legacy themes ro bind to point at the dev
+      # config dir (the same one arm-rippers mounts r/w at /etc/arm/config).
+      # Lets the dev migrator find any themes you've dropped there.
+      - ./dev-data/config/themes:/data/config/themes:ro
 
   arm-transcoder:
     build:
@@ -63,7 +60,16 @@ services:
       - DELETE_SOURCE=false
       - MINIMUM_FREE_SPACE_GB=1
     volumes:
-      - ${TRANSCODER_SRC_PATH:-../automatic-ripping-machine-transcoder}/src:/app:ro
+      # NB: /app is mounted rw (not ro) so docker can create the
+      # /app/components mountpoint for the contracts re-mount below.
+      # The container runs as a non-root user and main.py doesn't write
+      # back to /app at runtime; rw is functionally equivalent for dev.
+      - ${TRANSCODER_SRC_PATH:-../automatic-ripping-machine-transcoder}/src:/app
+      # Re-mount the arm_contracts package alongside src. The src bind
+      # shadows the image's /app/components and the editable-install
+      # .pth points at /app/components/contracts/src, so without this
+      # `import arm_contracts` fails inside the dev container.
+      - ${TRANSCODER_SRC_PATH:-../automatic-ripping-machine-transcoder}/components/contracts:/app/components/contracts:ro
       - ${TRANSCODER_SRC_PATH:-../automatic-ripping-machine-transcoder}/VERSION:/etc/arm-transcoder-version:ro
       - ${TRANSCODER_SRC_PATH:-../automatic-ripping-machine-transcoder}/presets:/config/presets:ro
       - ./dev-data/transcoder-logs:/data/logs:rw

--- a/docker-compose.remote-transcoder.yml
+++ b/docker-compose.remote-transcoder.yml
@@ -12,31 +12,6 @@ services:
     command: chown -R ${ARM_UID:-1000}:${ARM_GID:-1000} /data/db
     restart: "no"
 
-  # Dump HandBrake built-in presets to JSON for the UI settings page.
-  # Uses the transcoder image (which bundles HandBrakeCLI).
-  arm-hb-presets:
-    image: uprightbass360/arm-transcoder:${TRANSCODER_VERSION:-latest}
-    container_name: arm-hb-presets
-    user: root
-    volumes:
-      - hb-presets:/data/hb-presets
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        HandBrakeCLI --preset-list 2>&1 | python3 -c "
-        import json, sys, re
-        names = []
-        for line in sys.stdin:
-            m = re.match(r'^    (\S.+)$', line.rstrip())
-            if m:
-                name = m.group(1)
-                if not any(c in name for c in ['/', ':', '(']):
-                    names.append(name)
-        json.dump(sorted(set(names)), open('/data/hb-presets/presets.json', 'w'), indent=2)
-        print(f'Wrote {len(names)} HandBrake presets')
-        "
-    restart: "no"
-
   # ARM ripper — creates the database on first startup
   arm-rippers:
     image: uprightbass360/automatic-ripping-machine:${ARM_VERSION:-latest}
@@ -81,27 +56,27 @@ services:
       - "${UI_PORT:-8888}:8888"
     environment:
       - ARM_UI_ARM_LOG_PATH=/data/logs
-      - ARM_UI_ARM_CONFIG_PATH=/data/arm-config/arm.yaml
       - ARM_UI_ARM_URL=http://arm-rippers:8080
       - ARM_UI_TRANSCODER_URL=http://${TRANSCODER_HOST}:${TRANSCODER_PORT:-5000}
-      - ARM_UI_ARM_HB_PRESETS_PATH=/data/hb-presets/presets.json
       - ARM_UI_TRANSCODER_API_KEY=${TRANSCODER_API_KEY:-}
-      - ARM_UI_ARM_THEMES_PATH=/data/config/themes
+      - ARM_UI_TRANSCODER_WEBHOOK_SECRET=${WEBHOOK_SECRET:-}
+      - ARM_UI_THEMES_PATH=/data/themes
       - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
       - ${ARM_LOGS_PATH}:/data/logs:ro
-      - ${ARM_CONFIG_PATH}:/data/arm-config:rw
-      - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:rw
+      - arm-ui-themes:/data/themes:rw
       - ui-image-cache:/data/cache/images:rw
-      - hb-presets:/data/hb-presets:ro
+      # One-release migration shim: legacy themes path under the ripper config
+      # bind. arm-ui's startup migrator copies any *.json/*.css from here to
+      # arm-ui-themes the first time the named volume is empty. Drop this
+      # bind in the next release once existing deploys have rolled through.
+      - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:ro
     depends_on:
       arm-rippers:
         condition: service_healthy
-      arm-hb-presets:
-        condition: service_completed_successfully
 
 volumes:
   arm-db:
   makemkv-settings:
-  hb-presets:
   ui-image-cache:
+  arm-ui-themes:

--- a/docker-compose.ripper-only.yml
+++ b/docker-compose.ripper-only.yml
@@ -62,16 +62,19 @@ services:
       - "${UI_PORT:-8888}:8888"
     environment:
       - ARM_UI_ARM_LOG_PATH=/data/logs
-      - ARM_UI_ARM_CONFIG_PATH=/data/arm-config/arm.yaml
       - ARM_UI_ARM_URL=http://arm-rippers:8080
       - ARM_UI_TRANSCODER_ENABLED=false
-      - ARM_UI_ARM_THEMES_PATH=/data/config/themes
+      - ARM_UI_THEMES_PATH=/data/themes
       - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
       - ${ARM_LOGS_PATH}:/data/logs:ro
-      - ${ARM_CONFIG_PATH}:/data/arm-config:rw
-      - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:rw
+      - arm-ui-themes:/data/themes:rw
       - ui-image-cache:/data/cache/images:rw
+      # One-release migration shim: legacy themes path under the ripper config
+      # bind. arm-ui's startup migrator copies any *.json/*.css from here to
+      # arm-ui-themes the first time the named volume is empty. Drop this
+      # bind in the next release once existing deploys have rolled through.
+      - ${ARM_CONFIG_PATH}/themes:/data/config/themes:ro
     depends_on:
       arm-rippers:
         condition: service_healthy
@@ -80,3 +83,4 @@ volumes:
   arm-db:
   makemkv-settings:
   ui-image-cache:
+  arm-ui-themes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,30 +14,6 @@ services:
     command: chown -R ${ARM_UID:-1000}:${ARM_GID:-1000} /data/db
     restart: "no"
 
-  # Dump HandBrake built-in presets to JSON for the UI settings page
-  arm-hb-presets:
-    image: uprightbass360/arm-transcoder:${TRANSCODER_VERSION:-latest}
-    container_name: arm-hb-presets
-    user: root
-    volumes:
-      - hb-presets:/data/hb-presets
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        HandBrakeCLI --preset-list 2>&1 | python3 -c "
-        import json, sys, re
-        names = []
-        for line in sys.stdin:
-            m = re.match(r'^    (\S.+)$', line.rstrip())
-            if m:
-                name = m.group(1)
-                if not any(c in name for c in ['/', ':', '(']):
-                    names.append(name)
-        json.dump(sorted(set(names)), open('/data/hb-presets/presets.json', 'w'), indent=2)
-        print(f'Wrote {len(names)} HandBrake presets')
-        "
-    restart: "no"
-
   # ARM ripper — creates the database on first startup
   arm-rippers:
     image: uprightbass360/automatic-ripping-machine:${ARM_VERSION:-latest}
@@ -91,24 +67,24 @@ services:
       - "${UI_PORT:-8888}:8888"
     environment:
       - ARM_UI_ARM_LOG_PATH=/data/logs
-      - ARM_UI_ARM_CONFIG_PATH=/data/arm-config/arm.yaml
       - ARM_UI_ARM_URL=http://arm-rippers:8080
       - ARM_UI_TRANSCODER_URL=${ARM_UI_TRANSCODER_URL:-http://arm-transcoder:5000}
-      - ARM_UI_ARM_HB_PRESETS_PATH=/data/hb-presets/presets.json
       - ARM_UI_TRANSCODER_API_KEY=${TRANSCODER_API_KEY:-}
-      - ARM_UI_ARM_THEMES_PATH=/data/config/themes
+      - ARM_UI_TRANSCODER_WEBHOOK_SECRET=${WEBHOOK_SECRET:-}
+      - ARM_UI_THEMES_PATH=/data/themes
       - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
       - ${ARM_LOGS_PATH}:/data/logs:ro
-      - ${ARM_CONFIG_PATH}:/data/arm-config:rw
-      - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:rw
+      - arm-ui-themes:/data/themes:rw
       - ui-image-cache:/data/cache/images:rw
-      - hb-presets:/data/hb-presets:ro
+      # One-release migration shim: legacy themes path under the ripper config
+      # bind. arm-ui's startup migrator copies any *.json/*.css from here to
+      # arm-ui-themes the first time the named volume is empty. Drop this
+      # bind in the next release once existing deploys have rolled through.
+      - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:ro
     depends_on:
       arm-rippers:
         condition: service_healthy
-      arm-hb-presets:
-        condition: service_completed_successfully
 
   # Fix ownership on the transcoder work directory before it starts.
   # Docker creates bind-mount targets as root; the transcoder entrypoint
@@ -190,5 +166,5 @@ volumes:
   makemkv-settings:
   transcoder-db:
   transcoder-logs:
-  hb-presets:
   ui-image-cache:
+  arm-ui-themes:


### PR DESCRIPTION
## Summary

PR #1 of the UI bind-mount decoupling project. After this lands, the arm-ui block needs no bind mounts to the ripper at all on the next release; only the read-only logs bind remains, retired in PR #2 (see `project_logs_api_pr2.md`).

Three sub-changes bundled (each small, all touch the same compose stacks):

- **Webhook secret via env injection.** All three production stacks now wire `ARM_UI_TRANSCODER_WEBHOOK_SECRET=${WEBHOOK_SECRET:-}`, mirroring how the ripper already gets `ARM_TRANSCODER_WEBHOOK_SECRET`. arm-ui no longer needs to read `arm.yaml` from a shared bind.
- **Themes own named volume.** arm-rippers and arm-ui used to share `/etc/arm/config/themes`. Themes are pure UI state, so they move to a UI-owned named volume `arm-ui-themes`. Existing-deploy migration: a one-release read-only bind from `${ARM_CONFIG_PATH}/themes:/data/config/themes:ro` lets arm-ui's first-boot migrator copy any pre-existing themes into the new volume. Drop in next release (tracked in `project_drop_legacy_themes_bind.md`).
- **HandBrake presets pipeline deleted.** `arm-hb-presets` init container, `hb-presets` named volume, and the bind on arm-rippers all removed. The pipeline fed `SettingsResponse.arm_handbrake_presets` but no Svelte component ever consumed it - the HandBrake preset field in `PresetEditor` is a free-text input. A real picker should be served by a future transcoder endpoint (HandBrakeCLI lives in the transcoder image already), filed as a deferred polish item.

Pair with [arm-ui PR](https://github.com/uprightbass360/automatic-ripping-machine-ui/pulls?q=is%3Apr+head%3Afeat%2Fdecouple-config-themes-presets) - it carries the corresponding backend + frontend changes. Both PRs must merge together.

## Test plan

- [x] All four compose files validate (`docker compose config --quiet`)
- [x] Local dev stack `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build` brings everything up
- [x] arm-ui starts cleanly with empty `WEBHOOK_SECRET` (transcoder skips enforcement, no header sent)
- [x] `/api/settings` returns no `arm_handbrake_presets` field; `transcoder_auth_status.webhook_secret_configured: false`
- [x] `/api/themes` serves built-ins; named volume `arm-ui-themes` created empty
- [ ] Production deploy on hifi-server: existing custom themes (if any) migrate from legacy bind to named volume on first arm-ui restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)