### PR TITLE
feat: logs API + realtime progress in progress-state (PR #2 of UI bind-mount decoupling)

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -26,6 +26,7 @@ from arm.models.notifications import Notifications
 from arm.ripper.folder_ripper import rip_folder
 from arm.services import jobs as svc_jobs
 from arm.services import files as svc_files
+from arm.services import progress_reader
 
 _JOB_NOT_FOUND = "Job not found"
 _NOT_WAITING = "Job is not in waiting state"
@@ -919,18 +920,28 @@ def get_job_track_counts(job_id: int):
 @router.get('/jobs/{job_id}/progress-state')
 def get_job_progress_state(job_id: int):
     """Return the small bundle of job fields the UI's progress endpoint needs:
-    track counts plus disctype / logfile / no_of_titles. One round-trip
-    instead of three, so the dashboard's per-job progress polls stay cheap.
+    track counts plus disctype / logfile / no_of_titles, plus realtime
+    MakeMKV PRGV progress and abcde music progress parsed from the
+    progress + log files. One round-trip instead of three.
     """
     job = Job.query.get(job_id)
     if not job:
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
     counts = svc_jobs.track_counts(job)
+
+    rip = progress_reader.get_rip_progress(job_id)
+    music = progress_reader.get_music_progress(job.logfile, job.no_of_titles or 0)
+
     return {
         "track_counts": counts,
         "disctype": job.disctype,
         "logfile": job.logfile,
         "no_of_titles": job.no_of_titles,
+        "rip_progress": rip["progress"],
+        "rip_stage": rip["stage"],
+        "tracks_ripped_realtime": rip["tracks_ripped"],
+        "music_progress": music["progress"],
+        "music_stage": music["stage"],
     }
 
 

--- a/arm/api/v1/logs.py
+++ b/arm/api/v1/logs.py
@@ -1,13 +1,77 @@
-"""API v1 — Log endpoints."""
-from fastapi import APIRouter
+"""API v1 - Log endpoints."""
+from fastapi import APIRouter, Query
+from fastapi.responses import FileResponse, JSONResponse
 
 from arm.services import jobs as svc_jobs
+from arm.services import log_parser
 import arm.config.config as cfg
 
 router = APIRouter(prefix="/api/v1", tags=["logs"])
+
+
+_NOT_FOUND = "Log file not found"
 
 
 @router.get('/jobs/{job_id}/log')
 def get_job_log(job_id: int):
     """Get the full log for a job."""
     return svc_jobs.generate_log(cfg.arm_config['LOGPATH'], str(job_id))
+
+
+@router.get('/logs')
+def list_logs():
+    """List all log files in LOGPATH (newest first)."""
+    return log_parser.list_logs()
+
+
+@router.get('/logs/{filename}')
+def read_log(
+    filename: str,
+    mode: str = Query("tail", pattern="^(tail|full)$"),
+    lines: int = Query(100, ge=1, le=10000),
+):
+    """Read a log file. mode=tail returns the last N lines (default);
+    mode=full returns the whole file capped at 10 MB (truncated=true).
+    """
+    result = log_parser.read_log(filename, mode=mode, lines=lines)
+    if result is None:
+        return JSONResponse({"error": _NOT_FOUND}, status_code=404)
+    return result
+
+
+@router.get('/logs/{filename}/structured')
+def read_structured_log(
+    filename: str,
+    mode: str = Query("tail", pattern="^(tail|full)$"),
+    lines: int = Query(100, ge=1, le=10000),
+    level: str | None = Query(None),
+    search: str | None = Query(None),
+):
+    """Parsed log lines with optional level and substring filter."""
+    result = log_parser.read_structured_log(
+        filename, mode=mode, lines=lines, level=level, search=search,
+    )
+    if result is None:
+        return JSONResponse({"error": _NOT_FOUND}, status_code=404)
+    return result
+
+
+@router.get('/logs/{filename}/download')
+def download_log(filename: str):
+    """Stream the raw log file as text/plain for download."""
+    log_path = log_parser.resolve_log_path(filename)
+    if log_path is None:
+        return JSONResponse({"error": _NOT_FOUND}, status_code=404)
+    return FileResponse(
+        path=str(log_path),
+        filename=log_path.name,
+        media_type="text/plain",
+    )
+
+
+@router.delete('/logs/{filename}')
+def delete_log(filename: str):
+    """Delete a log file by name. Path traversal attempts are rejected."""
+    if not log_parser.delete_log(filename):
+        return JSONResponse({"error": _NOT_FOUND}, status_code=404)
+    return {"success": True, "filename": filename}

--- a/arm/api/v1/logs.py
+++ b/arm/api/v1/logs.py
@@ -1,4 +1,6 @@
 """API v1 - Log endpoints."""
+from typing import Annotated
+
 from fastapi import APIRouter, Query
 from fastapi.responses import FileResponse, JSONResponse
 
@@ -27,8 +29,8 @@ def list_logs():
 @router.get('/logs/{filename}')
 def read_log(
     filename: str,
-    mode: str = Query("tail", pattern="^(tail|full)$"),
-    lines: int = Query(100, ge=1, le=10000),
+    mode: Annotated[str, Query(pattern="^(tail|full)$")] = "tail",
+    lines: Annotated[int, Query(ge=1, le=10000)] = 100,
 ):
     """Read a log file. mode=tail returns the last N lines (default);
     mode=full returns the whole file capped at 10 MB (truncated=true).
@@ -42,10 +44,10 @@ def read_log(
 @router.get('/logs/{filename}/structured')
 def read_structured_log(
     filename: str,
-    mode: str = Query("tail", pattern="^(tail|full)$"),
-    lines: int = Query(100, ge=1, le=10000),
-    level: str | None = Query(None),
-    search: str | None = Query(None),
+    mode: Annotated[str, Query(pattern="^(tail|full)$")] = "tail",
+    lines: Annotated[int, Query(ge=1, le=10000)] = 100,
+    level: Annotated[str | None, Query()] = None,
+    search: Annotated[str | None, Query()] = None,
 ):
     """Parsed log lines with optional level and substring filter."""
     result = log_parser.read_structured_log(

--- a/arm/services/log_parser.py
+++ b/arm/services/log_parser.py
@@ -11,10 +11,17 @@ import arm.config.config as cfg
 
 # ARM plain text log format: "{timestamp} {logger}: {LEVEL}: {message}"
 # e.g. "02-28-2026 04:59:16 ARM: INFO: Ripping complete"
+# Anchor with \S at the very start to defeat the polynomial-ReDoS path
+# (py/polynomial-redos): leading-space input would otherwise force the
+# engine to backtrack every (.+?)\s+ split point.
 _ARM_PLAIN_RE = re.compile(
-    r'^(.+?)\s+(\w+):\s+(DEBUG|INFO|WARNING|ERROR|CRITICAL):\s*(.*)',
+    r'^(\S.{0,500}?)\s+(\w+):\s+(DEBUG|INFO|WARNING|ERROR|CRITICAL):\s*(.*)',
     re.IGNORECASE,
 )
+
+# Hard cap on per-line parsing to make the regex matchers linear under
+# any input. Real ARM log lines are well under this.
+_MAX_LINE_LEN = 8 * 1024
 
 # Wrapper script format: "{weekday} {month} {day} {time} [{AM/PM}] {TZ} {year} [{logger}] {message}"
 _WRAPPER_BRACKET_RE = re.compile(
@@ -136,6 +143,15 @@ def read_log(filename: str, mode: str = "tail", lines: int = 100) -> dict | None
 def _parse_log_line(line: str) -> dict:
     """Parse a single log line: JSON, ARM plain, wrapper, or ISO bracketed."""
     line = line.rstrip("\n")
+    # Defence against ReDoS on adversarial log content: skip parsing on
+    # absurdly long lines and just hand back the raw text. Real ARM lines
+    # are short; a multi-KB line is either a stack trace or an attack.
+    if len(line) > _MAX_LINE_LEN:
+        return {
+            "timestamp": "", "level": "info", "logger": "",
+            "event": line[:_MAX_LINE_LEN] + "...",
+            "job_id": None, "label": None, "raw": line,
+        }
     try:
         parsed = json.loads(line)
         return {

--- a/arm/services/log_parser.py
+++ b/arm/services/log_parser.py
@@ -1,0 +1,237 @@
+"""Structured log parsing - ported from arm-ui's log_reader for the v1 API."""
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import arm.config.config as cfg
+
+# ARM plain text log format: "{timestamp} {logger}: {LEVEL}: {message}"
+# e.g. "02-28-2026 04:59:16 ARM: INFO: Ripping complete"
+_ARM_PLAIN_RE = re.compile(
+    r'^(.+?)\s+(\w+):\s+(DEBUG|INFO|WARNING|ERROR|CRITICAL):\s*(.*)',
+    re.IGNORECASE,
+)
+
+# Wrapper script format: "{weekday} {month} {day} {time} [{AM/PM}] {TZ} {year} [{logger}] {message}"
+_WRAPPER_BRACKET_RE = re.compile(
+    r'^(\w{3}\s+\w{3}\s+\d+\s+[\d:]+(?:\s+[AP]M)?\s+\w+\s+\d{4})\s+\[(\w+)\]\s*(.*)',
+)
+
+# ISO timestamp with bracket logger: "{YYYY-MM-DD HH:MM:SS} [{logger}] {message}"
+_ISO_BRACKET_RE = re.compile(
+    r'^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})\s+\[(\w+)\]\s*(.*)',
+)
+
+# Wrapper script format without logger: "{timestamp} {message}"
+_WRAPPER_PLAIN_RE = re.compile(
+    r'^(\w{3}\s+\w{3}\s+\d+\s+[\d:]+(?:\s+[AP]M)?\s+\w+\s+\d{4})\s+(.*)',
+)
+
+
+def _log_dir() -> Path:
+    return Path(cfg.arm_config["LOGPATH"])
+
+
+def _resolve_within(name: str, root: Path) -> Path | None:
+    """Resolve a filename safely within root, stripping any directory components."""
+    try:
+        safe_name = Path(name).name
+        if not safe_name or safe_name in ('.', '..'):
+            return None
+        resolved = (root / safe_name).resolve()
+        if resolved.is_relative_to(root.resolve()):
+            return resolved
+    except (ValueError, OSError):
+        pass
+    return None
+
+
+def list_logs() -> list[dict[str, Any]]:
+    """List all *.log files in the ARM log directory, newest first."""
+    log_dir = _log_dir()
+    if not log_dir.is_dir():
+        return []
+
+    logs = []
+    for entry in sorted(log_dir.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+        if entry.is_file() and entry.suffix == ".log":
+            stat = entry.stat()
+            logs.append({
+                "filename": entry.name,
+                "size": stat.st_size,
+                "modified": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+            })
+    return logs
+
+
+def resolve_log_path(filename: str) -> Path | None:
+    """Resolve a log filename to an absolute path under LOGPATH, or None."""
+    resolved = _resolve_within(filename, _log_dir())
+    if resolved is None or not resolved.is_file():
+        return None
+    return resolved
+
+
+def delete_log(filename: str) -> bool:
+    """Delete a log file. Returns True on success, False if not found."""
+    log_path = resolve_log_path(filename)
+    if log_path is None:
+        return False
+    try:
+        log_path.unlink()
+        return True
+    except OSError:
+        return False
+
+
+# Cap on full-mode reads to protect the API thread pool. Active-job logs
+# can grow to hundreds of MB on a long Blu-ray rip; tail mode is the
+# default precisely so callers don't pull the whole thing every poll.
+_FULL_MODE_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def read_log(filename: str, mode: str = "tail", lines: int = 100) -> dict | None:
+    """Read a log file. Mode is 'tail' (last N lines) or 'full'."""
+    log_path = resolve_log_path(filename)
+    if log_path is None:
+        return None
+
+    truncated = False
+    try:
+        if mode == "full":
+            size = log_path.stat().st_size
+            if size > _FULL_MODE_MAX_BYTES:
+                with open(log_path, "rb") as f:
+                    f.seek(-_FULL_MODE_MAX_BYTES, 2)
+                    data = f.read().decode("utf-8", errors="replace")
+                # Drop the partial first line so callers don't see a fragment.
+                content = data.split("\n", 1)[1] if "\n" in data else data
+                truncated = True
+                line_count = content.count("\n")
+            else:
+                with open(log_path, "r", errors="replace") as f:
+                    content = f.read()
+                line_count = content.count("\n")
+        else:
+            with open(log_path, "r", errors="replace") as f:
+                all_lines = f.readlines()
+            tail = all_lines[-lines:] if len(all_lines) > lines else all_lines
+            content = "".join(tail)
+            line_count = len(tail)
+    except OSError:
+        return None
+
+    return {
+        "filename": filename,
+        "content": content,
+        "lines": line_count,
+        "truncated": truncated,
+    }
+
+
+def _parse_log_line(line: str) -> dict:
+    """Parse a single log line: JSON, ARM plain, wrapper, or ISO bracketed."""
+    line = line.rstrip("\n")
+    try:
+        parsed = json.loads(line)
+        return {
+            "timestamp": parsed.get("timestamp", ""),
+            "level": parsed.get("level", "info"),
+            "logger": parsed.get("logger", ""),
+            "event": parsed.get("event", ""),
+            "job_id": parsed.get("job_id"),
+            "label": parsed.get("label"),
+            "raw": line,
+        }
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    m = _ARM_PLAIN_RE.match(line)
+    if m:
+        return {
+            "timestamp": m.group(1).strip(),
+            "level": m.group(3).lower(),
+            "logger": m.group(2),
+            "event": m.group(4),
+            "job_id": None,
+            "label": None,
+            "raw": line,
+        }
+
+    m = _WRAPPER_BRACKET_RE.match(line)
+    if m:
+        return {
+            "timestamp": m.group(1).strip(),
+            "level": "info",
+            "logger": m.group(2),
+            "event": m.group(3),
+            "job_id": None,
+            "label": None,
+            "raw": line,
+        }
+
+    m = _ISO_BRACKET_RE.match(line)
+    if m:
+        return {
+            "timestamp": m.group(1).strip(),
+            "level": "info",
+            "logger": m.group(2),
+            "event": m.group(3),
+            "job_id": None,
+            "label": None,
+            "raw": line,
+        }
+
+    m = _WRAPPER_PLAIN_RE.match(line)
+    if m:
+        return {
+            "timestamp": m.group(1).strip(),
+            "level": "info",
+            "logger": "wrapper",
+            "event": m.group(2),
+            "job_id": None,
+            "label": None,
+            "raw": line,
+        }
+
+    return {
+        "timestamp": "",
+        "level": "info",
+        "logger": "",
+        "event": line,
+        "job_id": None,
+        "label": None,
+        "raw": line,
+    }
+
+
+def read_structured_log(
+    filename: str,
+    mode: str = "tail",
+    lines: int = 100,
+    level: str | None = None,
+    search: str | None = None,
+) -> dict | None:
+    """Read and parse a log file with optional level + substring filter."""
+    raw = read_log(filename, mode=mode, lines=lines)
+    if raw is None:
+        return None
+
+    entries = [_parse_log_line(l) for l in raw["content"].splitlines() if l.strip()]
+
+    if level:
+        entries = [e for e in entries if e["level"] == level.lower()]
+    if search:
+        search_lower = search.lower()
+        entries = [e for e in entries if search_lower in e["event"].lower()]
+
+    return {
+        "filename": filename,
+        "entries": entries,
+        "lines": len(entries),
+        "truncated": raw.get("truncated", False),
+    }

--- a/arm/services/progress_reader.py
+++ b/arm/services/progress_reader.py
@@ -1,0 +1,149 @@
+"""Read realtime rip progress from MakeMKV PRGV/PRGC/PRGT progress files
+and abcde music progress from job logs.
+
+MakeMKV writes real-time PRGV/PRGC messages to a dedicated progress file
+at {LOGPATH}/progress/{job_id}.log via the ``--progress=`` flag.  This is
+separate from the main job log which only receives this data after the
+subprocess completes (stdout is buffered).
+
+Ported from arm-ui's backend/services/progress.py so the BFF can read
+this data over HTTP instead of needing the LOGPATH bind mount.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import arm.config.config as cfg
+
+
+def _safe_log_path(*parts: str) -> Path | None:
+    """Resolve a path under LOGPATH, refusing anything that escapes it."""
+    root = Path(cfg.arm_config["LOGPATH"]).resolve()
+    candidate = (root / Path(*parts)).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
+def _parse_progress_lines(lines: list[str]):
+    """Scan MakeMKV progress lines and return (last_prgv, last_prgc, last_prgt)."""
+    last_prgv = None
+    last_prgc = None
+    last_prgt = None
+    for line in lines:
+        if line.startswith("PRGT:"):
+            m = re.match(r'PRGT:\d+,\d+,"([^"]+)"', line)
+            if m:
+                last_prgt = m.group(1)
+        elif line.startswith("PRGV:"):
+            m = re.match(r"PRGV:(\d+),(\d+),(\d+)", line)
+            if m:
+                last_prgv = m
+        elif line.startswith("PRGC:"):
+            m = re.match(r'PRGC:\d+,(\d+),"([^"]+)"', line)
+            if m:
+                last_prgc = m
+    return last_prgv, last_prgc, last_prgt
+
+
+def get_rip_progress(job_id: int) -> dict[str, Any]:
+    """Parse MakeMKV progress from a job's progress file.
+
+    Returns ``{progress: float|None, stage: str|None, tracks_ripped: int|None}``.
+    """
+    result: dict[str, Any] = {"progress": None, "stage": None, "tracks_ripped": None}
+
+    path = _safe_log_path("progress", f"{job_id}.log")
+    if path is None or not path.is_file():
+        return result
+
+    try:
+        with open(path, "rb") as f:
+            data = f.read().decode("utf-8", errors="replace")
+    except OSError:
+        return result
+
+    last_prgv, last_prgc, last_prgt = _parse_progress_lines(data.splitlines())
+
+    if last_prgv:
+        total = int(last_prgv.group(2))
+        maximum = int(last_prgv.group(3))
+        if maximum > 0:
+            is_rip_phase = last_prgt and "Saving" in last_prgt
+            if is_rip_phase:
+                result["progress"] = round(total / maximum * 100, 1)
+            else:
+                result["stage"] = last_prgt
+
+    if last_prgc:
+        index = int(last_prgc.group(1))
+        name = last_prgc.group(2)
+        result["stage"] = f"Title {index + 1}: {name}"
+        # During the "Saving to MKV file" phase, titles before the current
+        # index are complete. Used as a real-time ripped count so the UI
+        # can show progress before FILE_ADDED marks them in the DB.
+        if name == "Saving to MKV file":
+            result["tracks_ripped"] = index
+
+    return result
+
+
+def get_music_progress(logfile: str | None, total_tracks: int) -> dict[str, Any]:
+    """Parse abcde progress from the job's main log file.
+
+    Returns ``{progress: float|None, stage: str|None, tracks_ripped: int|None,
+    tracks_total: int|None}``.
+    """
+    result: dict[str, Any] = {
+        "progress": None,
+        "stage": None,
+        "tracks_ripped": None,
+        "tracks_total": None,
+    }
+
+    if not logfile:
+        return result
+
+    path = _safe_log_path(logfile)
+    if path is None or not path.is_file():
+        return result
+
+    try:
+        with open(path, "r", errors="replace") as f:
+            content = f.read()
+    except OSError:
+        return result
+
+    grabbing = {int(m.group(1)) for m in re.finditer(r"Grabbing track (\d+):", content)}
+    encoding = {int(m.group(1)) for m in re.finditer(r"Encoding track (\d+) of", content)}
+    tagging = {int(m.group(1)) for m in re.finditer(r"Tagging track (\d+) of", content)}
+
+    all_seen = grabbing | encoding | tagging
+    if not all_seen:
+        return result
+
+    total = total_tracks or len(all_seen)
+    # Encoding completes before tagging starts; using its count avoids the
+    # 1-track overcount you get from "Tagging track N" being logged at the
+    # START of tagging.
+    completed = len(encoding)
+    current_track = max(all_seen)
+
+    if tagging:
+        phase = "tagging"
+    elif encoding:
+        phase = "encoding"
+    else:
+        phase = "ripping"
+
+    result["stage"] = f"{completed}/{total} - {phase} track {current_track}"
+    result["tracks_ripped"] = completed
+    result["tracks_total"] = total
+    if total > 0:
+        result["progress"] = round(completed / total * 100, 1)
+
+    return result

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,7 +34,6 @@ services:
       - ${UI_SRC_PATH:-../automatic-ripping-machine-ui}/VERSION:/app/VERSION:ro
       - ${UI_SRC_PATH:-../automatic-ripping-machine-ui}/backend:/app/backend:ro
       - ${UI_SRC_PATH:-../automatic-ripping-machine-ui}/frontend/build:/app/frontend/build:ro
-      - ./dev-data/logs:/data/logs:ro
       - ./dev-data/cache/images:/data/cache/images:rw
 
   arm-transcoder:

--- a/docker-compose.remote-transcoder.yml
+++ b/docker-compose.remote-transcoder.yml
@@ -55,7 +55,6 @@ services:
     ports:
       - "${UI_PORT:-8888}:8888"
     environment:
-      - ARM_UI_ARM_LOG_PATH=/data/logs
       - ARM_UI_ARM_URL=http://arm-rippers:8080
       - ARM_UI_TRANSCODER_URL=http://${TRANSCODER_HOST}:${TRANSCODER_PORT:-5000}
       - ARM_UI_TRANSCODER_API_KEY=${TRANSCODER_API_KEY:-}
@@ -63,7 +62,6 @@ services:
       - ARM_UI_THEMES_PATH=/data/themes
       - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
-      - ${ARM_LOGS_PATH}:/data/logs:ro
       - arm-ui-themes:/data/themes:rw
       - ui-image-cache:/data/cache/images:rw
     depends_on:

--- a/docker-compose.ripper-only.yml
+++ b/docker-compose.ripper-only.yml
@@ -61,13 +61,11 @@ services:
     ports:
       - "${UI_PORT:-8888}:8888"
     environment:
-      - ARM_UI_ARM_LOG_PATH=/data/logs
       - ARM_UI_ARM_URL=http://arm-rippers:8080
       - ARM_UI_TRANSCODER_ENABLED=false
       - ARM_UI_THEMES_PATH=/data/themes
       - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
-      - ${ARM_LOGS_PATH}:/data/logs:ro
       - arm-ui-themes:/data/themes:rw
       - ui-image-cache:/data/cache/images:rw
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,6 @@ services:
     ports:
       - "${UI_PORT:-8888}:8888"
     environment:
-      - ARM_UI_ARM_LOG_PATH=/data/logs
       - ARM_UI_ARM_URL=http://arm-rippers:8080
       - ARM_UI_TRANSCODER_URL=${ARM_UI_TRANSCODER_URL:-http://arm-transcoder:5000}
       - ARM_UI_TRANSCODER_API_KEY=${TRANSCODER_API_KEY:-}
@@ -74,7 +73,6 @@ services:
       - ARM_UI_THEMES_PATH=/data/themes
       - ARM_UI_IMAGE_CACHE_PATH=/data/cache/images
     volumes:
-      - ${ARM_LOGS_PATH}:/data/logs:ro
       - arm-ui-themes:/data/themes:rw
       - ui-image-cache:/data/cache/images:rw
     depends_on:

--- a/test/test_logs_api.py
+++ b/test/test_logs_api.py
@@ -220,6 +220,15 @@ class TestLogParserUnit:
         assert result["event"] == line
         assert result["level"] == "info"
 
+    def test_parse_oversized_line_skipped(self):
+        """Defends the parser against catastrophic input (CodeQL py/polynomial-redos)."""
+        line = "a" + " " * 50000  # leading-space ReDoS attack shape
+        # Must complete instantly and return something safe.
+        result = log_parser._parse_log_line(line)
+        assert result["raw"] == line
+        # Truncated event (the parser bails before regex)
+        assert "..." in result["event"]
+
     def test_resolve_within_strips_traversal(self, tmp_path):
         from pathlib import Path
         result = log_parser._resolve_within("../escape", Path(tmp_path))

--- a/test/test_logs_api.py
+++ b/test/test_logs_api.py
@@ -1,0 +1,270 @@
+"""Tests for arm/api/v1/logs.py - log REST endpoints + log_parser service."""
+import unittest.mock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from arm.services import log_parser
+
+
+@pytest.fixture
+def logs_client(tmp_path):
+    from arm.api.v1.logs import router
+    app = FastAPI()
+    app.include_router(router)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(log_dir)}):
+        with TestClient(app) as c:
+            yield c, log_dir
+
+
+class TestListLogs:
+    def test_lists_log_files_newest_first(self, logs_client):
+        client, log_dir = logs_client
+        old = log_dir / "old.log"
+        new = log_dir / "new.log"
+        old.write_text("aaa")
+        new.write_text("bbb")
+        # Force mtime ordering (filesystem may give same-second writes)
+        import os
+        os.utime(old, (1000, 1000))
+        os.utime(new, (2000, 2000))
+
+        resp = client.get("/api/v1/logs")
+        assert resp.status_code == 200
+        data = resp.json()
+        names = [e["filename"] for e in data]
+        assert names == ["new.log", "old.log"]
+        assert data[0]["size"] == 3
+        assert "modified" in data[0]
+
+    def test_skips_non_log_files(self, logs_client):
+        client, log_dir = logs_client
+        (log_dir / "a.log").write_text("x")
+        (log_dir / "b.txt").write_text("y")
+        resp = client.get("/api/v1/logs")
+        names = [e["filename"] for e in resp.json()]
+        assert names == ["a.log"]
+
+    def test_missing_logdir_returns_empty(self, tmp_path):
+        from arm.api.v1.logs import router
+        app = FastAPI()
+        app.include_router(router)
+        missing = tmp_path / "nope"
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(missing)}):
+            with TestClient(app) as c:
+                resp = c.get("/api/v1/logs")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestReadLog:
+    def test_tail_returns_last_n_lines(self, logs_client):
+        client, log_dir = logs_client
+        (log_dir / "x.log").write_text("\n".join(f"line{i}" for i in range(10)) + "\n")
+        resp = client.get("/api/v1/logs/x.log", params={"mode": "tail", "lines": 3})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["filename"] == "x.log"
+        assert body["lines"] == 3
+        assert body["content"] == "line7\nline8\nline9\n"
+        assert body["truncated"] is False
+
+    def test_full_returns_whole_file(self, logs_client):
+        client, log_dir = logs_client
+        (log_dir / "x.log").write_text("a\nb\nc\n")
+        resp = client.get("/api/v1/logs/x.log", params={"mode": "full"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["content"] == "a\nb\nc\n"
+        assert body["truncated"] is False
+
+    def test_full_caps_at_max_bytes(self, logs_client, monkeypatch):
+        client, log_dir = logs_client
+        monkeypatch.setattr(log_parser, "_FULL_MODE_MAX_BYTES", 100)
+        # File is 230 bytes; we keep the last 100. The first newline inside
+        # those 100 bytes splits a partial y-line away from the trailing zzz.
+        big = ("x" * 200) + "\n" + ("y" * 20) + "\n" + "zzz\n"
+        (log_dir / "big.log").write_text(big)
+        resp = client.get("/api/v1/logs/big.log", params={"mode": "full"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["truncated"] is True
+        assert "zzz" in body["content"]
+        # Partial first line (some y's) is dropped, x-line never reaches us
+        assert "x" * 200 not in body["content"]
+
+    def test_missing_file_404(self, logs_client):
+        client, _ = logs_client
+        resp = client.get("/api/v1/logs/nope.log")
+        assert resp.status_code == 404
+
+    def test_traversal_rejected(self, logs_client, tmp_path):
+        client, log_dir = logs_client
+        outside = tmp_path / "secret.log"
+        outside.write_text("sensitive")
+        # The path component "../secret.log" is stripped to basename
+        # "secret.log" which doesn't exist in LOGPATH.
+        resp = client.get("/api/v1/logs/..%2Fsecret.log")
+        assert resp.status_code == 404
+        assert outside.exists()
+
+
+class TestStructuredLog:
+    def test_parses_arm_plain_format(self, logs_client):
+        client, log_dir = logs_client
+        (log_dir / "x.log").write_text(
+            "02-28-2026 04:59:16 ARM: INFO: Started\n"
+            "02-28-2026 04:59:17 ARM: ERROR: Crashed\n"
+        )
+        resp = client.get("/api/v1/logs/x.log/structured")
+        assert resp.status_code == 200
+        entries = resp.json()["entries"]
+        assert len(entries) == 2
+        assert entries[0]["level"] == "info"
+        assert entries[0]["event"] == "Started"
+        assert entries[1]["level"] == "error"
+
+    def test_level_filter(self, logs_client):
+        client, log_dir = logs_client
+        (log_dir / "x.log").write_text(
+            "02-28-2026 04:59:16 ARM: INFO: Hello\n"
+            "02-28-2026 04:59:17 ARM: ERROR: Boom\n"
+        )
+        resp = client.get("/api/v1/logs/x.log/structured", params={"level": "error"})
+        entries = resp.json()["entries"]
+        assert len(entries) == 1
+        assert entries[0]["event"] == "Boom"
+
+    def test_search_filter(self, logs_client):
+        client, log_dir = logs_client
+        (log_dir / "x.log").write_text(
+            "02-28-2026 04:59:16 ARM: INFO: ripping disc\n"
+            "02-28-2026 04:59:17 ARM: INFO: ejecting drive\n"
+        )
+        resp = client.get("/api/v1/logs/x.log/structured", params={"search": "rip"})
+        entries = resp.json()["entries"]
+        assert len(entries) == 1
+        assert "ripping" in entries[0]["event"]
+
+    def test_missing_file_404(self, logs_client):
+        client, _ = logs_client
+        resp = client.get("/api/v1/logs/nope.log/structured")
+        assert resp.status_code == 404
+
+
+class TestDownloadLog:
+    def test_streams_file(self, logs_client):
+        client, log_dir = logs_client
+        (log_dir / "x.log").write_text("hello world\n")
+        resp = client.get("/api/v1/logs/x.log/download")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/plain")
+        assert resp.text == "hello world\n"
+
+    def test_missing_file_404(self, logs_client):
+        client, _ = logs_client
+        resp = client.get("/api/v1/logs/nope.log/download")
+        assert resp.status_code == 404
+
+
+class TestDeleteLog:
+    def test_deletes_file(self, logs_client):
+        client, log_dir = logs_client
+        target = log_dir / "x.log"
+        target.write_text("bye")
+        resp = client.delete("/api/v1/logs/x.log")
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True, "filename": "x.log"}
+        assert not target.exists()
+
+    def test_missing_file_404(self, logs_client):
+        client, _ = logs_client
+        resp = client.delete("/api/v1/logs/nope.log")
+        assert resp.status_code == 404
+
+    def test_traversal_rejected(self, logs_client, tmp_path):
+        client, _ = logs_client
+        outside = tmp_path / "secret.log"
+        outside.write_text("sensitive")
+        resp = client.delete("/api/v1/logs/..%2Fsecret.log")
+        assert resp.status_code == 404
+        assert outside.exists()
+
+
+class TestLogParserUnit:
+    def test_parse_json_line(self):
+        line = '{"timestamp": "t", "level": "warning", "logger": "lg", "event": "hi"}'
+        result = log_parser._parse_log_line(line)
+        assert result["level"] == "warning"
+        assert result["event"] == "hi"
+
+    def test_parse_iso_bracket(self):
+        line = "2026-03-20 14:24:48 [rescan_drive] No disc in /dev/sr0"
+        result = log_parser._parse_log_line(line)
+        assert result["timestamp"] == "2026-03-20 14:24:48"
+        assert result["logger"] == "rescan_drive"
+        assert result["event"] == "No disc in /dev/sr0"
+
+    def test_parse_wrapper_bracket(self):
+        line = "Sun Mar  1 04:34:15 EST 2026 [ARM] Starting ARM for DVD on sr0"
+        result = log_parser._parse_log_line(line)
+        assert result["logger"] == "ARM"
+        assert "Starting" in result["event"]
+
+    def test_parse_fallback(self):
+        line = "totally unstructured garbage"
+        result = log_parser._parse_log_line(line)
+        assert result["event"] == line
+        assert result["level"] == "info"
+
+    def test_resolve_within_strips_traversal(self, tmp_path):
+        from pathlib import Path
+        result = log_parser._resolve_within("../escape", Path(tmp_path))
+        # basename "escape" - file doesn't exist but resolution stays in root
+        assert result is not None
+        assert result.parent == tmp_path.resolve()
+
+    def test_resolve_within_rejects_dotdot_only(self, tmp_path):
+        from pathlib import Path
+        assert log_parser._resolve_within("..", Path(tmp_path)) is None
+        assert log_parser._resolve_within(".", Path(tmp_path)) is None
+        assert log_parser._resolve_within("", Path(tmp_path)) is None
+
+    def test_delete_oserror_returns_false(self, tmp_path, monkeypatch):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        target = log_dir / "x.log"
+        target.write_text("x")
+        monkeypatch.setattr(
+            "arm.config.config.arm_config", {"LOGPATH": str(log_dir)}
+        )
+
+        def boom(self):
+            raise OSError("nope")
+
+        from pathlib import Path
+        monkeypatch.setattr(Path, "unlink", boom)
+        assert log_parser.delete_log("x.log") is False
+
+    def test_read_oserror_returns_none(self, tmp_path, monkeypatch):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        target = log_dir / "x.log"
+        target.write_text("x")
+        monkeypatch.setattr(
+            "arm.config.config.arm_config", {"LOGPATH": str(log_dir)}
+        )
+
+        import builtins
+        real_open = builtins.open
+
+        def boom(path, *a, **kw):
+            if str(path).endswith("x.log"):
+                raise OSError("nope")
+            return real_open(path, *a, **kw)
+
+        monkeypatch.setattr(builtins, "open", boom)
+        assert log_parser.read_log("x.log") is None

--- a/test/test_logs_api.py
+++ b/test/test_logs_api.py
@@ -20,6 +20,22 @@ def logs_client(tmp_path):
             yield c, log_dir
 
 
+class TestJobLog:
+    """Pre-existing /jobs/{id}/log endpoint - covered here so the new
+    test file owns the whole router's coverage."""
+
+    def test_delegates_to_svc_jobs(self, logs_client):
+        client, _ = logs_client
+        with unittest.mock.patch(
+            "arm.api.v1.logs.svc_jobs.generate_log",
+            return_value={"success": True, "job": "1", "log": "ok"},
+        ) as mock:
+            resp = client.get("/api/v1/jobs/1/log")
+        assert resp.status_code == 200
+        assert resp.json()["log"] == "ok"
+        mock.assert_called_once()
+
+
 class TestListLogs:
     def test_lists_log_files_newest_first(self, logs_client):
         client, log_dir = logs_client
@@ -102,7 +118,7 @@ class TestReadLog:
         assert resp.status_code == 404
 
     def test_traversal_rejected(self, logs_client, tmp_path):
-        client, log_dir = logs_client
+        client, _ = logs_client
         outside = tmp_path / "secret.log"
         outside.write_text("sensitive")
         # The path component "../secret.log" is stripped to basename
@@ -219,6 +235,22 @@ class TestLogParserUnit:
         result = log_parser._parse_log_line(line)
         assert result["event"] == line
         assert result["level"] == "info"
+
+    def test_parse_wrapper_plain(self):
+        """Wrapper-script format without [LOGGER] tag falls through to the plain branch."""
+        line = "Sun Mar  1 04:34:15 EST 2026 Entering docker wrapper"
+        result = log_parser._parse_log_line(line)
+        assert result["logger"] == "wrapper"
+        assert "Entering" in result["event"]
+
+    def test_resolve_within_oserror_returns_none(self, monkeypatch, tmp_path):
+        from pathlib import Path
+
+        def boom(self, *a, **kw):
+            raise OSError("disk gone")
+
+        monkeypatch.setattr(Path, "resolve", boom)
+        assert log_parser._resolve_within("x.log", Path(tmp_path)) is None
 
     def test_parse_oversized_line_skipped(self):
         """Defends the parser against catastrophic input (CodeQL py/polynomial-redos)."""

--- a/test/test_progress_reader.py
+++ b/test/test_progress_reader.py
@@ -1,0 +1,143 @@
+"""Tests for arm/services/progress_reader.py - MakeMKV + abcde progress."""
+import unittest.mock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from arm.services import progress_reader
+
+
+@pytest.fixture
+def progress_dir(tmp_path):
+    log_dir = tmp_path / "logs"
+    (log_dir / "progress").mkdir(parents=True)
+    with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(log_dir)}):
+        yield log_dir
+
+
+class TestRipProgress:
+    def test_no_file_returns_none(self, progress_dir):
+        result = progress_reader.get_rip_progress(99)
+        assert result == {"progress": None, "stage": None, "tracks_ripped": None}
+
+    def test_prgv_during_save_phase(self, progress_dir):
+        (progress_dir / "progress" / "1.log").write_text(
+            'PRGT:0,0,"Saving to MKV file"\n'
+            "PRGV:5000,7500,10000\n"
+        )
+        result = progress_reader.get_rip_progress(1)
+        assert result["progress"] == 75.0
+
+    def test_prgc_advances_stage_and_tracks(self, progress_dir):
+        (progress_dir / "progress" / "2.log").write_text(
+            'PRGC:0,2,"Saving to MKV file"\n'
+            "PRGV:1000,2000,10000\n"
+        )
+        result = progress_reader.get_rip_progress(2)
+        assert result["stage"] == "Title 3: Saving to MKV file"
+        assert result["tracks_ripped"] == 2
+
+    def test_zero_max_skipped(self, progress_dir):
+        (progress_dir / "progress" / "3.log").write_text("PRGV:0,0,0\n")
+        result = progress_reader.get_rip_progress(3)
+        assert result["progress"] is None
+
+    def test_oserror_on_open_returns_default(self, progress_dir, monkeypatch):
+        target = progress_dir / "progress" / "4.log"
+        target.write_text("PRGV:1,1,2\n")
+
+        import builtins
+        real_open = builtins.open
+
+        def boom(path, *a, **kw):
+            if str(path).endswith("4.log"):
+                raise OSError("nope")
+            return real_open(path, *a, **kw)
+
+        monkeypatch.setattr(builtins, "open", boom)
+        result = progress_reader.get_rip_progress(4)
+        assert result == {"progress": None, "stage": None, "tracks_ripped": None}
+
+    def test_traversal_returns_none(self, progress_dir):
+        # _safe_log_path coerces to None for paths escaping LOGPATH
+        result = progress_reader._safe_log_path("..", "..", "etc", "passwd")
+        assert result is None
+
+
+class TestMusicProgress:
+    def test_no_logfile(self, progress_dir):
+        result = progress_reader.get_music_progress(None, 10)
+        assert result["progress"] is None
+        assert result["stage"] is None
+
+    def test_missing_file(self, progress_dir):
+        result = progress_reader.get_music_progress("nonexistent.log", 10)
+        assert result["progress"] is None
+
+    def test_parses_abcde_phases(self, progress_dir):
+        (progress_dir / "music.log").write_text(
+            "Grabbing track 1: foo\n"
+            "Grabbing track 2: bar\n"
+            "Encoding track 1 of 5\n"
+            "Encoding track 2 of 5\n"
+            "Tagging track 1 of 5\n"
+        )
+        result = progress_reader.get_music_progress("music.log", 5)
+        assert result["tracks_total"] == 5
+        assert result["tracks_ripped"] == 2  # encoding count
+        assert result["progress"] == 40.0
+        assert "tagging track 2" in result["stage"]
+
+    def test_empty_log_returns_default(self, progress_dir):
+        (progress_dir / "music.log").write_text("nothing here\n")
+        result = progress_reader.get_music_progress("music.log", 5)
+        assert result["progress"] is None
+
+    def test_falls_back_to_seen_count_when_total_zero(self, progress_dir):
+        (progress_dir / "music.log").write_text("Grabbing track 1: foo\n")
+        result = progress_reader.get_music_progress("music.log", 0)
+        assert result["tracks_total"] == 1
+
+
+class TestProgressStateEndpoint:
+    @pytest.fixture
+    def jobs_client(self, progress_dir, app_context):
+        from arm.api.v1.jobs import router
+        app = FastAPI()
+        app.include_router(router)
+        with TestClient(app) as c:
+            yield c, progress_dir
+
+    def test_endpoint_includes_realtime_keys(self, jobs_client, sample_job):
+        client, log_dir = jobs_client
+        # MakeMKV progress for the job
+        (log_dir / "progress" / f"{sample_job.job_id}.log").write_text(
+            'PRGT:0,0,"Saving to MKV file"\n'
+            "PRGV:1000,5000,10000\n"
+        )
+        resp = client.get(f"/api/v1/jobs/{sample_job.job_id}/progress-state")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["rip_progress"] == 50.0
+        assert body["rip_stage"] is None  # no PRGC, name was "Saving"
+        # Pre-existing keys still present
+        assert body["disctype"] == "bluray"
+        assert body["logfile"] == "test.log"
+        assert "track_counts" in body
+        # Music keys present (None for video disc)
+        assert body["music_progress"] is None
+
+    def test_endpoint_with_no_progress_file(self, jobs_client, sample_job):
+        client, _ = jobs_client
+        resp = client.get(f"/api/v1/jobs/{sample_job.job_id}/progress-state")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["rip_progress"] is None
+        assert body["tracks_ripped_realtime"] is None
+        assert body["music_progress"] is None
+
+    def test_missing_job_404(self, jobs_client):
+        client, _ = jobs_client
+        resp = client.get("/api/v1/jobs/99999/progress-state")
+        assert resp.status_code == 404

--- a/test/test_progress_reader.py
+++ b/test/test_progress_reader.py
@@ -27,7 +27,7 @@ class TestRipProgress:
             "PRGV:5000,7500,10000\n"
         )
         result = progress_reader.get_rip_progress(1)
-        assert result["progress"] == 75.0
+        assert result["progress"] == pytest.approx(75.0)
 
     def test_prgc_advances_stage_and_tracks(self, progress_dir):
         (progress_dir / "progress" / "2.log").write_text(
@@ -86,7 +86,7 @@ class TestMusicProgress:
         result = progress_reader.get_music_progress("music.log", 5)
         assert result["tracks_total"] == 5
         assert result["tracks_ripped"] == 2  # encoding count
-        assert result["progress"] == 40.0
+        assert result["progress"] == pytest.approx(40.0)
         assert "tagging track 2" in result["stage"]
 
     def test_empty_log_returns_default(self, progress_dir):
@@ -98,6 +98,37 @@ class TestMusicProgress:
         (progress_dir / "music.log").write_text("Grabbing track 1: foo\n")
         result = progress_reader.get_music_progress("music.log", 0)
         assert result["tracks_total"] == 1
+
+    def test_grabbing_only_is_ripping_phase(self, progress_dir):
+        """Only Grabbing seen (no Encoding/Tagging yet) -> phase is 'ripping'."""
+        (progress_dir / "music.log").write_text("Grabbing track 1: foo\n")
+        result = progress_reader.get_music_progress("music.log", 5)
+        assert "ripping track 1" in result["stage"]
+
+    def test_encoding_without_tagging_is_encoding_phase(self, progress_dir):
+        """Encoding seen but no Tagging yet -> phase is 'encoding'."""
+        (progress_dir / "music.log").write_text(
+            "Grabbing track 1: foo\n"
+            "Encoding track 1 of 5\n"
+        )
+        result = progress_reader.get_music_progress("music.log", 5)
+        assert "encoding track 1" in result["stage"]
+
+    def test_oserror_on_open_returns_default(self, progress_dir, monkeypatch):
+        target = progress_dir / "music.log"
+        target.write_text("Grabbing track 1: foo\n")
+
+        import builtins
+        real_open = builtins.open
+
+        def boom(path, *a, **kw):
+            if "music.log" in str(path):
+                raise OSError("nope")
+            return real_open(path, *a, **kw)
+
+        monkeypatch.setattr(builtins, "open", boom)
+        result = progress_reader.get_music_progress("music.log", 5)
+        assert result["progress"] is None
 
 
 class TestProgressStateEndpoint:
@@ -119,7 +150,7 @@ class TestProgressStateEndpoint:
         resp = client.get(f"/api/v1/jobs/{sample_job.job_id}/progress-state")
         assert resp.status_code == 200
         body = resp.json()
-        assert body["rip_progress"] == 50.0
+        assert body["rip_progress"] == pytest.approx(50.0)
         assert body["rip_stage"] is None  # no PRGC, name was "Saving"
         # Pre-existing keys still present
         assert body["disctype"] == "bluray"


### PR DESCRIPTION
## Summary

Adds the log + progress endpoints arm-ui needs to retire its last bind mount to ripper-owned filesystem state (`\${ARM_LOGS_PATH}:/data/logs:ro`). After this lands and the matching arm-ui PR ships, arm-ui has zero filesystem coupling to the ripper and can run on any host with only HTTP to arm-neu.

This is **PR #2 of 2** in the UI bind-mount decoupling project. PR #1 (\`feat: decouple arm-ui from ripper-side bind mounts\`) shipped in v17.0.0 / v17.1.0; the cleanup PR shipped in v17.2.0. This is the final retirement.

Companion PR: arm-ui#feat/logs-api-bff

## What this changes

\`arm/api/v1/logs.py\` - extends the existing 1-endpoint module:
- \`GET /api/v1/logs\` - list LOGPATH \`*.log\` files (newest first)
- \`GET /api/v1/logs/{name}\` - read with \`mode=tail\` (default, last N lines) or \`mode=full\` (capped at 10 MB; \`truncated=true\` on overflow to protect the API thread pool from active-job logs that can hit hundreds of MB)
- \`GET /api/v1/logs/{name}/structured\` - parsed entries with optional \`level\` + \`search\` substring filters; supports JSON/structlog, ARM plain-text, wrapper-script, and ISO-bracket formats
- \`GET /api/v1/logs/{name}/download\` - FileResponse for raw download
- \`DELETE /api/v1/logs/{name}\` - basename-only resolution rejects traversal attempts

\`arm/api/v1/jobs.py\` - extend the existing \`/jobs/{id}/progress-state\` endpoint with realtime fields **(additive, no breaking change)**:
- \`rip_progress\` / \`rip_stage\` / \`tracks_ripped_realtime\` - parsed from MakeMKV PRGV/PRGC/PRGT messages in \`{LOGPATH}/progress/{job_id}.log\`
- \`music_progress\` / \`music_stage\` - parsed from abcde Grabbing/Encoding/Tagging counts in the job's main log

The MakeMKV + abcde parsers are ported from arm-ui's \`backend/services/progress.py\`. arm-ui's BFF will switch to consuming these keys and drop the local readers in the lockstep companion PR.

Compose: drops \`\${ARM_LOGS_PATH}:/data/logs:ro\` from arm-ui block in all 4 compose files (\`docker-compose.yml\`, \`docker-compose.remote-transcoder.yml\`, \`docker-compose.ripper-only.yml\`, \`docker-compose.dev.yml\`).

## Test plan

- [x] arm-neu suite green (2020 passed, +39 new)
- [x] Manual smoke: list/read/structured/download/delete all return correct shapes against running dev stack
- [x] Manual smoke: progress-state returns the new realtime keys; nulls when no rip is in progress
- [x] arm-ui dev container has no \`/data/logs\` mount after recreate
- [x] BFF pass-through working end-to-end on dev stack
- [ ] CI green (codecov, sonar) - to verify post-push
- [ ] Lockstep CI passes (arm-ui PR must be at companion tip)

## Risks

1. **Active-job log size** - mitigated: \`mode=tail\` is default; \`mode=full\` caps at 10 MB and reports \`truncated=true\`.
2. **Path-traversal regression** - mitigated: ported \`_resolve_within\` pattern from arm-ui verbatim, with traversal tests for both read and delete.
3. **Polling load** - mitigated on the consumer side: arm-ui adds a 1s TTL cache around the progress endpoint to absorb dashboard polls (companion PR).

## Plan doc

\`docs/superpowers/plans/2026-04-28-logs-api-implementation.md\` (in the sibling AI repo)