### PR TITLE
chore: drop legacy themes ro-bind shim

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,10 +36,6 @@ services:
       - ${UI_SRC_PATH:-../automatic-ripping-machine-ui}/frontend/build:/app/frontend/build:ro
       - ./dev-data/logs:/data/logs:ro
       - ./dev-data/cache/images:/data/cache/images:rw
-      # Override the base file's legacy themes ro bind to point at the dev
-      # config dir (the same one arm-rippers mounts r/w at /etc/arm/config).
-      # Lets the dev migrator find any themes you've dropped there.
-      - ./dev-data/config/themes:/data/config/themes:ro
 
   arm-transcoder:
     build:

--- a/docker-compose.remote-transcoder.yml
+++ b/docker-compose.remote-transcoder.yml
@@ -66,11 +66,6 @@ services:
       - ${ARM_LOGS_PATH}:/data/logs:ro
       - arm-ui-themes:/data/themes:rw
       - ui-image-cache:/data/cache/images:rw
-      # One-release migration shim: legacy themes path under the ripper config
-      # bind. arm-ui's startup migrator copies any *.json/*.css from here to
-      # arm-ui-themes the first time the named volume is empty. Drop this
-      # bind in the next release once existing deploys have rolled through.
-      - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:ro
     depends_on:
       arm-rippers:
         condition: service_healthy

--- a/docker-compose.ripper-only.yml
+++ b/docker-compose.ripper-only.yml
@@ -70,11 +70,6 @@ services:
       - ${ARM_LOGS_PATH}:/data/logs:ro
       - arm-ui-themes:/data/themes:rw
       - ui-image-cache:/data/cache/images:rw
-      # One-release migration shim: legacy themes path under the ripper config
-      # bind. arm-ui's startup migrator copies any *.json/*.css from here to
-      # arm-ui-themes the first time the named volume is empty. Drop this
-      # bind in the next release once existing deploys have rolled through.
-      - ${ARM_CONFIG_PATH}/themes:/data/config/themes:ro
     depends_on:
       arm-rippers:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,11 +77,6 @@ services:
       - ${ARM_LOGS_PATH}:/data/logs:ro
       - arm-ui-themes:/data/themes:rw
       - ui-image-cache:/data/cache/images:rw
-      # One-release migration shim: legacy themes path under the ripper config
-      # bind. arm-ui's startup migrator copies any *.json/*.css from here to
-      # arm-ui-themes the first time the named volume is empty. Drop this
-      # bind in the next release once existing deploys have rolled through.
-      - ${ARM_CONFIG_PATH:-/etc/arm/config}/themes:/data/config/themes:ro
     depends_on:
       arm-rippers:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Removes the one-release \`\${ARM_CONFIG_PATH}/themes:/data/config/themes:ro\` shim added by #282. After production verification on hifi-server confirmed no custom themes existed at the legacy path, the migration scaffolding is unneeded.

Changes:
- \`docker-compose.yml\`, \`docker-compose.remote-transcoder.yml\`, \`docker-compose.ripper-only.yml\`: drop the ro-bind from the arm-ui block
- \`docker-compose.dev.yml\`: drop the dev-data override (no longer needed since base no longer has the shim)

After this PR the arm-ui block has zero binds to the ripper's filesystem; only the read-only logs bind remains, retired in PR #2 (logs API).

Pair with arm-ui PR https://github.com/uprightbass360/automatic-ripping-machine-ui/pulls?q=is%3Apr+head%3Afeat%2Fdrop-legacy-themes-shim which removes the matching backend module.

## Test plan

- [x] Compose validates (\`docker compose config --quiet\`)
- [x] hifi-server already confirmed: \`/data/config/themes\` was empty pre-deploy, no migration ever needed
- [ ] Re-deploy on hifi after merge, verify nothing breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)