### PR TITLE
fix(progress): hold rip percentage during inter-title PRGT transitions

### DIFF
--- a/arm/services/progress_reader.py
+++ b/arm/services/progress_reader.py
@@ -69,11 +69,19 @@ def get_rip_progress(job_id: int) -> dict[str, Any]:
 
     last_prgv, last_prgc, last_prgt = _parse_progress_lines(data.splitlines())
 
+    # PRGC tracks per-title state; PRGT tracks overall operation. Between
+    # titles in a folder rip MakeMKV briefly emits non-"Saving" PRGT messages
+    # (e.g. "Analyzing seamless segments") while PRGC stays on "Saving to MKV
+    # file" - prefer PRGC so the percentage doesn't flicker to indeterminate.
+    is_rip_phase = (
+        (last_prgc and last_prgc.group(2) == "Saving to MKV file")
+        or (last_prgt and "Saving" in last_prgt)
+    )
+
     if last_prgv:
         total = int(last_prgv.group(2))
         maximum = int(last_prgv.group(3))
         if maximum > 0:
-            is_rip_phase = last_prgt and "Saving" in last_prgt
             if is_rip_phase:
                 result["progress"] = round(total / maximum * 100, 1)
             else:

--- a/test/test_progress_reader.py
+++ b/test/test_progress_reader.py
@@ -43,6 +43,30 @@ class TestRipProgress:
         result = progress_reader.get_rip_progress(3)
         assert result["progress"] is None
 
+    def test_progress_held_when_prgt_transitions_between_titles(self, progress_dir):
+        """Folder rips: MakeMKV emits non-'Saving' PRGT between titles while
+        PRGC stays on 'Saving to MKV file'. Progress must not go null during
+        those windows or the UI flickers to an indeterminate slider.
+        """
+        (progress_dir / "progress" / "5.log").write_text(
+            'PRGT:0,0,"Saving all titles to MKV files"\n'
+            'PRGC:0,1,"Saving to MKV file"\n'
+            "PRGV:2500,5000,10000\n"
+            'PRGT:0,0,"Analyzing seamless segments"\n'
+        )
+        result = progress_reader.get_rip_progress(5)
+        assert result["progress"] == pytest.approx(50.0)
+
+    def test_progress_held_when_prgc_is_saving_without_saving_prgt(self, progress_dir):
+        """PRGC alone is enough to identify the rip phase; PRGT can lag."""
+        (progress_dir / "progress" / "6.log").write_text(
+            'PRGT:0,0,"Processing AV clips"\n'
+            'PRGC:0,2,"Saving to MKV file"\n'
+            "PRGV:1000,4000,10000\n"
+        )
+        result = progress_reader.get_rip_progress(6)
+        assert result["progress"] == pytest.approx(40.0)
+
     def test_oserror_on_open_returns_default(self, progress_dir, monkeypatch):
         target = progress_dir / "progress" / "4.log"
         target.write_text("PRGV:1,1,2\n")


### PR DESCRIPTION
## Summary

- Fix UI progress flicker on `/jobs/[id]` during folder rips: percentage briefly disappears between titles, replaced by the indeterminate slider, then reappears at a different value ~30s later.
- Root cause: `progress_reader.get_rip_progress()` required the *latest* PRGT to contain "Saving" before populating progress. MakeMKV emits transitional PRGT messages (e.g. "Analyzing seamless segments", "Processing AV clips") between titles in a multi-title rip while PRGC stays on "Saving to MKV file".
- Fix: prefer PRGC's per-title state over PRGT's overall operation message. PRGC == "Saving to MKV file" is a sufficient rip-phase signal.

## Test Plan

- [x] `pytest test/test_progress_reader.py` (19 passed including 2 new regression tests)
- [x] Full suite: `pytest test/` (2017 passed)
- [ ] Cut RC, deploy to hifi-server, observe a folder rip without flicker