### PR TITLE
feat: per-job ExpectedTitle and unified skip_reason filter honesty

### DIFF
--- a/arm/api/v1/folder.py
+++ b/arm/api/v1/folder.py
@@ -18,6 +18,21 @@ log = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1", tags=["folder"])
 
 
+def auto_disable_short_tracks(job, minlength: int) -> int:
+    """Disable tracks below `minlength` seconds and tag them with skip_reason.
+
+    MakeMKV silently skips these during rip regardless of the checkbox state,
+    so disabling them prevents misleading UI. Returns the count disabled.
+    """
+    disabled_count = 0
+    for track in job.tracks:
+        if track.length is not None and track.length < minlength:
+            track.enabled = False
+            track.skip_reason = "too_short"
+            disabled_count += 1
+    return disabled_count
+
+
 class FolderScanRequest(BaseModel):
     path: str
 
@@ -182,15 +197,8 @@ def _prescan_and_wait(job_id: int):
             prep_mkv()
             prescan_track_info(job)
 
-            # Auto-disable tracks shorter than MakeMKV's minlength threshold.
-            # MakeMKV silently skips these during rip regardless of the
-            # checkbox state, so disabling them prevents misleading UI.
             minlength = int(cfg.arm_config.get("MINLENGTH", 120))
-            disabled_count = 0
-            for track in job.tracks:
-                if track.length is not None and track.length < minlength:
-                    track.enabled = False
-                    disabled_count += 1
+            disabled_count = auto_disable_short_tracks(job, minlength)
             if disabled_count:
                 log.info("Auto-disabled %d tracks shorter than %ds",
                          disabled_count, minlength)

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -1333,6 +1333,11 @@ def update_track_fields(job_id: int, track_id: int, body: dict):
 
     for key, value in clean.items():
         setattr(track, key, value)
+    # Mirror the user's enable/disable choice into skip_reason. Re-enabling
+    # clears any prior reason (auto-disable from prescan would re-fire on
+    # the next prescan if needed).
+    if "enabled" in clean:
+        track.skip_reason = None if clean["enabled"] else "user_disabled"
     # Keep track.title in sync — the webhook payload reads track.title for
     # the filename, so it must reflect the current episode_name when set.
     if "episode_name" in clean and clean["episode_name"]:

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -1333,9 +1333,7 @@ def update_track_fields(job_id: int, track_id: int, body: dict):
 
     for key, value in clean.items():
         setattr(track, key, value)
-    # Mirror the user's enable/disable choice into skip_reason. Re-enabling
-    # clears any prior reason (auto-disable from prescan would re-fire on
-    # the next prescan if needed).
+    # Re-enabling clears any prior reason; prescan re-fires it next pass.
     if "enabled" in clean:
         track.skip_reason = None if clean["enabled"] else "user_disabled"
     # Keep track.title in sync — the webhook payload reads track.title for

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -894,6 +894,8 @@ def _track_to_dict(track):
         episode_number=track.episode_number,
         episode_name=track.episode_name,
         custom_filename=track.custom_filename,
+        process=track.process if track.process is not None else True,
+        skip_reason=track.skip_reason,
     ).model_dump(mode="json")
 
 

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -878,6 +878,8 @@ def _track_to_dict(track):
         aspect_ratio=track.aspect_ratio,
         fps=track.fps,
         enabled=enabled,
+        process=track.process if track.process is not None else True,
+        skip_reason=track.skip_reason,
         basename=track.basename,
         filename=track.filename,
         orig_filename=track.orig_filename,
@@ -894,8 +896,6 @@ def _track_to_dict(track):
         episode_number=track.episode_number,
         episode_name=track.episode_name,
         custom_filename=track.custom_filename,
-        process=track.process if track.process is not None else True,
-        skip_reason=track.skip_reason,
     ).model_dump(mode="json")
 
 

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -113,6 +113,10 @@ def _job_to_dict(job):
     transcode_overrides arrives from the DB as a JSON string; pre-parse
     it to a dict so the contract's `dict | None` type validates. Legacy-
     key stripping is consumer-side (arm-ui) and not the producer's job.
+
+    expected_titles is a db.relationship (not a column), so it has to be
+    added explicitly. Pydantic's from_attributes=True on ExpectedTitle
+    handles the per-row validation.
     """
     data = {
         col.name: getattr(job, col.name)
@@ -124,6 +128,7 @@ def _job_to_dict(job):
             data["transcode_overrides"] = json.loads(raw_overrides)
         except (json.JSONDecodeError, TypeError):
             data["transcode_overrides"] = None
+    data["expected_titles"] = list(job.expected_titles or [])
     return JobContract.model_validate(data).model_dump(mode="json")
 
 

--- a/arm/migrations/versions/p1q2r3s4t5u6_expected_titles.py
+++ b/arm/migrations/versions/p1q2r3s4t5u6_expected_titles.py
@@ -1,0 +1,40 @@
+"""expected_titles table
+
+Revision ID: p1q2r3s4t5u6
+Revises: o0p1q2r3s4t5
+Create Date: 2026-05-01
+
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'p1q2r3s4t5u6'
+down_revision = 'o0p1q2r3s4t5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'expected_title',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('job_id', sa.Integer(),
+                  sa.ForeignKey('job.job_id'), nullable=False),
+        sa.Column('source', sa.String(16), nullable=False),
+        sa.Column('title', sa.String(256), nullable=True),
+        sa.Column('season', sa.Integer(), nullable=True),
+        sa.Column('episode_number', sa.Integer(), nullable=True),
+        sa.Column('external_id', sa.String(32), nullable=True),
+        sa.Column('runtime_seconds', sa.Integer(), nullable=True),
+        sa.Column('fetched_at', sa.DateTime(), nullable=True),
+    )
+    op.create_index('ix_expected_title_job_id', 'expected_title', ['job_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_expected_title_job_id', table_name='expected_title')
+    op.drop_table('expected_title')

--- a/arm/migrations/versions/q2r3s4t5u6v7_track_skip_reason.py
+++ b/arm/migrations/versions/q2r3s4t5u6v7_track_skip_reason.py
@@ -3,22 +3,26 @@
 Revision ID: q2r3s4t5u6v7
 Revises: p1q2r3s4t5u6
 Create Date: 2026-05-01
+
 """
+from __future__ import annotations
+
 import sqlalchemy as sa
 from alembic import op
 
 
-revision = "q2r3s4t5u6v7"
-down_revision = "p1q2r3s4t5u6"
+# revision identifiers, used by Alembic.
+revision = 'q2r3s4t5u6v7'
+down_revision = 'p1q2r3s4t5u6'
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    with op.batch_alter_table("track") as batch:
-        batch.add_column(sa.Column("skip_reason", sa.String(32), nullable=True))
+    with op.batch_alter_table('track') as batch:
+        batch.add_column(sa.Column('skip_reason', sa.String(32), nullable=True))
 
 
 def downgrade() -> None:
-    with op.batch_alter_table("track") as batch:
-        batch.drop_column("skip_reason")
+    with op.batch_alter_table('track') as batch:
+        batch.drop_column('skip_reason')

--- a/arm/migrations/versions/q2r3s4t5u6v7_track_skip_reason.py
+++ b/arm/migrations/versions/q2r3s4t5u6v7_track_skip_reason.py
@@ -1,0 +1,24 @@
+"""track.skip_reason column
+
+Revision ID: q2r3s4t5u6v7
+Revises: p1q2r3s4t5u6
+Create Date: 2026-05-01
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "q2r3s4t5u6v7"
+down_revision = "p1q2r3s4t5u6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("track") as batch:
+        batch.add_column(sa.Column("skip_reason", sa.String(32), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("track") as batch:
+        batch.drop_column("skip_reason")

--- a/arm/models/__init__.py
+++ b/arm/models/__init__.py
@@ -4,6 +4,7 @@
 from .alembic_version import AlembicVersion  # noqa F401
 from .app_state import AppState  # noqa F401
 from .config import Config  # noqa F401
+from .expected_title import ExpectedTitle  # noqa F401
 from .job import Job, JobState  # noqa F401
 from .notifications import Notifications  # noqa F401
 from .system_drives import SystemDrives  # noqa F401

--- a/arm/models/expected_title.py
+++ b/arm/models/expected_title.py
@@ -1,0 +1,35 @@
+"""ExpectedTitle: a title we expect to find on the disc, sourced from metadata.
+
+Populated at identification time. Used downstream by the track filter
+(Layer C, deferred) and by the matcher (already consumes episode runtimes).
+
+Generic shape covers single-feature movies (1 row), TV series (N rows
+per episode), and anthology / multi-feature discs (N rows per work).
+"""
+from datetime import datetime
+
+from arm.database import db
+
+
+class ExpectedTitle(db.Model):
+    __tablename__ = "expected_title"
+
+    id = db.Column(db.Integer, primary_key=True)
+    job_id = db.Column(
+        db.Integer, db.ForeignKey("job.job_id"), nullable=False, index=True
+    )
+    source = db.Column(db.String(16), nullable=False)
+    title = db.Column(db.String(256), nullable=True)
+    season = db.Column(db.Integer, nullable=True)
+    episode_number = db.Column(db.Integer, nullable=True)
+    external_id = db.Column(db.String(32), nullable=True)
+    runtime_seconds = db.Column(db.Integer, nullable=True)
+    fetched_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self) -> str:
+        ep = (
+            f" S{self.season}E{self.episode_number:02d}"
+            if self.season is not None and self.episode_number is not None
+            else ""
+        )
+        return f"<ExpectedTitle {self.source}:{self.title}{ep} {self.runtime_seconds}s>"

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -199,6 +199,12 @@ class Job(db.Model):
     folder_pattern_override = db.Column(db.String(512), nullable=True)
     tracks = db.relationship('Track', backref='job', lazy='dynamic')
     config = db.relationship('Config', uselist=False, backref="job")
+    expected_titles = db.relationship(
+        "ExpectedTitle",
+        backref="job",
+        lazy="select",
+        cascade="all, delete-orphan",
+    )
 
     def __init__(self, devpath, _skip_hardware=False):
         """Return a disc object"""

--- a/arm/models/track.py
+++ b/arm/models/track.py
@@ -20,6 +20,7 @@ class Track(db.Model):
     source = db.Column(db.String(32))
     process = db.Column(db.Boolean)
     enabled = db.Column(db.Boolean, default=True)
+    skip_reason = db.Column(db.String(32), nullable=True)
     chapters = db.Column(db.Integer, default=0)
     filesize = db.Column(db.BigInteger, default=0)
     # Per-track title metadata (nullable — inherits job-level when null)

--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -2,6 +2,7 @@
 It would help clear up main and make things easier to find
 """
 import logging
+from collections import Counter
 from importlib.util import find_spec
 from pathlib import Path
 import sys
@@ -70,6 +71,27 @@ def _post_rip_handoff(job):
         utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete.")
 
 
+def check_empty_rip(job) -> bool:
+    """Return True if the job ended with zero tracks ripped, False otherwise.
+
+    On True, also writes a structured failure reason to job.errors so the
+    UI can surface it. Caller should set job.status to a failure state.
+    """
+    tracks = list(job.tracks)
+    n_ripped = sum(1 for t in tracks if t.ripped)
+    if n_ripped > 0:
+        return False
+    reasons = Counter(t.skip_reason or "unknown" for t in tracks)
+    breakdown = ", ".join(f"{n} {reason}" for reason, n in reasons.most_common())
+    job.errors = (
+        f"All {len(tracks)} tracks were filtered or unprocessed: {breakdown}. "
+        f"Check MINLENGTH (current: {job.config.MINLENGTH}s) and "
+        f"MAXLENGTH ({job.config.MAXLENGTH}s)."
+    )
+    db.session.commit()
+    return True
+
+
 def rip_visual_media(have_dupes, job, logfile, protection):
     """
     Main ripping function for dvd and Blu-rays, movies or series.
@@ -110,6 +132,13 @@ def rip_visual_media(have_dupes, job, logfile, protection):
 
     # Persist raw_path to DB — this is the actual directory on disk
     utils.database_updater({'raw_path': makemkv_out_path}, job)
+
+    if check_empty_rip(job):
+        job.status = JobState.FAILURE.value
+        db.session.commit()
+        logging.warning("Empty rip detected: %s", job.errors)
+        notify_exit(job)
+        return
 
     _post_rip_handoff(job)
     logging.info("************* Ripping with MakeMKV completed *************")

--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -72,14 +72,11 @@ def _post_rip_handoff(job):
 
 
 def check_empty_rip(job) -> bool:
-    """Return True if the job ended with zero tracks ripped, False otherwise.
-
-    On True, also writes a structured failure reason to job.errors so the
-    UI can surface it. Caller should set job.status to a failure state.
-    """
+    """Return True and stage a structured job.errors message if no tracks were ripped."""
     tracks = list(job.tracks)
-    n_ripped = sum(1 for t in tracks if t.ripped)
-    if n_ripped > 0:
+    if not tracks:
+        return False
+    if any(t.ripped for t in tracks):
         return False
     reasons = Counter(t.skip_reason or "unknown" for t in tracks)
     breakdown = ", ".join(f"{n} {reason}" for reason, n in reasons.most_common())
@@ -88,7 +85,6 @@ def check_empty_rip(job) -> bool:
         f"Check MINLENGTH (current: {job.config.MINLENGTH}s) and "
         f"MAXLENGTH ({job.config.MAXLENGTH}s)."
     )
-    db.session.commit()
     return True
 
 

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -30,6 +30,7 @@ from arm.ripper import utils
 from arm.ripper.ProcessHandler import arm_subprocess
 from arm.ripper.utils import RipperException
 from arm.database import db
+from arm.models.expected_title import ExpectedTitle
 
 # flake8: noqa: W605
 
@@ -530,6 +531,13 @@ def identify_dvd(job):
                 'hasnicetitle': True
             }
             utils.database_updater(args, job)
+            _write_movie_expected_title(
+                job,
+                title=hit.get('title'),
+                imdb_id=hit.get('imdb_id'),
+                runtime_seconds=None,  # CRC database does not return runtime
+                source="manual",
+            )
             _detect_track_99(job)
             return True
     except Exception as error:
@@ -556,6 +564,35 @@ def _detect_track_99(job):
 
 
 # ── Metadata helpers (unchanged) ───────────────────────────────────────
+
+def _write_movie_expected_title(
+    job,
+    title: str | None,
+    imdb_id: str | None,
+    runtime_seconds: int | None,
+    source: str,
+) -> None:
+    """Write or replace the ExpectedTitle row(s) for a movie job.
+
+    Idempotent: clears any existing ExpectedTitle rows for the job before
+    writing, so re-running identification (e.g. via a future rematch
+    endpoint) rewrites cleanly.
+
+    `source` should be "omdb", "tmdb", or "manual" (or "tvdb" for TV - see
+    A6's TV-specific helper). Movie hits from update_job() use whatever
+    METADATA_PROVIDER produced the result; CRC64 fast-path hits use "manual"
+    since the CRC database is community-curated, not a metadata provider.
+    """
+    db.session.query(ExpectedTitle).filter_by(job_id=job.job_id).delete()
+    db.session.add(ExpectedTitle(
+        job_id=job.job_id,
+        source=source,
+        title=title,
+        external_id=imdb_id,
+        runtime_seconds=runtime_seconds,
+    ))
+    db.session.commit()
+
 
 def update_job(job, search_results):
     """
@@ -634,7 +671,19 @@ def update_job(job, search_results):
         if selection.label_info.season_number is not None:
             args['season_auto'] = str(selection.label_info.season_number)
             args['season'] = str(selection.label_info.season_number)
-    return utils.database_updater(args, job)
+    result = utils.database_updater(args, job)
+    runtime_seconds = (best.raw_result or {}).get("runtime_seconds")
+    provider = (cfg.arm_config.get("METADATA_PROVIDER") or "omdb").lower()
+    if provider not in ("omdb", "tmdb"):
+        provider = "omdb"
+    _write_movie_expected_title(
+        job,
+        title=title,
+        imdb_id=best.imdb_id,
+        runtime_seconds=runtime_seconds,
+        source=provider,
+    )
+    return result
 
 
 def _to_matcher_format(normalized: list[dict]) -> list[dict]:

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -672,17 +672,21 @@ def update_job(job, search_results):
             args['season_auto'] = str(selection.label_info.season_number)
             args['season'] = str(selection.label_info.season_number)
     result = utils.database_updater(args, job)
-    runtime_seconds = (best.raw_result or {}).get("runtime_seconds")
-    provider = (cfg.arm_config.get("METADATA_PROVIDER") or "omdb").lower()
-    if provider not in ("omdb", "tmdb"):
-        provider = "omdb"
-    _write_movie_expected_title(
-        job,
-        title=title,
-        imdb_id=best.imdb_id,
-        runtime_seconds=runtime_seconds,
-        source=provider,
-    )
+
+    # Only write ExpectedTitle for movies. TV series matches are handled by the
+    # TVDB-based path in A6, which writes one row per episode.
+    if best.type == "movie":
+        runtime_seconds = (best.raw_result or {}).get("runtime_seconds")
+        provider = (cfg.arm_config.get("METADATA_PROVIDER") or "omdb").lower()
+        if provider not in ("omdb", "tmdb"):
+            provider = "omdb"
+        _write_movie_expected_title(
+            job,
+            title=title,
+            imdb_id=best.imdb_id,
+            runtime_seconds=runtime_seconds,
+            source=provider,
+        )
     return result
 
 

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -745,11 +745,17 @@ def makemkv_mkv(job, rawpath):
             f"--minlength={job.config.MINLENGTH}",
         ]
         logging.info("Process all tracks from disc.")
+        skips: list[dict] = []
         for msg in run(cmd, OutputType.MSG):
             # Mark tracks ripped in real-time as MakeMKV saves each title.
             # MSG code 3307 = FILE_ADDED: "File {name} was added as title #{N}"
             if hasattr(msg, 'code') and int(msg.code) == MessageID.FILE_ADDED:
                 _mark_track_ripped_by_message(job, msg.message)
+            parsed = parse_makemkv_skip_message(getattr(msg, 'message', ''))
+            if parsed:
+                skips.append(parsed)
+        if skips:
+            apply_makemkv_skips(job, skips)
         # Final sweep: mark any remaining tracks whose files exist on disk
         _mark_ripped_from_disk(job, rawpath)
     else:
@@ -1672,6 +1678,51 @@ class MakeMKVOutputChecker:
         log_func = self.LOG_ONLY_CODES[self.data.code]
         log_func(self.data.message)
         return self.data
+
+
+_MAKEMKV_SKIP_RE = re.compile(
+    r"^Title #(?P<num>\d+) has length of (?P<len>\d+) seconds "
+    r"which is less than minimum title length of (?P<min>\d+) seconds "
+    r"and was therefore skipped$"
+)
+
+
+def parse_makemkv_skip_message(line: str) -> dict | None:
+    """Parse a MakeMKV 'title skipped because too short' stdout line.
+
+    Returns a dict with keys track_number, length, min_length, or None
+    if the line is not a skip message.
+    """
+    line = line.strip()
+    if line.startswith("MakeMKV: "):
+        line = line[len("MakeMKV: "):]
+    m = _MAKEMKV_SKIP_RE.match(line)
+    if not m:
+        return None
+    return {
+        "track_number": m.group("num"),
+        "length": int(m.group("len")),
+        "min_length": int(m.group("min")),
+    }
+
+
+def apply_makemkv_skips(job, skips: list[dict]) -> None:
+    """Apply a batch of parse_makemkv_skip_message results to track records.
+
+    Sets process=False, skip_reason='makemkv_skipped' on each matching
+    track. Tracks not present in the DB are silently ignored.
+    """
+    if not skips:
+        return
+    skip_nums = {s["track_number"] for s in skips}
+    rows = (db.session.query(Track)
+            .filter(Track.job_id == job.job_id,
+                    Track.track_number.in_(skip_nums))
+            .all())
+    for r in rows:
+        r.process = False
+        r.skip_reason = "makemkv_skipped"
+    db.session.commit()
 
 
 def run(options, select):

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -1291,20 +1291,19 @@ def process_single_tracks(job, rawpath, mode: str):
         # Process single track automatically based on start and finish times
         if mode == 'auto':
             if track.length < int(job.config.MINLENGTH):
-                # too short
                 logging.info(f"Track #{track.track_number} of {job.no_of_titles}. Length ({track.length}) "
                              f"is less than minimum length ({job.config.MINLENGTH}).  Skipping")
                 track.process = False
-
+                track.skip_reason = "too_short"
             elif track.length > int(job.config.MAXLENGTH):
-                # too long
                 logging.info(f"Track #{track.track_number} of {job.no_of_titles}. "
                              f"Length ({track.length}) is greater than maximum length ({job.config.MAXLENGTH}).  "
                              "Skipping")
                 track.process = False
+                track.skip_reason = "too_long"
             else:
-                # track is just right
                 track.process = True
+                track.skip_reason = None
 
         # Rip the track if the user has set it to rip, or in auto mode and the time is good
         if track.process:
@@ -1328,6 +1327,7 @@ def process_single_tracks(job, rawpath, mode: str):
             collections.deque(run(cmd, OutputType.MSG), maxlen=0)
             track.ripped = True
             db.session.commit()
+    db.session.commit()
 
 
 def setup_rawpath(raw_path):

--- a/arm/services/matching/tvdb_matcher.py
+++ b/arm/services/matching/tvdb_matcher.py
@@ -77,7 +77,7 @@ class TvdbMatcher(MatchStrategy):
 
         if season is not None:
             return self._match_single_season(
-                tvdb_id, tracks, season, tolerance,
+                job.job_id, tvdb_id, tracks, season, tolerance,
                 disc_number, disc_total, exclude,
             )
         else:
@@ -91,15 +91,20 @@ class TvdbMatcher(MatchStrategy):
     # ------------------------------------------------------------------
 
     def _match_single_season(
-        self, tvdb_id, tracks, season, tolerance,
+        self, job_id, tvdb_id, tracks, season, tolerance,
         disc_number, disc_total, exclude,
     ) -> MatchResult:
         from arm.services import tvdb
+        from arm.services.tvdb_sync import persist_expected_titles_from_episodes
 
         episodes = _run_async(tvdb.get_season_episodes(tvdb_id, season))
         if not episodes:
             log.info("TVDB: no episodes for series %d season %d", tvdb_id, season)
             return MatchResult(matcher=self.name, season=season, tvdb_id=tvdb_id)
+
+        # Persist expected titles before scoring; even if the match is later
+        # discarded, the runtime data is useful for Layer C / future rematches.
+        persist_expected_titles_from_episodes(job_id, season, episodes)
 
         raw = match_tracks_to_episodes(
             tracks, episodes, tolerance,

--- a/arm/services/matching/tvdb_matcher.py
+++ b/arm/services/matching/tvdb_matcher.py
@@ -123,6 +123,12 @@ class TvdbMatcher(MatchStrategy):
         self, tvdb_id, tracks, tolerance, max_season,
         disc_number, disc_total, exclude,
     ) -> MatchResult:
+        # Note: ExpectedTitle persistence is intentionally NOT done here.
+        # Unlike _match_single_season which has a stable season anchor,
+        # best-season matching scans across all seasons. Persisting episodes
+        # from a tentative season would create stale ExpectedTitle rows if
+        # the best-fit season later changes. Layer C will need to revisit
+        # this if we want runtime-aware filtering for best-season jobs.
         from arm.services import tvdb
 
         log.info("TVDB: no season from metadata, scanning seasons 1-%d", max_season)

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -14,6 +14,7 @@ from typing import Any
 import httpx
 
 import arm.config.config as cfg
+from arm.services.runtime_parsing import parse_runtime
 
 log = logging.getLogger(__name__)
 
@@ -447,8 +448,6 @@ async def _omdb_search(query: str, year: str | None, api_key: str, page: int = 1
 
 
 def _normalize_omdb(item: dict) -> dict[str, Any]:
-    from arm.services.runtime_parsing import parse_runtime
-
     media_type = (item.get("Type") or "movie").lower()
     if media_type != "series":
         media_type = "movie"
@@ -533,8 +532,6 @@ async def _tmdb_search(query: str, year: str | None, api_key: str) -> list[dict[
 async def _normalize_tmdb(
     item: dict, media_type: str, api_key: str
 ) -> dict[str, Any]:
-    from arm.services.runtime_parsing import parse_runtime
-
     title = item.get("title") or item.get("name", "")
     release = item.get("release_date") or item.get("first_air_date") or ""
     year = _extract_year(release) if release else ""

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -447,6 +447,8 @@ async def _omdb_search(query: str, year: str | None, api_key: str, page: int = 1
 
 
 def _normalize_omdb(item: dict) -> dict[str, Any]:
+    from arm.services.runtime_parsing import parse_runtime
+
     media_type = (item.get("Type") or "movie").lower()
     if media_type != "series":
         media_type = "movie"
@@ -460,6 +462,7 @@ def _normalize_omdb(item: dict) -> dict[str, Any]:
         "imdb_id": item.get("imdbID"),
         "media_type": media_type,
         "poster_url": poster,
+        "runtime_seconds": parse_runtime(item.get("Runtime")),
     }
 
 
@@ -530,6 +533,8 @@ async def _tmdb_search(query: str, year: str | None, api_key: str) -> list[dict[
 async def _normalize_tmdb(
     item: dict, media_type: str, api_key: str
 ) -> dict[str, Any]:
+    from arm.services.runtime_parsing import parse_runtime
+
     title = item.get("title") or item.get("name", "")
     release = item.get("release_date") or item.get("first_air_date") or ""
     year = _extract_year(release) if release else ""
@@ -542,6 +547,7 @@ async def _normalize_tmdb(
         "imdb_id": imdb_id,
         "media_type": media_type,
         "poster_url": poster_url,
+        "runtime_seconds": parse_runtime(item.get("runtime")),
     }
 
 

--- a/arm/services/runtime_parsing.py
+++ b/arm/services/runtime_parsing.py
@@ -20,7 +20,7 @@ _OMDB_HOUR_MIN_PATTERN = re.compile(
 def parse_runtime(raw: str | int | None) -> int | None:
     if raw is None:
         return None
-    if isinstance(raw, int):
+    if isinstance(raw, int) and not isinstance(raw, bool):
         return raw * 60 if raw > 0 else None
     if not isinstance(raw, str):
         return None

--- a/arm/services/runtime_parsing.py
+++ b/arm/services/runtime_parsing.py
@@ -1,0 +1,40 @@
+"""Parse runtime strings from metadata providers into seconds.
+
+OMDb returns strings like "95 min" or occasionally "2 h 31 min".
+TMDb returns integer minutes. TVDB runtimes are handled separately
+in arm/services/tvdb.py because they come pre-parsed.
+
+Returns None for missing/invalid/zero runtimes - downstream code
+treats None as "no runtime data, use static MIN/MAX fallback."
+"""
+from __future__ import annotations
+
+import re
+
+_OMDB_MIN_PATTERN = re.compile(r"^(\d+)\s*min$", re.IGNORECASE)
+_OMDB_HOUR_MIN_PATTERN = re.compile(
+    r"^(\d+)\s*h(?:our)?s?\s*(\d+)\s*min$", re.IGNORECASE
+)
+
+
+def parse_runtime(raw: str | int | None) -> int | None:
+    if raw is None:
+        return None
+    if isinstance(raw, int):
+        return raw * 60 if raw > 0 else None
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s or s.upper() == "N/A":
+        return None
+    m = _OMDB_MIN_PATTERN.match(s)
+    if m:
+        minutes = int(m.group(1))
+        return minutes * 60 if minutes > 0 else None
+    m = _OMDB_HOUR_MIN_PATTERN.match(s)
+    if m:
+        hours = int(m.group(1))
+        minutes = int(m.group(2))
+        total = hours * 60 + minutes
+        return total * 60 if total > 0 else None
+    return None

--- a/arm/services/tvdb_sync.py
+++ b/arm/services/tvdb_sync.py
@@ -75,6 +75,38 @@ def match_episodes_sync(job) -> bool:
         return False
 
 
+def persist_expected_titles_from_episodes(
+    job_id: int,
+    season: int,
+    episodes: list,
+) -> None:
+    """Write one ExpectedTitle per TVDB episode for the given job.
+
+    Episodes are dicts shaped like
+    {"number": int, "name": str, "runtime": int_seconds}
+    (the shape produced by tvdb.get_season_episodes which converts
+    TVDB's minute runtimes to seconds before returning).
+
+    Idempotent: clears any existing ExpectedTitle rows for the job
+    before writing - so a rematch with a different season correctly
+    replaces stale rows.
+    """
+    from arm.models.expected_title import ExpectedTitle
+
+    db.session.query(ExpectedTitle).filter_by(job_id=job_id).delete()
+    for ep in episodes:
+        runtime = ep.get("runtime")
+        db.session.add(ExpectedTitle(
+            job_id=job_id,
+            source="tvdb",
+            title=ep.get("name"),
+            season=season,
+            episode_number=ep.get("number"),
+            runtime_seconds=runtime if runtime else None,
+        ))
+    db.session.commit()
+
+
 def match_episodes_for_api(job, season=None, tolerance=None, apply=False):
     """API-facing match with detailed results.
 

--- a/arm/services/tvdb_sync.py
+++ b/arm/services/tvdb_sync.py
@@ -82,6 +82,9 @@ def persist_expected_titles_from_episodes(
 ) -> None:
     """Write one ExpectedTitle per TVDB episode for the given job.
 
+    Takes job_id rather than a Job instance so it can be called from
+    matcher context where no session-attached ORM object is needed.
+
     Episodes are dicts shaped like
     {"number": int, "name": str, "runtime": int_seconds}
     (the shape produced by tvdb.get_season_episodes which converts

--- a/test/fixtures/makemkv_stdout/movie_dvd_5_skipped.txt
+++ b/test/fixtures/makemkv_stdout/movie_dvd_5_skipped.txt
@@ -1,0 +1,13 @@
+MakeMKV v1.18.3 linux(x64-release) started
+Using LibreDrive mode (v02.1 id=2AE09FD4F501)
+Using direct disc access mode
+Title #1 was added (6 cell(s), 1:16:08)
+Title #1/1 was added (6 cell(s), 1:07:16)
+Title #2 has length of 21 seconds which is less than minimum title length of 600 seconds and was therefore skipped
+Title #3 has length of 249 seconds which is less than minimum title length of 600 seconds and was therefore skipped
+Title #4 has length of 188 seconds which is less than minimum title length of 600 seconds and was therefore skipped
+Title #5 has length of 50 seconds which is less than minimum title length of 600 seconds and was therefore skipped
+Title #6 has length of 60 seconds which is less than minimum title length of 600 seconds and was therefore skipped
+Operation successfully completed
+Saving 2 titles into directory file:///tmp/test
+2 titles saved

--- a/test/fixtures/metadata/omdb_movie_with_runtime.json
+++ b/test/fixtures/metadata/omdb_movie_with_runtime.json
@@ -1,0 +1,9 @@
+{
+  "Title": "Inception",
+  "Year": "2010",
+  "Runtime": "148 min",
+  "Type": "movie",
+  "Poster": "https://example.com/poster.jpg",
+  "imdbID": "tt1375666",
+  "Response": "True"
+}

--- a/test/fixtures/metadata/omdb_runtime_na.json
+++ b/test/fixtures/metadata/omdb_runtime_na.json
@@ -1,0 +1,9 @@
+{
+  "Title": "Obscure Old Film",
+  "Year": "1942",
+  "Runtime": "N/A",
+  "Type": "movie",
+  "Poster": "N/A",
+  "imdbID": "tt0000001",
+  "Response": "True"
+}

--- a/test/fixtures/metadata/tmdb_movie_with_runtime.json
+++ b/test/fixtures/metadata/tmdb_movie_with_runtime.json
@@ -1,0 +1,8 @@
+{
+  "id": 27205,
+  "title": "Inception",
+  "release_date": "2010-07-15",
+  "poster_path": "/9gk7adHYeDvHkCSEqAvQNLV5Uge.jpg",
+  "runtime": 148,
+  "media_type": "movie"
+}

--- a/test/test_empty_rip_failure.py
+++ b/test/test_empty_rip_failure.py
@@ -1,0 +1,52 @@
+"""Empty-rip detection: zero ripped tracks -> FAILED with structured reason."""
+
+from arm.database import db
+
+
+def test_zero_ripped_tracks_marks_job_failed(app_context, sample_job):
+    from arm.models.track import Track
+    from arm.ripper.arm_ripper import check_empty_rip
+
+    sample_job.no_of_titles = 7
+    db.session.commit()
+
+    for n, length, skip in [
+        ("0", 4568, None),
+        ("1", 33, "too_short"),
+        ("2", 21, "too_short"),
+        ("3", 60, "too_short"),
+        ("4", 50, "too_short"),
+        ("5", 11, "makemkv_skipped"),
+        ("6", 0, "makemkv_skipped"),
+    ]:
+        t = Track(
+            job_id=sample_job.job_id, track_number=n, length=length,
+            aspect_ratio="4:3", fps=29.97, main_feature=False,
+            source="MakeMKV", basename=f"t{n}", filename=f"t{n}.mkv",
+        )
+        t.ripped = False
+        t.skip_reason = skip
+        db.session.add(t)
+    db.session.commit()
+
+    is_empty = check_empty_rip(sample_job)
+    assert is_empty is True
+    assert "All 7 tracks" in (sample_job.errors or "")
+    assert "4 too_short" in sample_job.errors
+    assert "2 makemkv_skipped" in sample_job.errors
+
+
+def test_at_least_one_ripped_track_does_not_fail(app_context, sample_job):
+    from arm.models.track import Track
+    from arm.ripper.arm_ripper import check_empty_rip
+
+    t1 = Track(
+        job_id=sample_job.job_id, track_number="0", length=4568,
+        aspect_ratio="4:3", fps=29.97, main_feature=True,
+        source="MakeMKV", basename="t0", filename="t0.mkv",
+    )
+    t1.ripped = True
+    db.session.add(t1)
+    db.session.commit()
+
+    assert check_empty_rip(sample_job) is False

--- a/test/test_empty_rip_failure.py
+++ b/test/test_empty_rip_failure.py
@@ -50,3 +50,12 @@ def test_at_least_one_ripped_track_does_not_fail(app_context, sample_job):
     db.session.commit()
 
     assert check_empty_rip(sample_job) is False
+
+
+def test_no_tracks_at_all_does_not_fail(app_context, sample_job):
+    """A job that reaches the check with zero Track rows is unusual but must not
+    produce a confusing 'All 0 tracks were filtered: .' message."""
+    from arm.ripper.arm_ripper import check_empty_rip
+
+    assert check_empty_rip(sample_job) is False
+    assert sample_job.errors in (None, "")

--- a/test/test_expected_title_model.py
+++ b/test/test_expected_title_model.py
@@ -1,0 +1,86 @@
+"""ExpectedTitle ORM smoke tests."""
+
+import pytest
+
+from arm.database import db
+
+
+def test_expected_title_create_and_query(app_context, sample_job):
+    from arm.models.expected_title import ExpectedTitle
+
+    et = ExpectedTitle(
+        job_id=sample_job.job_id,
+        source="omdb",
+        title="Inception",
+        runtime_seconds=8880,
+        external_id="tt1375666",
+    )
+    db.session.add(et)
+    db.session.commit()
+
+    rows = db.session.query(ExpectedTitle).filter_by(job_id=sample_job.job_id).all()
+    assert len(rows) == 1
+    assert rows[0].source == "omdb"
+    assert rows[0].title == "Inception"
+    assert rows[0].runtime_seconds == 8880
+    assert rows[0].season is None
+    assert rows[0].episode_number is None
+
+
+def test_expected_title_tv_shape(app_context, sample_job):
+    from arm.models.expected_title import ExpectedTitle
+
+    for ep in range(1, 4):
+        db.session.add(ExpectedTitle(
+            job_id=sample_job.job_id,
+            source="tvdb",
+            title=f"Episode {ep}",
+            season=1,
+            episode_number=ep,
+            runtime_seconds=2820 + ep,  # avoid round numbers
+        ))
+    db.session.commit()
+
+    rows = (db.session.query(ExpectedTitle)
+            .filter_by(job_id=sample_job.job_id)
+            .order_by(ExpectedTitle.episode_number)
+            .all())
+    assert len(rows) == 3
+    assert all(r.season == 1 for r in rows)
+    assert [r.episode_number for r in rows] == [1, 2, 3]
+    assert [r.runtime_seconds for r in rows] == [2821, 2822, 2823]
+
+
+def test_expected_title_runtime_can_be_null(app_context, sample_job):
+    from arm.models.expected_title import ExpectedTitle
+
+    et = ExpectedTitle(
+        job_id=sample_job.job_id,
+        source="omdb",
+        title="Obscure Film",
+        runtime_seconds=None,
+    )
+    db.session.add(et)
+    db.session.commit()
+    assert db.session.query(ExpectedTitle).filter_by(runtime_seconds=None).count() == 1
+
+
+def test_job_expected_titles_relationship(app_context, sample_job):
+    """Verify the back-relationship: job.expected_titles returns the rows."""
+    from arm.models.expected_title import ExpectedTitle
+
+    db.session.add_all([
+        ExpectedTitle(
+            job_id=sample_job.job_id, source="omdb",
+            title="Movie A", runtime_seconds=5712,
+        ),
+        ExpectedTitle(
+            job_id=sample_job.job_id, source="tmdb",
+            title="Movie A (alt)", runtime_seconds=5701,
+        ),
+    ])
+    db.session.commit()
+    db.session.refresh(sample_job)
+
+    titles = sorted(et.title for et in sample_job.expected_titles)
+    assert titles == ["Movie A", "Movie A (alt)"]

--- a/test/test_expected_title_model.py
+++ b/test/test_expected_title_model.py
@@ -84,3 +84,22 @@ def test_job_expected_titles_relationship(app_context, sample_job):
 
     titles = sorted(et.title for et in sample_job.expected_titles)
     assert titles == ["Movie A", "Movie A (alt)"]
+
+
+def test_expected_title_null_title_works(app_context, sample_job):
+    """Title is nullable; metadata sources may not always return one."""
+    from arm.models.expected_title import ExpectedTitle
+
+    et = ExpectedTitle(
+        job_id=sample_job.job_id,
+        source="omdb",
+        title=None,
+        runtime_seconds=8880,
+    )
+    db.session.add(et)
+    db.session.commit()
+
+    row = db.session.query(ExpectedTitle).filter_by(runtime_seconds=8880).one()
+    assert row.title is None
+    # __repr__ must not crash on null title
+    assert "omdb" in repr(row)

--- a/test/test_expected_titles_api.py
+++ b/test/test_expected_titles_api.py
@@ -1,0 +1,74 @@
+"""Tests that ExpectedTitle data flows through Job detail and list endpoints."""
+import pytest
+
+from arm.database import db
+
+
+@pytest.fixture
+def client(app_context):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from arm.api.v1.jobs import router
+
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as c:
+        yield c
+
+
+def test_job_detail_includes_expected_titles(client, app_context, sample_job):
+    from arm.models.expected_title import ExpectedTitle
+
+    db.session.add(ExpectedTitle(
+        job_id=sample_job.job_id,
+        source="omdb",
+        title="Inception",
+        runtime_seconds=8523,  # fractional, not 8520
+        external_id="tt1375666",
+    ))
+    db.session.commit()
+
+    response = client.get(f"/api/v1/jobs/{sample_job.job_id}/detail")
+    assert response.status_code == 200
+    data = response.json()
+    assert "job" in data
+    assert "expected_titles" in data["job"]
+    titles = data["job"]["expected_titles"]
+    assert len(titles) == 1
+    assert titles[0]["source"] == "omdb"
+    assert titles[0]["title"] == "Inception"
+    assert titles[0]["runtime_seconds"] == 8523
+    assert titles[0]["external_id"] == "tt1375666"
+    assert titles[0]["season"] is None
+    assert titles[0]["episode_number"] is None
+
+
+def test_job_detail_with_no_expected_titles_returns_empty_list(client, app_context, sample_job):
+    response = client.get(f"/api/v1/jobs/{sample_job.job_id}/detail")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["job"]["expected_titles"] == []
+
+
+def test_job_detail_includes_tv_episode_rows(client, app_context, sample_job):
+    """TV jobs have multiple ExpectedTitle rows (one per episode)."""
+    from arm.models.expected_title import ExpectedTitle
+
+    for n in range(1, 4):
+        db.session.add(ExpectedTitle(
+            job_id=sample_job.job_id,
+            source="tvdb",
+            title=f"Episode {n}",
+            season=1,
+            episode_number=n,
+            runtime_seconds=2820 + n,  # avoid round numbers
+        ))
+    db.session.commit()
+
+    response = client.get(f"/api/v1/jobs/{sample_job.job_id}/detail")
+    assert response.status_code == 200
+    titles = response.json()["job"]["expected_titles"]
+    assert len(titles) == 3
+    assert all(t["source"] == "tvdb" for t in titles)
+    nums = sorted(t["episode_number"] for t in titles)
+    assert nums == [1, 2, 3]

--- a/test/test_expected_titles_api.py
+++ b/test/test_expected_titles_api.py
@@ -23,7 +23,7 @@ def test_job_detail_includes_expected_titles(client, app_context, sample_job):
         job_id=sample_job.job_id,
         source="omdb",
         title="Inception",
-        runtime_seconds=8523,  # fractional, not 8520
+        runtime_seconds=8523,
         external_id="tt1375666",
     ))
     db.session.commit()
@@ -61,7 +61,7 @@ def test_job_detail_includes_tv_episode_rows(client, app_context, sample_job):
             title=f"Episode {n}",
             season=1,
             episode_number=n,
-            runtime_seconds=2820 + n,  # avoid round numbers
+            runtime_seconds=2820 + n,
         ))
     db.session.commit()
 

--- a/test/test_identify.py
+++ b/test/test_identify.py
@@ -543,7 +543,8 @@ class TestIdentifyDvdCrc:
              unittest.mock.patch('arm.services.metadata_sync.lookup_crc_sync',
                                  return_value=crc_result), \
              unittest.mock.patch('arm.ripper.identify.utils') as mock_utils, \
-             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'), \
+             unittest.mock.patch('arm.ripper.identify._write_movie_expected_title'):
             mock_dvdid.compute.return_value = "abc123"
             mock_utils.extract_year.return_value = "1999"
             result = identify_dvd(job)
@@ -606,7 +607,8 @@ class TestIdentifyDvdCrc:
              unittest.mock.patch('arm.services.metadata_sync.get_details_sync',
                                  return_value=details_result) as mock_details, \
              unittest.mock.patch('arm.ripper.identify.utils') as mock_utils, \
-             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'), \
+             unittest.mock.patch('arm.ripper.identify._write_movie_expected_title'):
             mock_dvdid.compute.return_value = "abc123"
             mock_utils.extract_year.return_value = "2016"
             result = identify_dvd(job)
@@ -633,7 +635,8 @@ class TestIdentifyDvdCrc:
                                  return_value=crc_result), \
              unittest.mock.patch('arm.services.metadata_sync.get_details_sync') as mock_details, \
              unittest.mock.patch('arm.ripper.identify.utils') as mock_utils, \
-             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'), \
+             unittest.mock.patch('arm.ripper.identify._write_movie_expected_title'):
             mock_dvdid.compute.return_value = "abc123"
             mock_utils.extract_year.return_value = "2020"
             result = identify_dvd(job)
@@ -659,7 +662,8 @@ class TestIdentifyDvdCrc:
              unittest.mock.patch('arm.services.metadata_sync.get_details_sync',
                                  side_effect=Exception("API timeout")), \
              unittest.mock.patch('arm.ripper.identify.utils') as mock_utils, \
-             unittest.mock.patch('arm.ripper.identify._detect_track_99'):
+             unittest.mock.patch('arm.ripper.identify._detect_track_99'), \
+             unittest.mock.patch('arm.ripper.identify._write_movie_expected_title'):
             mock_dvdid.compute.return_value = "abc123"
             mock_utils.extract_year.return_value = "2016"
             result = identify_dvd(job)

--- a/test/test_identify_expected_titles.py
+++ b/test/test_identify_expected_titles.py
@@ -1,0 +1,63 @@
+"""Tests that successful identification writes ExpectedTitle rows."""
+
+from arm.database import db
+
+
+def test_write_movie_expected_title_creates_row(app_context, sample_job):
+    from arm.models.expected_title import ExpectedTitle
+    from arm.ripper.identify import _write_movie_expected_title
+
+    _write_movie_expected_title(
+        sample_job,
+        title="Inception",
+        imdb_id="tt1375666",
+        runtime_seconds=8880,
+        source="omdb",
+    )
+
+    rows = db.session.query(ExpectedTitle).filter_by(job_id=sample_job.job_id).all()
+    assert len(rows) == 1
+    assert rows[0].source == "omdb"
+    assert rows[0].title == "Inception"
+    assert rows[0].external_id == "tt1375666"
+    assert rows[0].runtime_seconds == 8880
+    assert rows[0].season is None
+    assert rows[0].episode_number is None
+
+
+def test_write_movie_expected_title_with_null_runtime(app_context, sample_job):
+    """CRC fast path provides no runtime; row is still written."""
+    from arm.models.expected_title import ExpectedTitle
+    from arm.ripper.identify import _write_movie_expected_title
+
+    _write_movie_expected_title(
+        sample_job,
+        title="Obscure",
+        imdb_id="tt0000001",
+        runtime_seconds=None,
+        source="manual",
+    )
+
+    rows = db.session.query(ExpectedTitle).filter_by(job_id=sample_job.job_id).all()
+    assert len(rows) == 1
+    assert rows[0].runtime_seconds is None
+    assert rows[0].source == "manual"
+
+
+def test_write_movie_expected_title_idempotent(app_context, sample_job):
+    """Calling twice replaces, does not duplicate."""
+    from arm.models.expected_title import ExpectedTitle
+    from arm.ripper.identify import _write_movie_expected_title
+
+    _write_movie_expected_title(
+        sample_job, title="V1", imdb_id="tt1", runtime_seconds=5712, source="omdb"
+    )
+    _write_movie_expected_title(
+        sample_job, title="V2", imdb_id="tt2", runtime_seconds=8523, source="tmdb"
+    )
+
+    rows = db.session.query(ExpectedTitle).filter_by(job_id=sample_job.job_id).all()
+    assert len(rows) == 1
+    assert rows[0].title == "V2"
+    assert rows[0].source == "tmdb"
+    assert rows[0].runtime_seconds == 8523

--- a/test/test_identify_expected_titles.py
+++ b/test/test_identify_expected_titles.py
@@ -61,3 +61,74 @@ def test_write_movie_expected_title_idempotent(app_context, sample_job):
     assert rows[0].title == "V2"
     assert rows[0].source == "tmdb"
     assert rows[0].runtime_seconds == 8523
+
+
+def test_update_job_skips_expected_title_for_series(app_context, sample_job):
+    """update_job should NOT write a movie ExpectedTitle for series matches.
+    TV ExpectedTitle rows are populated by the TVDB path in A6."""
+    from unittest.mock import MagicMock, patch
+    from arm.models.expected_title import ExpectedTitle
+    from arm.ripper.identify import update_job
+
+    # Construct a minimal MatchSelection-like return that update_job consumes.
+    best = MagicMock()
+    best.title = "Some Series"
+    best.year = "2020"
+    best.type = "series"
+    best.imdb_id = "tt9999999"
+    best.poster_url = ""
+    best.score = 0.95
+    best.title_score = 0.95
+    best.year_score = 1.0
+    best.type_score = 1.0
+    best.raw_result = {"runtime_seconds": 2820}
+
+    selection = MagicMock()
+    selection.hasnicetitle = True
+    selection.best = best
+    selection.label_info = None
+    selection.all_scored = [best]
+
+    with patch("arm.ripper.arm_matcher.match_disc", return_value=selection):
+        update_job(sample_job, {"Search": [{"_": "_"}]})
+
+    # No ExpectedTitle row should be written for a series match.
+    rows = db.session.query(ExpectedTitle).filter_by(
+        job_id=sample_job.job_id
+    ).all()
+    assert rows == []
+
+
+def test_update_job_writes_expected_title_for_movie(app_context, sample_job):
+    """update_job SHOULD write a movie ExpectedTitle for movie matches."""
+    from unittest.mock import MagicMock, patch
+    from arm.models.expected_title import ExpectedTitle
+    from arm.ripper.identify import update_job
+
+    best = MagicMock()
+    best.title = "Inception"
+    best.year = "2010"
+    best.type = "movie"
+    best.imdb_id = "tt1375666"
+    best.poster_url = ""
+    best.score = 0.95
+    best.title_score = 0.95
+    best.year_score = 1.0
+    best.type_score = 1.0
+    best.raw_result = {"runtime_seconds": 8880}
+
+    selection = MagicMock()
+    selection.hasnicetitle = True
+    selection.best = best
+    selection.label_info = None
+    selection.all_scored = [best]
+
+    with patch("arm.ripper.arm_matcher.match_disc", return_value=selection):
+        update_job(sample_job, {"Search": [{"_": "_"}]})
+
+    rows = db.session.query(ExpectedTitle).filter_by(
+        job_id=sample_job.job_id
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].title == "Inception"
+    assert rows[0].runtime_seconds == 8880

--- a/test/test_identify_no_sanitize.py
+++ b/test/test_identify_no_sanitize.py
@@ -15,6 +15,7 @@ class TestUpdateJobNoSanitize:
         match.type = "movie"
         match.imdb_id = "tt0111127"
         match.poster_url = ""
+        match.raw_result = None
         match.score = 0.95
         match.title_score = 0.95
         match.year_score = 1.0
@@ -46,6 +47,7 @@ class TestUpdateJobNoSanitize:
         match.type = "movie"
         match.imdb_id = "tt0076759"
         match.poster_url = ""
+        match.raw_result = None
         match.score = 0.95
         match.title_score = 0.95
         match.year_score = 1.0
@@ -76,6 +78,7 @@ class TestUpdateJobNoSanitize:
         match.type = "movie"
         match.imdb_id = "tt1259521"
         match.poster_url = ""
+        match.raw_result = None
         match.score = 0.95
         match.title_score = 0.95
         match.year_score = 1.0
@@ -106,6 +109,7 @@ class TestUpdateJobNoSanitize:
         match.type = "movie"
         match.imdb_id = "tt0112384"
         match.poster_url = ""
+        match.raw_result = None
         match.score = 0.95
         match.title_score = 0.95
         match.year_score = 1.0
@@ -136,6 +140,7 @@ class TestUpdateJobNoSanitize:
         match.type = "movie"
         match.imdb_id = "tt0062622"
         match.poster_url = ""
+        match.raw_result = None
         match.score = 0.95
         match.title_score = 0.95
         match.year_score = 1.0

--- a/test/test_jobs_api.py
+++ b/test/test_jobs_api.py
@@ -477,3 +477,29 @@ class TestNamingPreviewForJob:
         assert resp.status_code == 200
         data = resp.json()
         assert data["tracks"] == []
+
+
+def test_job_detail_track_includes_process_and_skip_reason(client, app_context, sample_job):
+    """Test that /jobs/{id}/detail serializes process and skip_reason in tracks."""
+    t1 = Track(
+        sample_job.job_id, '0', 4568, '4:3', 29.97, True,
+        'MakeMKV', 't0', 't0.mkv',
+    )
+    t1.process = True
+    t2 = Track(
+        sample_job.job_id, '1', 21, '4:3', 29.97, False,
+        'MakeMKV', 't1', 't1.mkv',
+    )
+    t2.process = False
+    t2.skip_reason = "too_short"
+    db.session.add_all([t1, t2])
+    db.session.commit()
+
+    response = client.get(f"/api/v1/jobs/{sample_job.job_id}/detail")
+    assert response.status_code == 200
+    data = response.json()
+    tracks = {t["track_number"]: t for t in data["tracks"]}
+    assert tracks["0"]["process"] is True
+    assert tracks["0"]["skip_reason"] is None
+    assert tracks["1"]["process"] is False
+    assert tracks["1"]["skip_reason"] == "too_short"

--- a/test/test_jobs_api.py
+++ b/test/test_jobs_api.py
@@ -480,7 +480,6 @@ class TestNamingPreviewForJob:
 
 
 def test_job_detail_track_includes_process_and_skip_reason(client, app_context, sample_job):
-    """Test that /jobs/{id}/detail serializes process and skip_reason in tracks."""
     t1 = Track(
         sample_job.job_id, '0', 4568, '4:3', 29.97, True,
         'MakeMKV', 't0', 't0.mkv',
@@ -492,7 +491,14 @@ def test_job_detail_track_includes_process_and_skip_reason(client, app_context, 
     )
     t2.process = False
     t2.skip_reason = "too_short"
-    db.session.add_all([t1, t2])
+    # Legacy row: pre-existing tracks may have process=NULL in the DB.
+    # The serializer must default those to True so they remain rippable.
+    t3 = Track(
+        sample_job.job_id, '2', 3601, '16:9', 23.976, False,
+        'MakeMKV', 't2', 't2.mkv',
+    )
+    t3.process = None
+    db.session.add_all([t1, t2, t3])
     db.session.commit()
 
     response = client.get(f"/api/v1/jobs/{sample_job.job_id}/detail")
@@ -503,3 +509,5 @@ def test_job_detail_track_includes_process_and_skip_reason(client, app_context, 
     assert tracks["0"]["skip_reason"] is None
     assert tracks["1"]["process"] is False
     assert tracks["1"]["skip_reason"] == "too_short"
+    assert tracks["2"]["process"] is True
+    assert tracks["2"]["skip_reason"] is None

--- a/test/test_makemkv_skip_parser.py
+++ b/test/test_makemkv_skip_parser.py
@@ -1,0 +1,64 @@
+"""Tests for parsing MakeMKV stdout 'title skipped' messages.
+
+In all-tracks rip mode, MakeMKV's binary does the MIN filtering itself
+and emits 'Title #X has length of Y seconds which is less than minimum
+title length of N seconds and was therefore skipped' messages. We parse
+these and persist skip_reason='makemkv_skipped' on the corresponding
+track records so the UI shows backend truth.
+"""
+from pathlib import Path
+
+from arm.ripper.makemkv import parse_makemkv_skip_message
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "makemkv_stdout" / "movie_dvd_5_skipped.txt"
+
+
+def test_parse_skip_message_extracts_title_number():
+    line = "Title #2 has length of 21 seconds which is less than minimum title length of 600 seconds and was therefore skipped"
+    result = parse_makemkv_skip_message(line)
+    assert result == {"track_number": "2", "length": 21, "min_length": 600}
+
+
+def test_parse_skip_message_returns_none_for_non_skip_line():
+    assert parse_makemkv_skip_message("Operation successfully completed") is None
+    assert parse_makemkv_skip_message("Title #1 was added (6 cell(s), 1:16:08)") is None
+
+
+def test_real_log_extracts_5_skip_records():
+    text = _FIXTURE.read_text()
+    skips = [
+        parse_makemkv_skip_message(line)
+        for line in text.splitlines()
+        if parse_makemkv_skip_message(line) is not None
+    ]
+    assert len(skips) == 5
+    assert {s["track_number"] for s in skips} == {"2", "3", "4", "5", "6"}
+    assert sorted(s["length"] for s in skips) == [21, 50, 60, 188, 249]
+
+
+def test_apply_skip_to_track_records(app_context, sample_job):
+    """Calling apply_makemkv_skips with a list of skip dicts updates the
+    matching track records: process=False, skip_reason='makemkv_skipped'."""
+    from arm.database import db
+    from arm.models.track import Track
+    from arm.ripper.makemkv import apply_makemkv_skips
+
+    for n, length in [("1", 4568), ("2", 21), ("3", 249)]:
+        db.session.add(Track(
+            job_id=sample_job.job_id, track_number=n, length=length,
+            aspect_ratio="4:3", fps=29.97, main_feature=False,
+            source="MakeMKV", basename=f"t{n}", filename=f"t{n}.mkv",
+        ))
+    db.session.commit()
+
+    skips = [
+        {"track_number": "2", "length": 21, "min_length": 600},
+        {"track_number": "3", "length": 249, "min_length": 600},
+    ]
+    apply_makemkv_skips(sample_job, skips)
+
+    rows = {t.track_number: t for t in db.session.query(Track).filter_by(job_id=sample_job.job_id)}
+    assert rows["1"].skip_reason is None
+    assert rows["2"].skip_reason == "makemkv_skipped"
+    assert rows["2"].process is False
+    assert rows["3"].skip_reason == "makemkv_skipped"

--- a/test/test_makemkv_skip_parser.py
+++ b/test/test_makemkv_skip_parser.py
@@ -24,12 +24,19 @@ def test_parse_skip_message_returns_none_for_non_skip_line():
     assert parse_makemkv_skip_message("Title #1 was added (6 cell(s), 1:16:08)") is None
 
 
+def test_parse_skip_message_strips_makemkv_log_prefix():
+    """ARM's logger sometimes re-emits MakeMKV stdout with a 'MakeMKV: ' prefix."""
+    line = "MakeMKV: Title #7 has length of 42 seconds which is less than minimum title length of 600 seconds and was therefore skipped"
+    result = parse_makemkv_skip_message(line)
+    assert result == {"track_number": "7", "length": 42, "min_length": 600}
+
+
 def test_real_log_extracts_5_skip_records():
     text = _FIXTURE.read_text()
     skips = [
-        parse_makemkv_skip_message(line)
+        parsed
         for line in text.splitlines()
-        if parse_makemkv_skip_message(line) is not None
+        if (parsed := parse_makemkv_skip_message(line)) is not None
     ]
     assert len(skips) == 5
     assert {s["track_number"] for s in skips} == {"2", "3", "4", "5", "6"}

--- a/test/test_matching.py
+++ b/test/test_matching.py
@@ -728,6 +728,9 @@ class TestTvdbMatcherMatch:
              ), \
              unittest.mock.patch(
                  "arm.services.matching.tvdb_matcher.get_excluded_episodes", return_value=set()
+             ), \
+             unittest.mock.patch(
+                 "arm.services.tvdb_sync.persist_expected_titles_from_episodes"
              ):
             result = TvdbMatcher().match(job, tracks)
 
@@ -818,6 +821,9 @@ class TestTvdbMatcherMatch:
              ), \
              unittest.mock.patch(
                  "arm.services.matching.tvdb_matcher.get_excluded_episodes", return_value=set()
+             ), \
+             unittest.mock.patch(
+                 "arm.services.tvdb_sync.persist_expected_titles_from_episodes"
              ):
             result = TvdbMatcher().match(job, [{"track_number": "0", "length": 3550}])
 

--- a/test/test_metadata_runtime.py
+++ b/test/test_metadata_runtime.py
@@ -1,0 +1,20 @@
+"""Tests that metadata normalizers preserve the runtime_seconds field."""
+
+import json
+from pathlib import Path
+
+from arm.services.metadata import _normalize_omdb
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "metadata"
+
+
+def test_normalize_omdb_keeps_runtime():
+    data = json.loads((_FIXTURES / "omdb_movie_with_runtime.json").read_text())
+    result = _normalize_omdb(data)
+    assert result["runtime_seconds"] == 8880  # 148 * 60
+
+
+def test_normalize_omdb_runtime_na_returns_none():
+    data = json.loads((_FIXTURES / "omdb_runtime_na.json").read_text())
+    result = _normalize_omdb(data)
+    assert result["runtime_seconds"] is None

--- a/test/test_migration_expected_titles.py
+++ b/test/test_migration_expected_titles.py
@@ -59,15 +59,18 @@ def test_upgrade_creates_table_and_index(db_at_prev_revision):
 
 
 def test_fk_to_job_works_after_upgrade(db_at_prev_revision):
+    """Smoke test: confirm we can insert into expected_title with a valid
+    job_id and read it back. Does not assert FK enforcement (SQLite's FK
+    pragma is off by default); the FK shape is structural only here.
+    """
     cfg, engine = db_at_prev_revision
     command.upgrade(cfg, _TARGET_REVISION)
 
     with engine.begin() as conn:
-        # Insert a parent Job row first (job has a NOT NULL guid).
+        # Insert a Job parent row, then a child expected_title.
         conn.execute(text(
             "INSERT INTO job (job_id, guid) VALUES (1, 'test-guid-1')"
         ))
-        # Insert a child expected_title row referencing it.
         conn.execute(text(
             "INSERT INTO expected_title (job_id, source, title, runtime_seconds) "
             "VALUES (1, 'omdb', 'Test', 5712)"

--- a/test/test_migration_expected_titles.py
+++ b/test/test_migration_expected_titles.py
@@ -1,0 +1,89 @@
+"""Tests for the expected_title table creation migration."""
+import os
+
+import pytest
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import create_engine, inspect, text
+
+
+_MIGRATIONS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    'arm', 'migrations',
+)
+_PREV_REVISION = 'o0p1q2r3s4t5'
+_TARGET_REVISION = 'p1q2r3s4t5u6'
+
+
+def _make_config(db_path):
+    cfg = AlembicConfig()
+    cfg.set_main_option('script_location', _MIGRATIONS_DIR)
+    cfg.set_main_option('sqlalchemy.url', f'sqlite:///{db_path}')
+    return cfg
+
+
+@pytest.fixture
+def db_at_prev_revision(tmp_path):
+    db_path = tmp_path / 'test.db'
+    cfg = _make_config(str(db_path))
+    command.upgrade(cfg, _PREV_REVISION)
+    engine = create_engine(f'sqlite:///{db_path}')
+    yield cfg, engine
+    engine.dispose()
+
+
+def test_table_does_not_exist_before_migration(db_at_prev_revision):
+    cfg, engine = db_at_prev_revision
+    insp = inspect(engine)
+    assert 'expected_title' not in insp.get_table_names()
+
+
+def test_upgrade_creates_table_and_index(db_at_prev_revision):
+    cfg, engine = db_at_prev_revision
+    command.upgrade(cfg, _TARGET_REVISION)
+
+    insp = inspect(engine)
+    assert 'expected_title' in insp.get_table_names()
+
+    cols = {c['name']: c for c in insp.get_columns('expected_title')}
+    assert set(cols.keys()) == {
+        'id', 'job_id', 'source', 'title', 'season', 'episode_number',
+        'external_id', 'runtime_seconds', 'fetched_at',
+    }
+    assert cols['job_id']['nullable'] is False
+    assert cols['source']['nullable'] is False
+    assert cols['runtime_seconds']['nullable'] is True
+
+    index_names = {ix['name'] for ix in insp.get_indexes('expected_title')}
+    assert 'ix_expected_title_job_id' in index_names
+
+
+def test_fk_to_job_works_after_upgrade(db_at_prev_revision):
+    cfg, engine = db_at_prev_revision
+    command.upgrade(cfg, _TARGET_REVISION)
+
+    with engine.begin() as conn:
+        # Insert a parent Job row first (job has a NOT NULL guid).
+        conn.execute(text(
+            "INSERT INTO job (job_id, guid) VALUES (1, 'test-guid-1')"
+        ))
+        # Insert a child expected_title row referencing it.
+        conn.execute(text(
+            "INSERT INTO expected_title (job_id, source, title, runtime_seconds) "
+            "VALUES (1, 'omdb', 'Test', 5712)"
+        ))
+        rows = conn.execute(text(
+            "SELECT title, runtime_seconds FROM expected_title WHERE job_id = 1"
+        )).fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == 'Test'
+        assert rows[0][1] == 5712
+
+
+def test_downgrade_drops_table(db_at_prev_revision):
+    cfg, engine = db_at_prev_revision
+    command.upgrade(cfg, _TARGET_REVISION)
+    command.downgrade(cfg, _PREV_REVISION)
+
+    insp = inspect(engine)
+    assert 'expected_title' not in insp.get_table_names()

--- a/test/test_runtime_parsing.py
+++ b/test/test_runtime_parsing.py
@@ -31,3 +31,9 @@ def test_parse_runtime_valid(raw, expected):
 ])
 def test_parse_runtime_invalid_returns_none(raw):
     assert parse_runtime(raw) is None
+
+
+def test_parse_runtime_rejects_bool():
+    """bool is a subclass of int in Python; True/False are not valid runtimes."""
+    assert parse_runtime(True) is None
+    assert parse_runtime(False) is None

--- a/test/test_runtime_parsing.py
+++ b/test/test_runtime_parsing.py
@@ -1,0 +1,33 @@
+"""Tests for runtime string parsing across metadata provider formats."""
+
+import pytest
+
+from arm.services.runtime_parsing import parse_runtime
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("95 min", 5700),
+    ("142 min", 8520),
+    ("1 min", 60),
+    ("2 h 31 min", 9060),
+    ("1 h 0 min", 3600),
+    ("0 h 47 min", 2820),
+    (95, 5700),  # integer minutes (TMDb shape)
+    (142, 8520),
+])
+def test_parse_runtime_valid(raw, expected):
+    assert parse_runtime(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [
+    "N/A",
+    "",
+    None,
+    "unknown",
+    "abc",
+    0,
+    -5,
+    "0 min",
+])
+def test_parse_runtime_invalid_returns_none(raw):
+    assert parse_runtime(raw) is None

--- a/test/test_track_skip_reason.py
+++ b/test/test_track_skip_reason.py
@@ -1,0 +1,39 @@
+"""Tests for the new skip_reason column on Track."""
+
+from arm.database import db
+
+
+def test_track_skip_reason_default_null(app_context, sample_job):
+    from arm.models.track import Track
+
+    t = Track(
+        job_id=sample_job.job_id,
+        track_number="0",
+        length=5712,
+        aspect_ratio="16:9",
+        fps=23.976,
+        main_feature=True,
+        source="MakeMKV",
+        basename="title_00",
+        filename="title_00.mkv",
+    )
+    db.session.add(t)
+    db.session.commit()
+    assert t.skip_reason is None
+
+
+def test_track_skip_reason_set_to_too_short(app_context, sample_job):
+    from arm.models.track import Track
+
+    t = Track(
+        job_id=sample_job.job_id, track_number="1", length=33,
+        aspect_ratio="16:9", fps=23.976, main_feature=False,
+        source="MakeMKV", basename="title_01", filename="title_01.mkv",
+    )
+    t.skip_reason = "too_short"
+    t.process = False
+    db.session.add(t)
+    db.session.commit()
+
+    rows = db.session.query(Track).filter_by(skip_reason="too_short").all()
+    assert len(rows) == 1

--- a/test/test_track_skip_reason.py
+++ b/test/test_track_skip_reason.py
@@ -1,6 +1,19 @@
 """Tests for the new skip_reason column on Track."""
 
+import pytest
 from arm.database import db
+
+
+@pytest.fixture
+def client(app_context):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from arm.api.v1.jobs import router
+
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as c:
+        yield c
 
 
 def test_track_skip_reason_default_null(app_context, sample_job):
@@ -116,3 +129,47 @@ def test_folder_prescan_auto_disable_sets_too_short(app_context, sample_job):
     assert rows["1"].skip_reason == "too_short"
     assert rows["2"].enabled is False
     assert rows["2"].skip_reason == "too_short"
+
+
+def test_manual_disable_sets_user_disabled(client, app_context, sample_job):
+    from arm.models.track import Track
+
+    t = Track(
+        job_id=sample_job.job_id, track_number="0", length=4568,
+        aspect_ratio="4:3", fps=29.97, main_feature=False,
+        source="MakeMKV", basename="t0", filename="t0.mkv",
+    )
+    db.session.add(t)
+    db.session.commit()
+
+    response = client.patch(
+        f"/api/v1/jobs/{sample_job.job_id}/tracks/{t.track_id}",
+        json={"enabled": False},
+    )
+    assert response.status_code == 200
+    db.session.refresh(t)
+    assert t.enabled is False
+    assert t.skip_reason == "user_disabled"
+
+
+def test_manual_re_enable_clears_skip_reason(client, app_context, sample_job):
+    from arm.models.track import Track
+
+    t = Track(
+        job_id=sample_job.job_id, track_number="0", length=4568,
+        aspect_ratio="4:3", fps=29.97, main_feature=False,
+        source="MakeMKV", basename="t0", filename="t0.mkv",
+    )
+    t.enabled = False
+    t.skip_reason = "user_disabled"
+    db.session.add(t)
+    db.session.commit()
+
+    response = client.patch(
+        f"/api/v1/jobs/{sample_job.job_id}/tracks/{t.track_id}",
+        json={"enabled": True},
+    )
+    assert response.status_code == 200
+    db.session.refresh(t)
+    assert t.enabled is True
+    assert t.skip_reason is None

--- a/test/test_track_skip_reason.py
+++ b/test/test_track_skip_reason.py
@@ -173,3 +173,26 @@ def test_manual_re_enable_clears_skip_reason(client, app_context, sample_job):
     db.session.refresh(t)
     assert t.enabled is True
     assert t.skip_reason is None
+
+
+def test_manual_patch_without_enabled_leaves_skip_reason_alone(client, app_context, sample_job):
+    """A PATCH that does not include 'enabled' must not touch skip_reason."""
+    from arm.models.track import Track
+
+    t = Track(
+        job_id=sample_job.job_id, track_number="0", length=4568,
+        aspect_ratio="4:3", fps=29.97, main_feature=False,
+        source="MakeMKV", basename="t0", filename="t0.mkv",
+    )
+    t.skip_reason = "makemkv_skipped"
+    db.session.add(t)
+    db.session.commit()
+
+    response = client.patch(
+        f"/api/v1/jobs/{sample_job.job_id}/tracks/{t.track_id}",
+        json={"filename": "renamed.mkv"},
+    )
+    assert response.status_code == 200
+    db.session.refresh(t)
+    assert t.filename == "renamed.mkv"
+    assert t.skip_reason == "makemkv_skipped"

--- a/test/test_track_skip_reason.py
+++ b/test/test_track_skip_reason.py
@@ -91,3 +91,28 @@ def test_process_single_tracks_sets_too_long(app_context, sample_job, tmp_path):
     db.session.refresh(long_track)
     assert long_track.process is False
     assert long_track.skip_reason == "too_long"
+
+
+def test_folder_prescan_auto_disable_sets_too_short(app_context, sample_job):
+    """The folder-import prescan auto-disable should set both enabled=False
+    AND skip_reason='too_short' on tracks below MINLENGTH."""
+    from arm.models.track import Track
+    from arm.api.v1.folder import auto_disable_short_tracks
+
+    for n, length in [("0", 4568), ("1", 33), ("2", 22)]:
+        db.session.add(Track(
+            job_id=sample_job.job_id, track_number=n, length=length,
+            aspect_ratio="16:9", fps=23.976, main_feature=False,
+            source="MakeMKV", basename=f"t{n}", filename=f"t{n}.mkv",
+        ))
+    db.session.commit()
+
+    auto_disable_short_tracks(sample_job, minlength=600)
+
+    rows = {t.track_number: t for t in db.session.query(Track).filter_by(job_id=sample_job.job_id)}
+    assert rows["0"].enabled is True
+    assert rows["0"].skip_reason is None
+    assert rows["1"].enabled is False
+    assert rows["1"].skip_reason == "too_short"
+    assert rows["2"].enabled is False
+    assert rows["2"].skip_reason == "too_short"

--- a/test/test_track_skip_reason.py
+++ b/test/test_track_skip_reason.py
@@ -37,3 +37,57 @@ def test_track_skip_reason_set_to_too_short(app_context, sample_job):
 
     rows = db.session.query(Track).filter_by(skip_reason="too_short").all()
     assert len(rows) == 1
+
+
+def test_process_single_tracks_sets_too_short(app_context, sample_job, tmp_path):
+    """When a track is below MINLENGTH, process_single_tracks sets
+    process=False and skip_reason='too_short'."""
+    from unittest.mock import patch
+    from arm.models.track import Track
+    from arm.ripper import makemkv
+
+    sample_job.config.MINLENGTH = "600"
+    sample_job.config.MAXLENGTH = "5000"
+    sample_job.config.MKV_ARGS = ""
+
+    short = Track(
+        job_id=sample_job.job_id, track_number="0", length=33,
+        aspect_ratio="16:9", fps=23.976, main_feature=False,
+        source="MakeMKV", basename="t0", filename="t0.mkv",
+    )
+    db.session.add(short)
+    db.session.commit()
+    db.session.refresh(sample_job)
+
+    with patch.object(makemkv, "run", return_value=iter([])):
+        makemkv.process_single_tracks(sample_job, str(tmp_path), "auto")
+
+    db.session.refresh(short)
+    assert short.process is False
+    assert short.skip_reason == "too_short"
+
+
+def test_process_single_tracks_sets_too_long(app_context, sample_job, tmp_path):
+    from unittest.mock import patch
+    from arm.models.track import Track
+    from arm.ripper import makemkv
+
+    sample_job.config.MINLENGTH = "600"
+    sample_job.config.MAXLENGTH = "5000"
+    sample_job.config.MKV_ARGS = ""
+
+    long_track = Track(
+        job_id=sample_job.job_id, track_number="0", length=12345,
+        aspect_ratio="16:9", fps=23.976, main_feature=False,
+        source="MakeMKV", basename="t0", filename="t0.mkv",
+    )
+    db.session.add(long_track)
+    db.session.commit()
+    db.session.refresh(sample_job)
+
+    with patch.object(makemkv, "run", return_value=iter([])):
+        makemkv.process_single_tracks(sample_job, str(tmp_path), "auto")
+
+    db.session.refresh(long_track)
+    assert long_track.process is False
+    assert long_track.skip_reason == "too_long"

--- a/test/test_tvdb_expected_titles.py
+++ b/test/test_tvdb_expected_titles.py
@@ -1,0 +1,71 @@
+"""Tests for TVDB ExpectedTitle population."""
+
+from arm.database import db
+
+
+def test_persist_expected_titles_from_episodes_writes_n_rows(app_context, sample_job):
+    from arm.models.expected_title import ExpectedTitle
+    from arm.services.tvdb_sync import persist_expected_titles_from_episodes
+
+    episodes = [
+        {"number": 1, "name": "Pilot", "runtime": 3300},
+        {"number": 2, "name": "Episode 2", "runtime": 3083},
+        {"number": 3, "name": "Episode 3", "runtime": 3017},
+    ]
+    persist_expected_titles_from_episodes(sample_job.job_id, season=1, episodes=episodes)
+
+    rows = (db.session.query(ExpectedTitle)
+            .filter_by(job_id=sample_job.job_id)
+            .order_by(ExpectedTitle.episode_number)
+            .all())
+    assert len(rows) == 3
+    assert all(r.source == "tvdb" for r in rows)
+    assert all(r.season == 1 for r in rows)
+    assert [r.episode_number for r in rows] == [1, 2, 3]
+    assert [r.runtime_seconds for r in rows] == [3300, 3083, 3017]
+    assert rows[0].title == "Pilot"
+
+
+def test_persist_idempotent_replaces_rows(app_context, sample_job):
+    from arm.models.expected_title import ExpectedTitle
+    from arm.services.tvdb_sync import persist_expected_titles_from_episodes
+
+    persist_expected_titles_from_episodes(
+        sample_job.job_id, season=1,
+        episodes=[
+            {"number": 1, "name": "Old Pilot", "runtime": 3300},
+            {"number": 2, "name": "Old Ep", "runtime": 3083},
+        ],
+    )
+    persist_expected_titles_from_episodes(
+        sample_job.job_id, season=2,
+        episodes=[
+            {"number": 1, "name": "New Pilot", "runtime": 2520},
+        ],
+    )
+
+    rows = db.session.query(ExpectedTitle).filter_by(job_id=sample_job.job_id).all()
+    assert len(rows) == 1
+    assert rows[0].season == 2
+    assert rows[0].title == "New Pilot"
+
+
+def test_persist_handles_missing_runtime(app_context, sample_job):
+    from arm.models.expected_title import ExpectedTitle
+    from arm.services.tvdb_sync import persist_expected_titles_from_episodes
+
+    episodes = [
+        {"number": 1, "name": "Ep with runtime", "runtime": 3300},
+        {"number": 2, "name": "Ep without runtime", "runtime": 0},
+        {"number": 3, "name": "Ep with None", "runtime": None},
+    ]
+    persist_expected_titles_from_episodes(sample_job.job_id, season=1, episodes=episodes)
+
+    rows = (db.session.query(ExpectedTitle)
+            .filter_by(job_id=sample_job.job_id)
+            .order_by(ExpectedTitle.episode_number)
+            .all())
+    assert len(rows) == 3
+    assert rows[0].runtime_seconds == 3300
+    assert rows[1].runtime_seconds is None
+    assert rows[2].runtime_seconds is None


### PR DESCRIPTION
## Summary

Two-layer feature for the disc-rip pipeline, motivated by the 8bitReid use case (rip a queue of varying-runtime movies back-to-back without per-disc MIN/MAX adjustment).

**Layer A - per-job ExpectedTitle metadata.** New `ExpectedTitle` ORM model captures the runtime + identifier we already pulled from OMDb/TMDb at ID time but were throwing away. Single-feature movies get 1 row; TV/anthology discs get N rows (one per episode from TVDB). Foundation for a future runtime-aware filter (Layer C, deferred until 8bitReid's user story is captured).

**Layer B - unified skip_reason across all three filter paths.** `Track.skip_reason` (new column) is now populated by every code path that filters or disables a track:
- Path 1 - `process_single_tracks` (single-track rip mode): writes `too_short`/`too_long`
- Path 2 - MakeMKV `--minlength` stdout in all-tracks mode: parses skip messages and writes `makemkv_skipped`
- Path 3 - folder-import prescan auto-disable: writes `too_short`
- Manual UI deselect: writes `user_disabled` (cleared on re-enable)

Plus an empty-rip detector: when zero tracks finish ripping the job flips to `FAILURE` with a structured breakdown of why each track was skipped (instead of silently succeeding with no output).

The frontend disc-review widget (in arm-ui, separate PR) reads `track.process` directly instead of re-deriving the filter client-side, so users see backend truth for which tracks won't actually rip.

## Wire shape (new fields)

- `Job.expected_titles: list[ExpectedTitle]` on `/api/v1/jobs/{id}/detail`
- `Track.process: bool` (default True) and `Track.skip_reason: SkipReason | null` on each track in the response

Contracts 0.6.0 (release-please PR open at uprightbass360/automatic-ripping-machine-contracts#12) ships these. Submodule pins origin/main tip; will resolve to v0.6.0 once that release lands.

## Migrations

Two additive Alembic migrations:
- `p1q2r3s4t5u6_expected_titles` - new `expected_title` table
- `q2r3s4t5u6v7_track_skip_reason` - adds nullable `skip_reason` column to `track`

## Test plan

- [ ] `pytest -x -q` passes (2092 tests; baseline was ~2036 - 56 new)
- [ ] Migrations roll forward + back cleanly on a populated DB
- [ ] Movie disc with metadata writes 1 ExpectedTitle row
- [ ] TV disc with TVDB match writes N ExpectedTitle rows
- [ ] Single-track-mode rip with too-short titles writes skip_reason="too_short"
- [ ] All-tracks-mode rip on a disc with MakeMKV-filtered titles writes skip_reason="makemkv_skipped"
- [ ] Folder-import prescan dims short tracks AND records skip_reason="too_short"
- [ ] Manual deselect via UI writes skip_reason="user_disabled"; re-enable clears it
- [ ] Empty-rip job flips to FAILURE with structured `errors` text