### PR TITLE
feat(version): stamp build identity into VERSION at image-build time

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -53,6 +53,8 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            IMAGE_TAG=${{ steps.version.outputs.version }}
           tags: |
             ${{ env.DOCKERHUB_IMAGE }}:latest
             ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -64,6 +64,8 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            IMAGE_TAG=${{ steps.version.outputs.version }}-rc
           tags: |
             ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.version }}-rc
             ${{ env.GHCR_IMAGE }}:${{ steps.version.outputs.version }}-rc

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,5 +70,18 @@ RUN apt-get update -qq \
     && ln -sv /opt/arm/setup/61-docker-arm.rules /lib/udev/rules.d/ \
     && git config --global --add safe.directory /opt/arm
 
+# Stamp VERSION with the actual build identity so the running image can
+# distinguish release / RC / dev builds in the Settings -> Versions panel.
+# - Release workflow passes IMAGE_TAG=<version>           -> e.g. 17.3.0
+# - RC workflow passes      IMAGE_TAG=<version>-rc        -> e.g. 17.3.0-rc
+# - Local docker compose build with no arg                -> e.g. 17.3.0-dev
+# Last layer on purpose: this changes per build but costs ~nothing to rerun.
+ARG IMAGE_TAG=
+RUN if [ -n "$IMAGE_TAG" ]; then \
+        echo "$IMAGE_TAG" > /opt/arm/VERSION; \
+    else \
+        echo "$(cat /opt/arm/VERSION)-dev" > /opt/arm/VERSION; \
+    fi
+
 CMD ["/sbin/my_init"]
 WORKDIR /home/arm

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,7 +31,11 @@ services:
       - --reload
       - --reload-dir=/app/backend
     volumes:
-      - ${UI_SRC_PATH:-../automatic-ripping-machine-ui}/VERSION:/app/VERSION:ro
+      # NB: VERSION is intentionally NOT mounted from source. The image's
+      # build-time RUN stamps it with a "-dev" suffix so the Settings ->
+      # Versions panel reflects "this is a dev build", not the last
+      # released semver. Source VERSION only changes on release-please
+      # commits, which already require a rebuild.
       - ${UI_SRC_PATH:-../automatic-ripping-machine-ui}/backend:/app/backend:ro
       - ${UI_SRC_PATH:-../automatic-ripping-machine-ui}/frontend/build:/app/frontend/build:ro
       - ./dev-data/cache/images:/data/cache/images:rw
@@ -65,6 +69,8 @@ services:
       # .pth points at /app/components/contracts/src, so without this
       # `import arm_contracts` fails inside the dev container.
       - ${TRANSCODER_SRC_PATH:-../automatic-ripping-machine-transcoder}/components/contracts:/app/components/contracts:ro
-      - ${TRANSCODER_SRC_PATH:-../automatic-ripping-machine-transcoder}/VERSION:/etc/arm-transcoder-version:ro
+      # NB: VERSION is intentionally NOT mounted from source. Dockerfile.dev
+      # stamps /etc/arm-transcoder-version with a "-dev" suffix at build time
+      # so the Settings -> Versions panel reflects "this is a dev build".
       - ${TRANSCODER_SRC_PATH:-../automatic-ripping-machine-transcoder}/presets:/config/presets:ro
       - ./dev-data/transcoder-logs:/data/logs:rw


### PR DESCRIPTION
## Summary
The Settings -> Versions panel will now show the actual build identity instead of always parroting the last released semver:

- Release image (\`:17.2.0\`)  -> \`17.2.0\`
- RC image     (\`:17.3.0-rc\`) -> \`17.3.0-rc\` _(was: \`17.3.0\`)_
- Dev image    (\`arm:dev\`)    -> \`17.2.0-dev\` _(was: \`17.2.0\`)_

## Why
Today every container shows the value of \`VERSION\` baked in at \`COPY . /opt/arm/\`, which is just the source-tree value (= last release-please bump). An RC image and a dev image of the same base look identical to a user staring at the Versions panel - which is the visible bug from today's session.

## Approach
Three coordinated edits, no application code changes:

1. \`Dockerfile\`: append a final \`ARG IMAGE_TAG=\` + \`RUN\` that either writes the supplied tag verbatim or appends \`-dev\` to the existing source value.
2. \`publish-image.yml\` + \`publish-prerelease.yml\`: pass \`IMAGE_TAG=<version>\` and \`IMAGE_TAG=<version>-rc\` respectively.
3. \`docker-compose.dev.yml\`: drop the source-bind of \`VERSION\` for the arm-ui dev container (which was shadowing the image's stamped value).

Pairs with arm-ui PR https://github.com/uprightbass360/automatic-ripping-machine-ui/pull/245 and arm-transcoder PR https://github.com/uprightbass360/automatic-ripping-machine-transcoder/pull/127 for end-to-end consistency.

## Verified locally
\`\`\`
$ docker build --target automatic-ripping-machine -t arm:dev-test .
$ docker run --rm arm:dev-test cat /opt/arm/VERSION
17.2.0-dev

$ docker build --target automatic-ripping-machine --build-arg IMAGE_TAG=17.3.0-rc -t arm:rc-test .
$ docker run --rm arm:rc-test cat /opt/arm/VERSION
17.3.0-rc
\`\`\`

## Test plan
- [x] Local docker build verified for both \`-dev\` and \`-rc\` paths.
- [ ] CI: tests + codecov + SonarCloud + CodeQL pass.
- [ ] Pre-release workflow on next release-please PR produces an image whose \`/opt/arm/VERSION\` is \`<version>-rc\`.
- [ ] After local rebuild, Settings -> Versions on dev shows \`arm 17.2.0-dev\`.