### PR TITLE
feat(api): adopt shared Job/Track/JobSummary/JobProgressState contracts (v0.5.1)

### DIFF
--- a/arm/api/v1/drives.py
+++ b/arm/api/v1/drives.py
@@ -7,6 +7,7 @@ import os
 import re
 import subprocess
 
+from arm_contracts import JobSummary
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
@@ -84,18 +85,7 @@ def list_drives_with_jobs():
         job = Job.query.get(job_id)
         if not job:
             return None
-        return {
-            "job_id": job.job_id,
-            "title": job.title,
-            "year": job.year,
-            "video_type": job.video_type,
-            "status": job.status,
-            "stage": job.stage,
-            "disctype": job.disctype,
-            "label": job.label,
-            "poster_url": job.poster_url,
-            "no_of_titles": job.no_of_titles,
-        }
+        return JobSummary.model_validate(job).model_dump(mode="json")
 
     result = []
     for d in drives:

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -11,7 +11,14 @@ import threading
 from datetime import datetime, timedelta
 from typing import Annotated
 
-from arm_contracts import JobStatus, TranscodeCallbackPayload
+from arm_contracts import (
+    Job as JobContract,
+    JobProgressState,
+    JobStatus,
+    Track as TrackContract,
+    TrackCounts,
+    TranscodeCallbackPayload,
+)
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
@@ -96,15 +103,27 @@ HIDDEN_CONFIG_FIELDS = {
 
 
 def _job_to_dict(job):
-    """Serialize a Job record to a dict with ISO datetimes."""
+    """Serialize a Job record to a wire dict via the shared JobContract.
+
+    Builds via Pydantic (mode='json') so datetimes round-trip as ISO
+    strings and any column not in the contract is silently dropped
+    (extra='ignore'), keeping the wire shape stable as the ORM grows.
+
+    transcode_overrides arrives from the DB as a JSON string; pre-parse
+    it to a dict so the contract's `dict | None` type validates. Legacy-
+    key stripping is consumer-side (arm-ui) and not the producer's job.
+    """
     data = {
         col.name: getattr(job, col.name)
         for col in Job.__table__.columns
     }
-    for key, val in data.items():
-        if hasattr(val, 'isoformat'):
-            data[key] = val.isoformat()
-    return data
+    raw_overrides = data.get("transcode_overrides")
+    if isinstance(raw_overrides, str):
+        try:
+            data["transcode_overrides"] = json.loads(raw_overrides)
+        except (json.JSONDecodeError, TypeError):
+            data["transcode_overrides"] = None
+    return JobContract.model_validate(data).model_dump(mode="json")
 
 
 @router.get('/jobs')
@@ -838,36 +857,38 @@ def update_transcode_config(job_id: int, body: dict):
 
 
 def _track_to_dict(track):
-    """Serialize a Track row to a dict matching the UI's TrackSchema.
+    """Serialize a Track row to a wire dict via the shared TrackContract.
 
     main_feature -> enabled fallback preserves the legacy semantic where
-    older tracks with no enabled flag default to main_feature.
+    older tracks with no enabled flag default to main_feature. The fold
+    happens here so the contract never carries main_feature.
     """
     enabled = track.enabled if track.enabled is not None else track.main_feature
-    return {
-        "track_id": track.track_id,
-        "job_id": track.job_id,
-        "track_number": track.track_number,
-        "length": track.length,
-        "aspect_ratio": track.aspect_ratio,
-        "fps": track.fps,
-        "enabled": enabled,
-        "basename": track.basename,
-        "filename": track.filename,
-        "orig_filename": track.orig_filename,
-        "new_filename": track.new_filename,
-        "ripped": track.ripped,
-        "status": track.status,
-        "error": track.error,
-        "source": track.source,
-        "title": track.title,
-        "year": track.year,
-        "imdb_id": track.imdb_id,
-        "poster_url": track.poster_url,
-        "video_type": track.video_type,
-        "episode_number": track.episode_number,
-        "episode_name": track.episode_name,
-    }
+    return TrackContract(
+        track_id=track.track_id,
+        job_id=track.job_id,
+        track_number=track.track_number,
+        length=track.length,
+        aspect_ratio=track.aspect_ratio,
+        fps=track.fps,
+        enabled=enabled,
+        basename=track.basename,
+        filename=track.filename,
+        orig_filename=track.orig_filename,
+        new_filename=track.new_filename,
+        ripped=track.ripped,
+        status=track.status,
+        error=track.error,
+        source=track.source,
+        title=track.title,
+        year=track.year,
+        imdb_id=track.imdb_id,
+        poster_url=track.poster_url,
+        video_type=track.video_type,
+        episode_number=track.episode_number,
+        episode_name=track.episode_name,
+        custom_filename=track.custom_filename,
+    ).model_dump(mode="json")
 
 
 def _job_config_masked(job_config):
@@ -932,17 +953,17 @@ def get_job_progress_state(job_id: int):
     rip = progress_reader.get_rip_progress(job_id)
     music = progress_reader.get_music_progress(job.logfile, job.no_of_titles or 0)
 
-    return {
-        "track_counts": counts,
-        "disctype": job.disctype,
-        "logfile": job.logfile,
-        "no_of_titles": job.no_of_titles,
-        "rip_progress": rip["progress"],
-        "rip_stage": rip["stage"],
-        "tracks_ripped_realtime": rip["tracks_ripped"],
-        "music_progress": music["progress"],
-        "music_stage": music["stage"],
-    }
+    return JobProgressState(
+        track_counts=TrackCounts(**counts),
+        disctype=job.disctype,
+        logfile=job.logfile,
+        no_of_titles=job.no_of_titles,
+        rip_progress=rip["progress"],
+        rip_stage=rip["stage"],
+        tracks_ripped_realtime=rip["tracks_ripped"],
+        music_progress=music["progress"],
+        music_stage=music["stage"],
+    ).model_dump(mode="json")
 
 
 def _parse_transcode_overrides(raw: str | None) -> dict | None:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -2801,6 +2801,49 @@ class TestApiJobDetail:
         assert response.status_code == 200
         assert response.json()["config"] is None
 
+    def test_job_detail_track_carries_custom_filename(self, client, sample_job, app_context):
+        """Audit gap fix: custom_filename was previously dropped by _track_to_dict;
+        the contract adoption restores it on the wire so the UI can render it."""
+        from arm.models.track import Track
+        from arm.database import db
+
+        t = Track(
+            job_id=sample_job.job_id, track_number="0",
+            length=3600, aspect_ratio="16:9", fps="23.976",
+            main_feature=True, source="MakeMKV",
+            basename="title_t00.mkv", filename="title_t00.mkv",
+        )
+        t.custom_filename = "S01E01_pilot.mkv"
+        db.session.add(t)
+        db.session.commit()
+
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/detail')
+        data = response.json()
+        assert data["tracks"][0]["custom_filename"] == "S01E01_pilot.mkv"
+
+    def test_job_detail_transcode_overrides_dict_round_trips(self, client, sample_job, app_context):
+        """A valid JSON-string transcode_overrides column round-trips as a dict
+        on the wire (not the raw string), so the UI can read preset_slug etc."""
+        import json as _json
+        from arm.database import db
+        sample_job.transcode_overrides = _json.dumps({"preset_slug": "nvidia_balanced"})
+        db.session.commit()
+
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/detail')
+        data = response.json()
+        assert data["job"]["transcode_overrides"] == {"preset_slug": "nvidia_balanced"}
+
+    def test_job_detail_corrupt_transcode_overrides_drops_to_null(self, client, sample_job, app_context):
+        """A non-JSON transcode_overrides column drops to null instead of
+        propagating garbage to the UI."""
+        from arm.database import db
+        sample_job.transcode_overrides = "{this is not json"
+        db.session.commit()
+
+        response = client.get(f'/api/v1/jobs/{sample_job.job_id}/detail')
+        data = response.json()
+        assert data["job"]["transcode_overrides"] is None
+
 
 class TestApiJobProgressState:
     """Test GET /api/v1/jobs/<id>/progress-state endpoint."""


### PR DESCRIPTION
Phase B of the Job-family contracts rollout.

## What's in this PR

1. **Submodule bump** components/contracts -> v0.5.1 (1f17568)
   - v0.5.0 adds Job, JobSummary, Track, TrackCounts, JobProgressState contracts
   - v0.5.1 adds from_attributes=True to JobSummary (so producers can call .model_validate(orm_job) directly)

2. **Producer adoption** - all four wire-shape producers in arm-neu now build via Pydantic:
   - `_job_to_dict` (jobs.py): Job contract with mode='json' for ISO datetimes; JSON-parses transcode_overrides string column to dict before validation
   - `_track_to_dict` (jobs.py): Track contract construction with `enabled = enabled or main_feature` fold preserved here so the contract never carries main_feature; **adds custom_filename to the wire** (was silently dropped)
   - `_job_summary` (drives.py): JobSummary.model_validate(orm_job) on the slim 9-field shape
   - `get_job_progress_state` (jobs.py): JobProgressState construction instead of inline dict

## Drift fixes inherited from the contracts

These four fields were silently inconsistent before this PR:
- `Track.custom_filename` - producer set it on disk but never on the wire
- `Job.title_pattern_override` / `Job.folder_pattern_override` - on the wire from arm-neu but stripped by arm-ui's old JobSchema
- `Job.transcode_overrides` - was a raw JSON string; now arrives as a typed dict

## Test plan

- [x] arm-neu pytest: 2028 passed locally
- [x] contracts pytest: 81 passed (v0.5.1 tag)
- [ ] CI green on this PR
- [ ] Phase C (arm-ui adoption) opens after this lands