### PR TITLE
feat(api): version-handshake on transcode-callback receiver (G2, lenient)

### DIFF
--- a/arm/api/dependencies.py
+++ b/arm/api/dependencies.py
@@ -1,0 +1,36 @@
+"""Shared FastAPI dependencies for the v1 API surface."""
+from __future__ import annotations
+
+from fastapi import Header, HTTPException
+
+from arm.version import (
+    ACCEPT_MISSING_VERSION_HEADER,
+    ACCEPTED_VERSIONS,
+)
+
+
+async def require_api_version(
+    x_api_version: str | None = Header(default=None, alias="X-Api-Version"),
+) -> str | None:
+    """Validate the X-Api-Version header on cross-service inbound calls.
+
+    Mirrors transcoder/src/routers/jobs.py:require_api_version. Returns the
+    accepted header value (or None when missing-and-lenient) so route
+    handlers can log it. Raises HTTPException(400) on rejection.
+    """
+    if x_api_version is None:
+        if ACCEPT_MISSING_VERSION_HEADER:
+            return None
+        raise HTTPException(
+            status_code=400,
+            detail="X-Api-Version header is required",
+        )
+    if x_api_version not in ACCEPTED_VERSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported X-Api-Version: {x_api_version!r}. "
+                f"Accepted: {sorted(ACCEPTED_VERSIONS)}"
+            ),
+        )
+    return x_api_version

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -19,11 +19,12 @@ from arm_contracts import (
     TrackCounts,
     TranscodeCallbackPayload,
 )
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from sqlalchemy import func, or_
 
+from arm.api.dependencies import require_api_version
 import arm.config.config as cfg
 from arm.constants import SINGLE_TRACK_VIDEO_TYPES
 from arm.database import db
@@ -1055,7 +1056,7 @@ def get_retranscode_info(job_id: int):
     return payload
 
 
-@router.post('/jobs/{job_id}/transcode-callback')
+@router.post('/jobs/{job_id}/transcode-callback', dependencies=[Depends(require_api_version)])
 def transcode_callback(job_id: int, body: dict):
     """Receive status update from the external transcoder.
 

--- a/arm/version.py
+++ b/arm/version.py
@@ -1,0 +1,28 @@
+"""API version constant for the cross-service ARM handshake.
+
+Mirrors transcoder/src/version.py, but starts in LENIENT mode
+(ACCEPT_MISSING_VERSION_HEADER = True) because not all transcoder
+deployments stamp X-Api-Version on outbound callbacks yet (fixed
+2026-04-29 in transcoder; needs deploy + soak before strict mode).
+
+Bumped when the cross-service contract changes in a backwards-
+incompatible way.
+
+  v1 - pre-preset, flat encoding keys (video_encoder, handbrake_preset*, ...)
+  v2 - preset-based shape (preset_slug + overrides dict)
+"""
+
+API_VERSION = "2"
+
+# Versions accepted on inbound requests that opt into version checking
+# (currently: the transcode-callback receiver).
+ACCEPTED_VERSIONS = frozenset({"2"})
+
+# When True, requests with no X-Api-Version header are accepted (lenient).
+# When False, missing header returns 400.
+#
+# Lenient initially: until all deployed transcoders carry the post-2026-04-29
+# fix, callbacks may arrive without the header. Flip to False once prod logs
+# show all callbacks include the header. Tracked in memory:
+# project_arm_neu_callback_strict_version_flip.md
+ACCEPT_MISSING_VERSION_HEADER = True

--- a/test/test_callback_version_handshake.py
+++ b/test/test_callback_version_handshake.py
@@ -1,0 +1,78 @@
+"""Version-handshake tests for /api/v1/jobs/{id}/transcode-callback.
+
+Mirrors transcoder/tests/test_version_handshake.py for the opposite
+direction. Currently runs in lenient mode
+(ACCEPT_MISSING_VERSION_HEADER = True). The 'strict mode' test is
+skipped until F1 ships and we flip the flag.
+
+Audit reference:
+docs/superpowers/specs/2026-04-29-cross-service-contract-drift-audit-design.md G2.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def client(app_context):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from arm.api.v1.jobs import router
+
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as c:
+        yield c
+
+
+_VALID_BODY = {"status": "transcoding"}
+
+
+def test_callback_accepts_version_2(client, sample_job):
+    """X-Api-Version: 2 is accepted."""
+    response = client.post(
+        f"/api/v1/jobs/{sample_job.job_id}/transcode-callback",
+        json=_VALID_BODY,
+        headers={"X-Api-Version": "2"},
+    )
+    assert response.status_code in (200, 204), response.text
+
+
+def test_callback_rejects_version_1(client, sample_job):
+    """X-Api-Version: 1 is rejected with 400."""
+    response = client.post(
+        f"/api/v1/jobs/{sample_job.job_id}/transcode-callback",
+        json=_VALID_BODY,
+        headers={"X-Api-Version": "1"},
+    )
+    assert response.status_code == 400
+    assert "Unsupported X-Api-Version" in response.text
+
+
+def test_callback_lenient_on_missing_header(client, sample_job):
+    """Missing header is currently accepted (ACCEPT_MISSING_VERSION_HEADER=True).
+
+    This test documents lenient mode. Flip to expect 400 when the strict-mode
+    fix lands.
+    """
+    response = client.post(
+        f"/api/v1/jobs/{sample_job.job_id}/transcode-callback",
+        json=_VALID_BODY,
+    )
+    # Must NOT be 400. Other 4xx (e.g. 422 for malformed body, which our body
+    # is not) would also indicate a different bug.
+    assert response.status_code in (200, 204), response.text
+
+
+@pytest.mark.skip(
+    reason="F2 strict-mode flip is a separate one-line follow-up. "
+    "Enable when ACCEPT_MISSING_VERSION_HEADER flips to False."
+)
+def test_callback_rejects_missing_header_in_strict_mode(client, sample_job):
+    """When ACCEPT_MISSING_VERSION_HEADER=False, missing header is 400."""
+    response = client.post(
+        f"/api/v1/jobs/{sample_job.job_id}/transcode-callback",
+        json=_VALID_BODY,
+    )
+    assert response.status_code == 400
+    assert "X-Api-Version header is required" in response.text


### PR DESCRIPTION
## Summary

Closes G2 from the 2026-04-29 cross-service contract-drift audit. arm-neu's `POST /api/v1/jobs/{id}/transcode-callback` had no version handshake; the transcoder enforced `X-Api-Version: 2` on its inbound `/webhook/arm` but the reverse direction did nothing.

This PR adds the symmetric piece in lenient mode (`ACCEPT_MISSING_VERSION_HEADER = True`). Three commits, each a small step:

1. `feat(api): add version module and require_api_version dependency` - new `arm/version.py` and `arm/api/dependencies.py`. Mirrors `transcoder/src/version.py`. Lenient by design.
2. `feat(api): require_api_version dependency on transcode-callback receiver` - one-line wiring with `dependencies=[Depends(require_api_version)]` on the route decorator. Function signature unchanged so existing tests still POST without a header.
3. `test(api): version-handshake tests for transcode-callback receiver` - new `test/test_callback_version_handshake.py` mirroring transcoder's `test_version_handshake.py`. 3 tests pass + 1 strict-mode test marked `@pytest.mark.skip` as a canary for the eventual flip.

**Deployment ordering:** the companion transcoder PR (`feat/contract-drift-audit-2026-04-29` in transcoder repo) ships the X-Api-Version stamp on outbound callbacks. That PR must merge and reach prod before flipping `ACCEPT_MISSING_VERSION_HEADER` to `False` here, or callbacks from older transcoders would 400. The flip is tracked in memory (`project_arm_neu_callback_strict_version_flip.md`) and the skipped test is the canary.

## Test Plan

- [x] `pytest test/ -q` -> 2034 passed, 1 skipped (the strict-mode canary)
- [x] All three commits land cleanly with no test regressions in lenient mode
- [ ] After merge + transcoder PR deploy: confirm prod logs show every callback carrying `X-Api-Version: 2`, then submit a one-line follow-up flipping the flag and unskipping the canary test