### PR TITLE
fix(preflight): stop blocking event loop in MakeMKV key check

### DIFF
--- a/arm/services/preflight.py
+++ b/arm/services/preflight.py
@@ -6,6 +6,7 @@ setup wizard and system health dashboard.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -205,11 +206,16 @@ async def _check_tvdb_key() -> dict:
 
 
 async def _check_makemkv_key() -> dict:
-    """Check the MakeMKV key via prep_mkv()."""
+    """Check the MakeMKV key via prep_mkv().
+
+    prep_mkv() spawns a blocking subprocess that hits forum.makemkv.com,
+    which can stall for tens of seconds; run it in the default executor
+    so the asyncio loop stays responsive for other concurrent requests.
+    """
     from arm.ripper.makemkv import UpdateKeyRunTimeError, UpdateKeyErrorCodes, prep_mkv
 
     try:
-        prep_mkv()
+        await asyncio.get_running_loop().run_in_executor(None, prep_mkv)
         return {
             "name": "makemkv_key",
             "success": True,

--- a/scripts/update_key.sh
+++ b/scripts/update_key.sh
@@ -18,7 +18,7 @@ MAKEMKV_SERIAL="$1"
 
 # Use beta key if serial is not passed
 if [[ -z "$MAKEMKV_SERIAL" ]]; then
-    if ! MAKEMKV_SERIAL=$(curl -fsSL "$MAKEMKV_SERIAL_URL" | grep -oP 'T-[\w\d@]{66}'); then
+    if ! MAKEMKV_SERIAL=$(curl -fsSL --connect-timeout 5 --max-time 15 "$MAKEMKV_SERIAL_URL" | grep -oP 'T-[\w\d@]{66}'); then
 		echo "The beta key cannot be found at: $MAKEMKV_SERIAL_URL"
 		exit $EXIT_CODE_URL_ERROR
 	fi

--- a/test/test_preflight.py
+++ b/test/test_preflight.py
@@ -385,3 +385,50 @@ class TestRunChecks:
             assert "success" in check
             assert "message" in check
             assert "fixable" in check
+
+
+class TestCheckMakemkvKeyExecutor:
+    """_check_makemkv_key() must offload prep_mkv() to a thread executor.
+
+    prep_mkv() spawns a blocking subprocess that hits forum.makemkv.com.
+    Running it on the asyncio loop starves all other concurrent requests
+    until it returns. The fix is to dispatch via run_in_executor.
+    """
+
+    def test_prep_mkv_runs_off_event_loop(self):
+        """While prep_mkv() blocks, other coroutines must still run."""
+        from arm.services.preflight import _check_makemkv_key
+
+        progress = {"ticks": 0, "prep_done": False}
+
+        def slow_prep_mkv():
+            # Simulate forum.makemkv.com hanging for ~0.5s of wall time.
+            import time
+            time.sleep(0.3)
+            progress["prep_done"] = True
+
+        async def ticker():
+            for _ in range(5):
+                await asyncio.sleep(0.05)
+                progress["ticks"] += 1
+
+        async def driver():
+            with unittest.mock.patch(
+                "arm.ripper.makemkv.prep_mkv", side_effect=slow_prep_mkv
+            ):
+                check_task = asyncio.create_task(_check_makemkv_key())
+                tick_task = asyncio.create_task(ticker())
+                result = await check_task
+                await tick_task
+                return result
+
+        result = asyncio.run(driver())
+
+        # The ticker must have made progress *while* prep_mkv was sleeping.
+        # If prep_mkv blocked the loop, ticks would be 0 until prep_done.
+        assert progress["prep_done"] is True
+        assert progress["ticks"] >= 3, (
+            f"event loop was starved during prep_mkv() (ticks={progress['ticks']})"
+        )
+        assert result["success"] is True
+        assert result["name"] == "makemkv_key"


### PR DESCRIPTION
## Summary
- `_check_makemkv_key` now offloads `prep_mkv()` to the default thread executor; the asyncio loop no longer stalls during the synchronous subprocess that hits `forum.makemkv.com`.
- `scripts/update_key.sh` adds `--connect-timeout 5 --max-time 15` to the curl so a slow forum can't push preflight past the BFF's HTTP timeout.
- New regression test asserts the loop keeps ticking while `prep_mkv()` blocks (would have caught this).

## Why
arm-ui's System Health card was getting stuck on "Running health checks..." in production because every other in-flight BFF request was being starved while preflight ran. The arm-ui side bumps its preflight timeout to 60s in https://github.com/uprightbass360/automatic-ripping-machine-ui/pull/preflight-timeout-bump; together those two changes make the preflight call reliable even when forum.makemkv.com is slow.

## Test plan
- [x] `_check_makemkv_key` regression test asserts the asyncio loop keeps ticking (5 sleeps land) while `prep_mkv()` blocks for ~300ms.
- [ ] CI tests, codecov, SonarCloud, CodeQL pass.
- [ ] Smoke test on hifi after merge: `curl -m 60 -X POST http://hifi:8080/api/v1/system/preflight` returns 200 in under 20s on a normal day.