### PR TITLE
feat: extract stringly-typed states to enums + db.Enum enforcement

### DIFF
--- a/arm/api/v1/folder.py
+++ b/arm/api/v1/folder.py
@@ -7,6 +7,8 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from arm_contracts.enums import SkipReason
+
 import arm.config.config as cfg
 from arm.database import db
 from arm.models.config import Config
@@ -28,7 +30,7 @@ def auto_disable_short_tracks(job, minlength: int) -> int:
     for track in job.tracks:
         if track.length is not None and track.length < minlength:
             track.enabled = False
-            track.skip_reason = "too_short"
+            track.skip_reason = SkipReason.too_short.value
             disabled_count += 1
     return disabled_count
 

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -19,6 +19,7 @@ from arm_contracts import (
     TrackCounts,
     TranscodeCallbackPayload,
 )
+from arm_contracts.enums import SkipReason, SourceType, TrackStatus
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
@@ -28,6 +29,7 @@ from arm.api.dependencies import require_api_version
 import arm.config.config as cfg
 from arm.constants import SINGLE_TRACK_VIDEO_TYPES
 from arm.database import db
+from arm.enums import RipMethod
 from arm.models.job import Job, JobState
 from arm.models.track import Track
 from arm.models.notifications import Notifications
@@ -83,7 +85,7 @@ def _auto_flag_tracks(job, mainfeature: bool):
 router = APIRouter(prefix="/api/v1", tags=["jobs"])
 
 
-_ACTIVE_STATUSES = {"active", "ripping", "transcoding", "waiting"}
+_ACTIVE_STATUSES = {"ripping", "transcoding", "waiting"}
 _WAITING_STATUSES = {"waiting", "waiting_transcode"}
 
 _SORTABLE_COLUMNS = {
@@ -294,7 +296,7 @@ def start_waiting_job(job_id: int):
     if job.status != JobState.MANUAL_WAIT_STARTED.value:
         return JSONResponse({"success": False, "error": _NOT_WAITING}, status_code=409)
 
-    if job.source_type == "folder":
+    if job.source_type == SourceType.folder.value:
         # Folder jobs: launch rip_folder in a background thread.
         # Pass job_id, not the ORM object — the thread has its own session
         # scope and the original object would be detached.
@@ -375,7 +377,7 @@ def change_job_config(job_id: int, body: dict):
     changes = []
     config_updates = {}  # collected for atomic apply under lock
 
-    valid_ripmethods = ('mkv', 'backup')
+    valid_ripmethods = tuple(m.value for m in RipMethod)
     valid_disctypes = ('dvd', 'bluray', 'bluray4k', 'music', 'data')
     valid_audio_formats = (
         'flac', 'mp3', 'vorbis', 'opus', 'm4a', 'wav', 'mka',
@@ -1145,9 +1147,11 @@ def transcode_callback(job_id: int, body: dict):
             track = track_map.get(str(tr.track_number))
             if track:
                 if tr.status == JobStatus.completed:
-                    track.status = "transcoded"
+                    track.status = TrackStatus.transcoded.value
                 elif tr.status == JobStatus.failed:
-                    track.status = f"transcode_failed: {(tr.error or '')[:200]}"
+                    track.status = TrackStatus.transcode_failed.value
+                    if tr.error:
+                        track.error = tr.error
 
     db.session.commit()
     return {"success": True, "job_id": job.job_id, "status": job.status}
@@ -1337,7 +1341,7 @@ def update_track_fields(job_id: int, track_id: int, body: dict):
         setattr(track, key, value)
     # Re-enabling clears any prior reason; prescan re-fires it next pass.
     if "enabled" in clean:
-        track.skip_reason = None if clean["enabled"] else "user_disabled"
+        track.skip_reason = None if clean["enabled"] else SkipReason.user_disabled.value
     # Keep track.title in sync — the webhook payload reads track.title for
     # the filename, so it must reflect the current episode_name when set.
     if "episode_name" in clean and clean["episode_name"]:

--- a/arm/enums.py
+++ b/arm/enums.py
@@ -1,0 +1,38 @@
+"""Ripper-internal enums.
+
+Values that never cross a service boundary live here. Anything that
+appears in a webhook payload, callback payload, or HTTP API response
+that arm-ui consumes belongs in arm_contracts.enums instead.
+"""
+from enum import Enum
+
+
+class _StrValueEnum(str, Enum):
+    """Base for string-valued enums; mirrors arm_contracts._StrValueEnum
+    so we don't drag the contracts package in for ripper-only types."""
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __format__(self, format_spec: str) -> str:
+        return self.value.__format__(format_spec)
+
+
+class RipMethod(_StrValueEnum):
+    """MakeMKV rip strategy. Used for Job.config.RIPMETHOD.
+
+    backup / backup_dvd are Blu-ray strategies (backup decrypts then
+    copies; backup_dvd extracts via MakeMKV before post-processing).
+    mkv is the default direct-to-MKV path used for DVDs and most
+    Blu-rays.
+    """
+    mkv = "mkv"
+    backup = "backup"
+    backup_dvd = "backup_dvd"
+
+
+class AudioTitleSource(_StrValueEnum):
+    """Audio CD title lookup source. Used for Job.config.GET_AUDIO_TITLE."""
+    none = "none"
+    musicbrainz = "musicbrainz"
+    freecddb = "freecddb"

--- a/arm/migrations/versions/r3s4t5u6v7w8_enum_columns.py
+++ b/arm/migrations/versions/r3s4t5u6v7w8_enum_columns.py
@@ -57,9 +57,9 @@ def _assert_clean(conn, table, column, allowed):
 def upgrade() -> None:
     conn = op.get_bind()
 
-    # 1. Track.status backfill: split 'transcode_failed: <msg>' rows.
-    #    The error text is preserved in the existing Track.error column,
-    #    which is db.Text (no length cap).
+    # 1a. Track.status backfill: split 'transcode_failed: <msg>' rows.
+    #     The error text is preserved in the existing Track.error column,
+    #     which is db.Text (no length cap).
     conn.execute(sa.text("""
         UPDATE track
         SET error = CASE
@@ -70,6 +70,16 @@ def upgrade() -> None:
             status = 'transcode_failed'
         WHERE status LIKE 'transcode_failed:%'
     """))
+
+    # 1b. Backfill Job.status NULLs to 'identifying' before the NOT NULL
+    #     flip below. _assert_clean filters WHERE col IS NOT NULL, so NULL
+    #     rows would otherwise pass the pre-check and then trip the new
+    #     constraint mid-ALTER. 'identifying' matches the new
+    #     Job.__init__ default and is the natural state for a row that
+    #     was created but never had its status populated.
+    conn.execute(sa.text(
+        "UPDATE job SET status = 'identifying' WHERE status IS NULL"
+    ))
 
     # 2. Pre-checks: refuse to migrate if any column has an out-of-band
     #    value. Better to fail loudly here than to silently truncate or

--- a/arm/migrations/versions/r3s4t5u6v7w8_enum_columns.py
+++ b/arm/migrations/versions/r3s4t5u6v7w8_enum_columns.py
@@ -1,0 +1,163 @@
+"""Convert Job.status, Job.source_type, Track.status, Track.skip_reason,
+Config.RIPMETHOD to db.Enum; split transcode_failed:<msg> Track rows into
+status + error.
+
+Revision ID: r3s4t5u6v7w8
+Revises: q2r3s4t5u6v7
+Create Date: 2026-05-02
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = 'r3s4t5u6v7w8'
+down_revision = 'q2r3s4t5u6v7'
+branch_labels = None
+depends_on = None
+
+
+# Allowed value sets - duplicated here intentionally so the migration
+# is self-contained and doesn't depend on importable Python enums
+# (which may have drifted by the time someone runs an old migration).
+JOB_STATE_VALUES = (
+    'success', 'fail', 'waiting', 'identifying', 'ready', 'ripping',
+    'info', 'copying', 'ejecting', 'transcoding', 'waiting_transcode',
+)
+SOURCE_TYPE_VALUES = ('disc', 'folder')
+TRACK_STATUS_VALUES = (
+    'pending', 'ripping', 'encoding', 'success',
+    'transcoded', 'transcode_failed',
+)
+SKIP_REASON_VALUES = (
+    'too_short', 'too_long', 'makemkv_skipped',
+    'user_disabled', 'below_main_feature',
+)
+RIPMETHOD_VALUES = ('mkv', 'backup', 'backup_dvd')
+
+
+def _assert_clean(conn, table, column, allowed):
+    """Raise loudly if the table contains values outside the allowed set."""
+    rows = conn.execute(
+        sa.text(
+            f'SELECT DISTINCT {column} FROM {table} '
+            f'WHERE {column} IS NOT NULL'
+        )
+    ).fetchall()
+    bad = [r[0] for r in rows if r[0] not in allowed]
+    if bad:
+        raise RuntimeError(
+            f'{table}.{column} contains values not in the new enum: {bad}. '
+            f'Allowed: {sorted(allowed)}. Fix the rows manually before '
+            f'running this migration.'
+        )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # 1. Track.status backfill: split 'transcode_failed: <msg>' rows.
+    #    The error text is preserved in the existing Track.error column,
+    #    which is db.Text (no length cap).
+    conn.execute(sa.text("""
+        UPDATE track
+        SET error = CASE
+                      WHEN error IS NULL OR error = ''
+                      THEN SUBSTR(status, LENGTH('transcode_failed: ') + 1)
+                      ELSE error
+                    END,
+            status = 'transcode_failed'
+        WHERE status LIKE 'transcode_failed:%'
+    """))
+
+    # 2. Pre-checks: refuse to migrate if any column has an out-of-band
+    #    value. Better to fail loudly here than to silently truncate or
+    #    coerce; the operator can then clean up the row manually and
+    #    retry.
+    _assert_clean(conn, 'job', 'status', JOB_STATE_VALUES)
+    _assert_clean(conn, 'job', 'source_type', SOURCE_TYPE_VALUES)
+    _assert_clean(conn, 'track', 'status', TRACK_STATUS_VALUES)
+    _assert_clean(conn, 'track', 'skip_reason', SKIP_REASON_VALUES)
+    _assert_clean(conn, 'config', 'RIPMETHOD', RIPMETHOD_VALUES)
+
+    # 3. Column-type conversions. native_enum=False means no DDL ENUM
+    #    type is created; the constraint is enforced via a CHECK clause
+    #    that batch_alter_table emits.
+    with op.batch_alter_table('job') as batch_op:
+        batch_op.alter_column(
+            'status',
+            existing_type=sa.String(32),
+            type_=sa.Enum(*JOB_STATE_VALUES, name='job_state_enum',
+                          native_enum=False, validate_strings=True),
+            existing_nullable=True,
+            nullable=False,
+        )
+        batch_op.alter_column(
+            'source_type',
+            existing_type=sa.String(16),
+            type_=sa.Enum(*SOURCE_TYPE_VALUES, name='job_source_type_enum',
+                          native_enum=False, validate_strings=True),
+            existing_nullable=False,
+            existing_server_default='disc',
+        )
+
+    with op.batch_alter_table('track') as batch_op:
+        batch_op.alter_column(
+            'status',
+            existing_type=sa.String(32),
+            type_=sa.Enum(*TRACK_STATUS_VALUES, name='track_status_enum',
+                          native_enum=False, validate_strings=True),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            'skip_reason',
+            existing_type=sa.String(32),
+            type_=sa.Enum(*SKIP_REASON_VALUES, name='track_skip_reason_enum',
+                          native_enum=False, validate_strings=True),
+            existing_nullable=True,
+        )
+
+    with op.batch_alter_table('config') as batch_op:
+        batch_op.alter_column(
+            'RIPMETHOD',
+            existing_type=sa.String(25),
+            type_=sa.Enum(*RIPMETHOD_VALUES, name='config_ripmethod_enum',
+                          native_enum=False, validate_strings=True),
+            existing_nullable=True,
+        )
+
+
+def downgrade() -> None:
+    """Revert columns to plain String. Track.status backfill is NOT
+    reversed - the error text stays in Track.error (where it should
+    have been all along)."""
+    with op.batch_alter_table('config') as batch_op:
+        batch_op.alter_column(
+            'RIPMETHOD',
+            type_=sa.String(25),
+            existing_nullable=True,
+        )
+    with op.batch_alter_table('track') as batch_op:
+        batch_op.alter_column(
+            'skip_reason',
+            type_=sa.String(32),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            'status',
+            type_=sa.String(32),
+            existing_nullable=True,
+        )
+    with op.batch_alter_table('job') as batch_op:
+        batch_op.alter_column(
+            'source_type',
+            type_=sa.String(16),
+            existing_nullable=False,
+            existing_server_default='disc',
+        )
+        batch_op.alter_column(
+            'status',
+            type_=sa.String(32),
+            existing_nullable=False,
+        )

--- a/arm/models/config.py
+++ b/arm/models/config.py
@@ -44,7 +44,8 @@ class Config(db.Model):
     CHOWN_GROUP = db.Column(db.String(50))
     RIPMETHOD = db.Column(
         db.Enum(RipMethod, name="config_ripmethod_enum",
-                native_enum=False, validate_strings=True),
+                native_enum=False, validate_strings=True,
+                values_callable=lambda e: [m.value for m in e]),
         nullable=True,
     )
     MKV_ARGS = db.Column(db.String(25))

--- a/arm/models/config.py
+++ b/arm/models/config.py
@@ -1,6 +1,7 @@
 from prettytable import PrettyTable
 
 from arm.database import db
+from arm.enums import RipMethod
 
 
 hidden_attribs = ("OMDB_API_KEY", "EMBY_USERID", "EMBY_PASSWORD",
@@ -41,7 +42,11 @@ class Config(db.Model):
     SET_MEDIA_OWNER = db.Column(db.Boolean)
     CHOWN_USER = db.Column(db.String(50))
     CHOWN_GROUP = db.Column(db.String(50))
-    RIPMETHOD = db.Column(db.String(25))
+    RIPMETHOD = db.Column(
+        db.Enum(RipMethod, name="config_ripmethod_enum",
+                native_enum=False, validate_strings=True),
+        nullable=True,
+    )
     MKV_ARGS = db.Column(db.String(25))
     DELRAWFILES = db.Column(db.Boolean)
     HASHEDKEYS = db.Column(db.Boolean)

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -1,4 +1,3 @@
-import enum
 import logging
 import os
 import psutil
@@ -48,53 +47,10 @@ def _disc_dir_exists(mountpoint, name):
     return _find_disc_dir(mountpoint, name) is not None
 
 
-class JobState(str, enum.Enum):
-    """Possible states for Job.status.
-
-    The origin of the states is getting unclear at this point. Therefore, the
-    possible `Job.status` states are defined as fixed enums to handle and group
-    them better. Some come from CD, some from DVD ripping.
-
-    Note: The timestamps could also be saved particularily for each step to
-          show, for example, the pure transcoding time without the waiting
-          time.
-    """
-
-    # Job Finished States
-    SUCCESS = "success"
-    FAILURE = "fail"
-
-    # Manual wait (see job.config.MANUAL_WAIT)
-    MANUAL_WAIT_STARTED = "waiting"
-
-    # Disc identification phase
-    IDENTIFYING = "identifying"
-    """Indicate that ARM is identifying the disc (reading label, querying APIs)."""
-
-    # Job identified and ready to rip
-    IDLE = "ready"
-    """Job has been identified and is ready to proceed to ripping."""
-
-    # Video Ripping States
-    VIDEO_RIPPING = "ripping"
-    """Indicate that makemkv is ripping."""
-    VIDEO_WAITING = "waiting"
-    """Indicate that the job waits for user input or for the next queue slot."""
-    VIDEO_INFO = "info"
-    """Indicate that the job calls makemkv info"""
-
-    # Audio ripping states
-    AUDIO_RIPPING = "ripping"
-
-    # Post-rip states
-    COPYING = "copying"
-    """Indicate that ripped files are being moved to shared/network storage."""
-    EJECTING = "ejecting"
-    """Indicate that the disc is being ejected from the drive."""
-
-    # Transcoding states
-    TRANSCODE_ACTIVE = "transcoding"
-    TRANSCODE_WAITING = "waiting_transcode"
+# JobState lives in shared contracts so transcoder + arm-ui can import the
+# same enum that arm-neu persists. Re-exported here for backwards
+# compatibility with any existing `from arm.models.job import JobState`.
+from arm_contracts.enums import JobState  # noqa: E402,F401
 
 
 JOB_STATUS_FINISHED = {

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -89,7 +89,8 @@ class Job(db.Model):
     job_length = db.Column(db.String(12))
     status = db.Column(
         db.Enum(JobState, name="job_state_enum",
-                native_enum=False, validate_strings=True),
+                native_enum=False, validate_strings=True,
+                values_callable=lambda e: [m.value for m in e]),
         nullable=False,
     )
     stage = db.Column(db.String(63))
@@ -145,7 +146,8 @@ class Job(db.Model):
     is_iso = db.Column(db.Boolean)
     source_type = db.Column(
         db.Enum(SourceType, name="job_source_type_enum",
-                native_enum=False, validate_strings=True),
+                native_enum=False, validate_strings=True,
+                values_callable=lambda e: [m.value for m in e]),
         default=SourceType.disc.value,
         server_default=SourceType.disc.value,
         nullable=False,
@@ -175,6 +177,13 @@ class Job(db.Model):
         self.video_type = "unknown"
         self.ejected = False
         self.updated = False
+        # Status starts in IDENTIFYING - the disc-identification phase is
+        # the first thing the ripper does after Job() construction.
+        # Production code overwrites this almost immediately via
+        # database_updater(); the default is here so the NOT NULL
+        # constraint on Job.status is satisfied even on bare Job() use
+        # (e.g. from test fixtures that bypass the rip orchestration).
+        self.status = JobState.IDENTIFYING.value
         if cfg.arm_config.get('VIDEOTYPE', 'auto') != "auto":
             self.video_type = cfg.arm_config['VIDEOTYPE']
         if not _skip_hardware:
@@ -193,7 +202,7 @@ class Job(db.Model):
             devpath=None,
             _skip_hardware=True,
         )
-        job.source_type = "folder"
+        job.source_type = SourceType.folder.value
         job.source_path = source_path
         job.disctype = disctype
         job.start_time = dt.now()
@@ -399,14 +408,14 @@ class Job(db.Model):
     @property
     def makemkv_source(self) -> str:
         """Return the MakeMKV source string for this job."""
-        if self.source_type == "folder":
+        if self.source_type == SourceType.folder.value:
             return f"file:{self.source_path}"
         return f"dev:{self.devpath}"
 
     @property
     def is_folder_import(self) -> bool:
         """Return True if this job was created from a folder import."""
-        return self.source_type == "folder"
+        return self.source_type == SourceType.folder.value
 
     @property
     def type_subfolder(self):

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -50,7 +50,7 @@ def _disc_dir_exists(mountpoint, name):
 # JobState lives in shared contracts so transcoder + arm-ui can import the
 # same enum that arm-neu persists. Re-exported here for backwards
 # compatibility with any existing `from arm.models.job import JobState`.
-from arm_contracts.enums import JobState  # noqa: E402,F401
+from arm_contracts.enums import JobState, SourceType  # noqa: E402,F401
 
 
 JOB_STATUS_FINISHED = {
@@ -87,13 +87,11 @@ class Job(db.Model):
     start_time = db.Column(db.DateTime)
     stop_time = db.Column(db.DateTime)
     job_length = db.Column(db.String(12))
-    status = db.Column(db.String(32))
-    """Now that we have JobState, we should migrate this column.
     status = db.Column(
-        db.Enum(JobState, name="job_state_enum", native_enum=False, validate_strings=True),
-        nullable=False
+        db.Enum(JobState, name="job_state_enum",
+                native_enum=False, validate_strings=True),
+        nullable=False,
     )
-    """
     stage = db.Column(db.String(63))
     no_of_titles = db.Column(db.Integer)
     title = db.Column(db.String(256))
@@ -145,7 +143,13 @@ class Job(db.Model):
     pid = db.Column(db.Integer)
     pid_hash = db.Column(db.Integer)
     is_iso = db.Column(db.Boolean)
-    source_type = db.Column(db.String(16), default="disc", nullable=False, server_default="disc")
+    source_type = db.Column(
+        db.Enum(SourceType, name="job_source_type_enum",
+                native_enum=False, validate_strings=True),
+        default=SourceType.disc.value,
+        server_default=SourceType.disc.value,
+        nullable=False,
+    )
     source_path = db.Column(db.String(1024), nullable=True)
     manual_start = db.Column(db.Boolean)
     manual_pause = db.Column(db.Boolean)

--- a/arm/models/track.py
+++ b/arm/models/track.py
@@ -1,3 +1,5 @@
+from arm_contracts.enums import TrackStatus, SkipReason
+
 from arm.database import db
 
 
@@ -15,12 +17,20 @@ class Track(db.Model):
     orig_filename = db.Column(db.String(256))
     new_filename = db.Column(db.String(256))
     ripped = db.Column(db.Boolean)
-    status = db.Column(db.String(32))
+    status = db.Column(
+        db.Enum(TrackStatus, name="track_status_enum",
+                native_enum=False, validate_strings=True),
+        nullable=True,
+    )
     error = db.Column(db.Text)
     source = db.Column(db.String(32))
     process = db.Column(db.Boolean)
     enabled = db.Column(db.Boolean, default=True)
-    skip_reason = db.Column(db.String(32), nullable=True)
+    skip_reason = db.Column(
+        db.Enum(SkipReason, name="track_skip_reason_enum",
+                native_enum=False, validate_strings=True),
+        nullable=True,
+    )
     chapters = db.Column(db.Integer, default=0)
     filesize = db.Column(db.BigInteger, default=0)
     # Per-track title metadata (nullable — inherits job-level when null)
@@ -48,7 +58,7 @@ class Track(db.Model):
         self.source = source
         self.basename = basename
         self.filename = filename
-        self.status = 'pending'
+        self.status = TrackStatus.pending.value
         self.ripped = False
         self.process = False
         self.enabled = True

--- a/arm/models/track.py
+++ b/arm/models/track.py
@@ -19,7 +19,8 @@ class Track(db.Model):
     ripped = db.Column(db.Boolean)
     status = db.Column(
         db.Enum(TrackStatus, name="track_status_enum",
-                native_enum=False, validate_strings=True),
+                native_enum=False, validate_strings=True,
+                values_callable=lambda e: [m.value for m in e]),
         nullable=True,
     )
     error = db.Column(db.Text)
@@ -28,7 +29,8 @@ class Track(db.Model):
     enabled = db.Column(db.Boolean, default=True)
     skip_reason = db.Column(
         db.Enum(SkipReason, name="track_skip_reason_enum",
-                native_enum=False, validate_strings=True),
+                native_enum=False, validate_strings=True,
+                values_callable=lambda e: [m.value for m in e]),
         nullable=True,
     )
     chapters = db.Column(db.Integer, default=0)

--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -8,6 +8,8 @@ import os
 
 import structlog
 
+from arm_contracts.enums import SourceType
+
 import arm.config.config as cfg
 from arm.database import db
 from arm.models.job import JobState
@@ -128,7 +130,7 @@ def rip_folder(job):
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(
             job_id=job.job_id,
-            source_type="folder",
+            source_type=SourceType.folder.value,
             source_path=job.source_path,
         )
 

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -19,8 +19,11 @@ import shutil
 import subprocess
 from time import sleep
 
+from arm_contracts.enums import SkipReason, TrackStatus
+
 import arm.config.config as cfg
 from arm.constants import SINGLE_TRACK_VIDEO_TYPES
+from arm.enums import RipMethod
 from arm.models import SystemDrives, Track
 from arm.models.job import JobState
 from arm.ripper import utils
@@ -954,7 +957,7 @@ def _mark_track_ripped_by_message(job, message):
         track_prefix = re.sub(r'_t\d+\.mkv$', '', track.filename or '')
         if track_prefix == prefix:
             track.ripped = True
-            track.status = "success"
+            track.status = TrackStatus.success.value
             logging.info("Track %s ripped: %s", track.track_number, filename)
             try:
                 db.session.commit()
@@ -978,7 +981,7 @@ def _mark_ripped_from_disk(job, rawpath):
             continue
         if track.filename and track.filename in actual_files:
             track.ripped = True
-            track.status = "success"
+            track.status = TrackStatus.success.value
             changed = True
         else:
             # Check by prefix match (MakeMKV renumbers output files)
@@ -986,7 +989,7 @@ def _mark_ripped_from_disk(job, rawpath):
             for f in actual_files:
                 if f.endswith('.mkv') and re.sub(r'_t\d+\.mkv$', '', f) == prefix:
                     track.ripped = True
-                    track.status = "success"
+                    track.status = TrackStatus.success.value
                     changed = True
                     break
     if changed:
@@ -1248,9 +1251,10 @@ def makemkv(job):
     rawpath = setup_rawpath(job.build_raw_path())
     logging.info(f"Processing files to: {rawpath}")
 
-    if (job.config.RIPMETHOD in ("backup", "backup_dvd")) and job.disctype in ("bluray", "bluray4k"):
+    if (job.config.RIPMETHOD in (RipMethod.backup.value, RipMethod.backup_dvd.value)) \
+            and job.disctype in ("bluray", "bluray4k"):
         makemkv_backup(job, rawpath)
-    elif job.config.RIPMETHOD == "mkv" or job.disctype == "dvd":
+    elif job.config.RIPMETHOD == RipMethod.mkv.value or job.disctype == "dvd":
         makemkv_mkv(job, rawpath)
     else:
         logging.info("I'm confused what to do....  Passing on MakeMKV")
@@ -1306,13 +1310,13 @@ def process_single_tracks(job, rawpath, mode: str):
                 logging.info(f"Track #{track.track_number} of {job.no_of_titles}. Length ({track.length}) "
                              f"is less than minimum length ({job.config.MINLENGTH}).  Skipping")
                 track.process = False
-                track.skip_reason = "too_short"
+                track.skip_reason = SkipReason.too_short.value
             elif track.length > int(job.config.MAXLENGTH):
                 logging.info(f"Track #{track.track_number} of {job.no_of_titles}. "
                              f"Length ({track.length}) is greater than maximum length ({job.config.MAXLENGTH}).  "
                              "Skipping")
                 track.process = False
-                track.skip_reason = "too_long"
+                track.skip_reason = SkipReason.too_long.value
             else:
                 track.process = True
                 track.skip_reason = None
@@ -1727,7 +1731,7 @@ def apply_makemkv_skips(job, skips: list[dict]) -> None:
             .all())
     for r in rows:
         r.process = False
-        r.skip_reason = "makemkv_skipped"
+        r.skip_reason = SkipReason.makemkv_skipped.value
     db.session.commit()
 
 

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -31,6 +31,8 @@ import psutil
 
 from netifaces import interfaces, ifaddresses, AF_INET
 
+from arm_contracts.enums import TrackStatus, WebhookEventType
+
 import arm.config.config as cfg
 from arm.ripper.ProcessHandler import arm_subprocess
 from arm.database import db  # needs to be imported before models
@@ -208,7 +210,7 @@ def _build_webhook_payload(title, body, job, raw_basename):
         # WebhookPayload requires job_id, so we hand-build the dict here -
         # the typed model is only meaningful for the job-bound transcode
         # webhook the transcoder actually receives.
-        payload = {"title": title, "body": body, "type": "info"}
+        payload = {"title": title, "body": body, "type": WebhookEventType.info.value}
         if raw_basename:
             payload["path"] = raw_basename
         return payload
@@ -254,7 +256,7 @@ def _build_webhook_payload(title, body, job, raw_basename):
     payload = WebhookPayload(
         title=title,
         body=body,
-        type="info",
+        type=WebhookEventType.info,
         path=raw_basename or None,
         job_id=str(job.job_id),  # WebhookPayload coerces str -> int.
         video_type=str(job.video_type or ''),
@@ -470,7 +472,12 @@ def find_file(filename, search_path):
 
 
 def _update_music_tracks(job, ripped, status):
-    """Bulk-update ripped/status on all tracks for a music job."""
+    """Bulk-update ripped/status on all tracks for a music job.
+
+    `status` must be a member-value of TrackStatus (validated at the DB
+    layer via db.Enum). For music-rip failure where no enum member
+    applies, use _update_music_tracks_ripped_only() instead.
+    """
     try:
         Track.query.filter_by(job_id=job.job_id).update(
             {"ripped": ripped, "status": status}
@@ -478,6 +485,21 @@ def _update_music_tracks(job, ripped, status):
         db.session.commit()
     except Exception as exc:
         logging.debug("Could not update music tracks: %s", exc)
+        db.session.rollback()
+
+
+def _update_music_tracks_ripped_only(job, ripped):
+    """Bulk-update only the ripped boolean on all tracks for a music job.
+
+    Used on music-rip failure - TrackStatus has no music-failed member,
+    so we leave status at its prior value (typically pending) rather
+    than coerce to a misleading transcode_failed.
+    """
+    try:
+        Track.query.filter_by(job_id=job.job_id).update({"ripped": ripped})
+        db.session.commit()
+    except Exception as exc:
+        logging.debug("Could not update music tracks (ripped-only): %s", exc)
         db.session.rollback()
 
 
@@ -653,17 +675,17 @@ def _apply_track_phases(job, grabbing, encoding, tagging):
             except (ValueError, TypeError):
                 continue
             if tn in tagging:
-                if t.status != "success":
+                if t.status != TrackStatus.success.value:
                     t.ripped = True
-                    t.status = "success"
+                    t.status = TrackStatus.success.value
                     changed = True
             elif tn in encoding:
-                if t.status != "encoding":
-                    t.status = "encoding"
+                if t.status != TrackStatus.encoding.value:
+                    t.status = TrackStatus.encoding.value
                     changed = True
             elif tn in grabbing:
-                if t.status != "ripping":
-                    t.status = "ripping"
+                if t.status != TrackStatus.ripping.value:
+                    t.status = TrackStatus.ripping.value
                     changed = True
         if changed:
             db.session.commit()
@@ -822,10 +844,14 @@ def rip_music(job, logfile):
                 logging.error(err)
                 args = {"status": JobState.FAILURE.value, "errors": err}
                 database_updater(args, job)
-                _update_music_tracks(job, ripped=False, status="fail")
+                # Music rip failure: leave per-track status at its current
+                # value (pending), since TrackStatus has no music-rip-failed
+                # member. The job-level JobState.FAILURE above is the source
+                # of truth. Tracks stay marked ripped=False.
+                _update_music_tracks_ripped_only(job, ripped=False)
                 return False
             logging.info("abcde call successful")
-            _update_music_tracks(job, ripped=True, status="success")
+            _update_music_tracks(job, ripped=True, status=TrackStatus.success.value)
             args = {"status": JobState.IDLE.value}
             database_updater(args, job)
             return True

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -1061,7 +1061,12 @@ def clean_old_jobs():
     :return: None
     """
     # Exclude terminal states and transcode states (managed by the external transcoder)
-    excluded = ['fail', 'success', 'waiting_transcode', 'transcoding']
+    excluded = [
+        JobState.FAILURE.value,
+        JobState.SUCCESS.value,
+        JobState.TRANSCODE_WAITING.value,
+        JobState.TRANSCODE_ACTIVE.value,
+    ]
     active_jobs = db.session.query(Job).filter(Job.status.notin_(excluded)).all()
     # Clean up abandoned jobs
     for job in active_jobs:

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -859,13 +859,18 @@ def rip_music(job, logfile):
             err = str(te)
             args = {"status": JobState.FAILURE.value, "errors": err}
             database_updater(args, job)
-            _update_music_tracks(job, ripped=False, status="fail")
+            # Music rip failure: leave per-track status at its current
+            # value (pending), since TrackStatus has no music-rip-failed
+            # member. The job-level JobState.FAILURE above is the source
+            # of truth. Tracks stay marked ripped=False.
+            _update_music_tracks_ripped_only(job, ripped=False)
             logging.error(err)
         except subprocess.CalledProcessError as ab_error:
             err = f"Call to abcde failed with code: {ab_error.returncode}"
             args = {"status": JobState.FAILURE.value, "errors": err}
             database_updater(args, job)
-            _update_music_tracks(job, ripped=False, status="fail")
+            # Music rip failure: same rationale as the TimeoutError branch.
+            _update_music_tracks_ripped_only(job, ripped=False)
             logging.error(err)
         finally:
             if tmp_config:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -118,7 +118,9 @@ def sample_job(app_context):
     job.start_time = None
     job.stop_time = None
     job.job_length = ""
-    job.status = "active"
+    # JobState.VIDEO_RIPPING ("ripping") - placeholder active state for test
+    # fixtures. Validated by db.Enum on Job.status.
+    job.status = "ripping"
     job.stage = "170750493000"
     job.no_of_titles = 3
     job.title = "SERIAL_MOM"
@@ -336,7 +338,7 @@ def transcoder_notify_job():
     job.video_type = 'movie'
     job.year = '2024'
     job.disctype = 'bluray'
-    job.status = 'active'
+    job.status = 'ripping'
     job.poster_url = ''
     job.title = 'Movie'
     job.multi_title = False

--- a/test/test_abcde_no_resume.py
+++ b/test/test_abcde_no_resume.py
@@ -177,7 +177,9 @@ class TestRipMusicTimeoutCatch:
              patch("arm.ripper.utils.database_updater") as mock_db_update, \
              patch("arm.ripper.utils._stream_abcde_output",
                    side_effect=TimeoutError("CD rip timed out after 600s")), \
-             patch("arm.ripper.utils._update_music_tracks") as mock_tracks:
+             patch("arm.ripper.utils._update_music_tracks") as mock_tracks, \
+             patch("arm.ripper.utils._update_music_tracks_ripped_only") \
+                 as mock_tracks_ripped_only:
             mock_cfg.arm_config = {
                 "ABCDE_CONFIG_FILE": "/nonexistent/abcde.conf",
                 "CD_RIP_TIMEOUT": 600,
@@ -198,8 +200,13 @@ class TestRipMusicTimeoutCatch:
                          if c[0][0].get("status") == JobState.FAILURE.value]
         assert len(failure_calls) == 1
         assert "timed out" in failure_calls[0][0][0]["errors"]
-        # Tracks should be marked as failed
-        mock_tracks.assert_called_with(sample_job, ripped=False, status="fail")
+        # Tracks should be marked ripped=False via the ripped-only helper -
+        # the failure path no longer attempts to coerce a bare "fail" string
+        # into Track.status (TrackStatus has no music-rip-failed member).
+        mock_tracks_ripped_only.assert_called_once_with(sample_job, ripped=False)
+        # And the status-touching helper must NOT have been called for this
+        # failure branch.
+        mock_tracks.assert_not_called()
 
 
 # ── identify.py: udev re-read after mount failure ────────────────────────

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -72,7 +72,7 @@ class TestApiJobPause:
     def test_pause_job_not_waiting(self, client, sample_job, app_context):
         """Can only pause jobs in MANUAL_WAIT_STARTED status."""
         from arm.ripper.utils import database_updater
-        database_updater({"status": "active"}, sample_job)
+        database_updater({"status": "ripping"}, sample_job)
         response = client.post(f'/api/v1/jobs/{sample_job.job_id}/pause')
         assert response.status_code == 409
 
@@ -1914,7 +1914,7 @@ class TestApiJobStart:
 
     def test_start_job_not_waiting(self, client, sample_job, app_context):
         from arm.ripper.utils import database_updater
-        database_updater({"status": "active"}, sample_job)
+        database_updater({"status": "ripping"}, sample_job)
         response = client.post(f'/api/v1/jobs/{sample_job.job_id}/start')
         assert response.status_code == 409
 
@@ -1936,7 +1936,7 @@ class TestApiJobCancel:
 
     def test_cancel_not_waiting(self, client, sample_job, app_context):
         from arm.ripper.utils import database_updater
-        database_updater({"status": "active"}, sample_job)
+        database_updater({"status": "ripping"}, sample_job)
         response = client.post(f'/api/v1/jobs/{sample_job.job_id}/cancel')
         assert response.status_code == 409
 
@@ -2521,6 +2521,7 @@ class TestApiAutoFlagTracks:
         with unittest.mock.patch.object(Job, 'parse_udev'), \
              unittest.mock.patch.object(Job, 'get_pid'):
             job = Job('/dev/sr0')
+        job.status = "ripping"
         job.video_type = "movie"
         job.multi_title = False
         db.session.add(job)
@@ -2552,6 +2553,7 @@ class TestApiAutoFlagTracks:
         with unittest.mock.patch.object(Job, 'parse_udev'), \
              unittest.mock.patch.object(Job, 'get_pid'):
             job = Job('/dev/sr0')
+        job.status = "ripping"
         job.video_type = "movie"
         db.session.add(job)
         db.session.flush()
@@ -2711,7 +2713,7 @@ class TestApiDrivesWithJobs:
         drive = next(d for d in data["drives"] if d["name"] == "Living Room")
         assert drive["current_job"] is not None
         assert drive["current_job"]["title"] == "SERIAL_MOM"
-        assert drive["current_job"]["status"] == "active"
+        assert drive["current_job"]["status"] == "ripping"
 
     def test_drives_without_jobs(self, client, sample_drives):
         response = client.get('/api/v1/drives/with-jobs')
@@ -3106,18 +3108,20 @@ class TestApiJobsStats:
         assert response.json() == {"total": 0, "active": 0, "waiting": 0, "success": 0, "fail": 0}
 
     def test_stats_buckets(self, client, app_context):
+        # Two values map to the "active" stats bucket
+        # (ripping/transcoding) per _ACTIVE_STATUSES - _WAITING_STATUSES.
         self._make_jobs([
-            "ripping", "transcoding", "active",   # 3 active
+            "ripping", "transcoding",              # 2 active
             "waiting", "waiting_transcode",        # 2 waiting
             "success", "success",                  # 2 success
             "fail",                                # 1 fail
         ])
         data = client.get('/api/v1/jobs/stats').json()
-        assert data == {"total": 8, "active": 3, "waiting": 2, "success": 2, "fail": 1}
+        assert data == {"total": 7, "active": 2, "waiting": 2, "success": 2, "fail": 1}
 
     def test_stats_status_groups_match_paginated(self, client, app_context):
         """Active and waiting buckets must use the same grouping as /jobs/paginated."""
-        self._make_jobs(["active", "ripping", "waiting", "waiting_transcode", "success"])
+        self._make_jobs(["transcoding", "ripping", "waiting", "waiting_transcode", "success"])
         stats = client.get('/api/v1/jobs/stats').json()
         active_paged = client.get('/api/v1/jobs/paginated?status=active').json()
         waiting_paged = client.get('/api/v1/jobs/paginated?status=waiting').json()

--- a/test/test_arm_enums.py
+++ b/test/test_arm_enums.py
@@ -1,0 +1,19 @@
+"""Tests for ripper-internal enums (arm/enums.py)."""
+
+
+def test_ripmethod_members():
+    from arm.enums import RipMethod
+    assert {m.value for m in RipMethod} == {"mkv", "backup", "backup_dvd"}
+
+
+def test_ripmethod_str_serialization():
+    from arm.enums import RipMethod
+    assert str(RipMethod.backup_dvd) == "backup_dvd"
+    assert f"{RipMethod.mkv}" == "mkv"
+
+
+def test_audio_title_source_members():
+    from arm.enums import AudioTitleSource
+    assert {m.value for m in AudioTitleSource} == {
+        "none", "musicbrainz", "freecddb",
+    }

--- a/test/test_enum_db_enforcement.py
+++ b/test/test_enum_db_enforcement.py
@@ -1,0 +1,124 @@
+"""Verify columns reject out-of-band values at the SQLAlchemy boundary."""
+import unittest.mock
+import pytest
+from sqlalchemy.exc import StatementError
+
+
+def _make_bare_job(devpath="/dev/sr0"):
+    """Create a Job bypassing udev/PID lookup (mirrors sample_job fixture)."""
+    from arm.models.job import Job
+    with unittest.mock.patch.object(Job, 'parse_udev'), \
+         unittest.mock.patch.object(Job, 'get_pid'):
+        return Job(devpath)
+
+
+def test_job_status_rejects_unknown_value(app_context):
+    from arm.database import db
+    job = _make_bare_job()
+    job.status = "totally-not-a-state"
+    db.session.add(job)
+    with pytest.raises((StatementError, ValueError, LookupError)):
+        db.session.flush()
+    db.session.rollback()
+
+
+def test_job_source_type_rejects_unknown(app_context):
+    from arm.database import db
+    job = _make_bare_job()
+    job.status = "ready"
+    job.source_type = "carrier-pigeon"
+    db.session.add(job)
+    with pytest.raises((StatementError, ValueError, LookupError)):
+        db.session.flush()
+    db.session.rollback()
+
+
+def test_track_status_rejects_unknown(app_context):
+    from arm.database import db
+    from arm.models.track import Track
+    job = _make_bare_job()
+    job.status = "ready"
+    db.session.add(job)
+    db.session.flush()
+    track = Track(
+        job_id=job.job_id, track_number="1", length=0, aspect_ratio="",
+        fps=0.0, main_feature=False, source="x", basename="b", filename="f",
+    )
+    track.status = "transcode_failed: this is the old prefix smell"
+    db.session.add(track)
+    with pytest.raises((StatementError, ValueError, LookupError)):
+        db.session.flush()
+    db.session.rollback()
+
+
+def test_config_ripmethod_rejects_unknown(app_context):
+    from arm.database import db
+    from arm.models.config import Config
+    c = Config({}, job_id=None)
+    c.RIPMETHOD = "rsync"
+    db.session.add(c)
+    with pytest.raises((StatementError, ValueError, LookupError)):
+        db.session.flush()
+    db.session.rollback()
+
+
+def test_config_ripmethod_accepts_backup_dvd(app_context):
+    """Regression: backup_dvd was rejected by the API but accepted by the
+    ripper before the enum extraction. Now both sides use the enum."""
+    from arm.database import db
+    from arm.models.config import Config
+    c = Config({}, job_id=None)
+    c.RIPMETHOD = "backup_dvd"
+    db.session.add(c)
+    db.session.flush()  # must not raise
+    db.session.rollback()
+
+
+def test_config_ripmethod_accepts_all_three(app_context):
+    """All three RipMethod values must be persistable."""
+    from arm.database import db
+    from arm.models.config import Config
+    for value in ("mkv", "backup", "backup_dvd"):
+        c = Config({}, job_id=None)
+        c.RIPMETHOD = value
+        db.session.add(c)
+        db.session.flush()  # must not raise
+        db.session.rollback()
+
+
+def test_track_skip_reason_rejects_unknown(app_context):
+    from arm.database import db
+    from arm.models.track import Track
+    job = _make_bare_job()
+    job.status = "ready"
+    db.session.add(job)
+    db.session.flush()
+    track = Track(
+        job_id=job.job_id, track_number="1", length=0, aspect_ratio="",
+        fps=0.0, main_feature=False, source="x", basename="b", filename="f",
+    )
+    track.skip_reason = "obviously_not_a_reason"
+    db.session.add(track)
+    with pytest.raises((StatementError, ValueError, LookupError)):
+        db.session.flush()
+    db.session.rollback()
+
+
+def test_track_skip_reason_accepts_below_main_feature(app_context):
+    """below_main_feature is reserved in the SkipReason enum but has no
+    arm-neu writer yet; make sure the column accepts it for forward
+    compatibility."""
+    from arm.database import db
+    from arm.models.track import Track
+    job = _make_bare_job()
+    job.status = "ready"
+    db.session.add(job)
+    db.session.flush()
+    track = Track(
+        job_id=job.job_id, track_number="1", length=0, aspect_ratio="",
+        fps=0.0, main_feature=False, source="x", basename="b", filename="f",
+    )
+    track.skip_reason = "below_main_feature"
+    db.session.add(track)
+    db.session.flush()  # must not raise
+    db.session.rollback()

--- a/test/test_jobstate_reexport.py
+++ b/test/test_jobstate_reexport.py
@@ -1,0 +1,18 @@
+"""Verify JobState moves to contracts but stays importable from arm.models."""
+
+
+def test_jobstate_importable_from_arm_models_job():
+    from arm.models.job import JobState
+    from arm_contracts.enums import JobState as ContractsJobState
+    assert JobState is ContractsJobState
+
+
+def test_jobstate_status_sets_unchanged():
+    from arm.models.job import (
+        JobState, JOB_STATUS_FINISHED, JOB_STATUS_RIPPING,
+        JOB_STATUS_TRANSCODING, JOB_STATUS_SCANNING,
+    )
+    assert JOB_STATUS_FINISHED == {JobState.SUCCESS, JobState.FAILURE}
+    assert JobState.VIDEO_RIPPING in JOB_STATUS_RIPPING
+    assert JobState.TRANSCODE_ACTIVE in JOB_STATUS_TRANSCODING
+    assert JOB_STATUS_SCANNING == {JobState.IDENTIFYING}

--- a/test/test_music_failure_no_invalid_status.py
+++ b/test/test_music_failure_no_invalid_status.py
@@ -1,0 +1,263 @@
+"""Regression: music-rip failure paths must not write a non-enum
+``status`` value into ``Track.status``.
+
+Background
+----------
+Before this fix, the abcde wrapper's ``TimeoutError`` and
+``subprocess.CalledProcessError`` branches in ``utils.rip_music`` called
+``_update_music_tracks(job, ripped=False, status="fail")``.  ``"fail"``
+is not a member of ``TrackStatus``; with the column declared as
+``db.Enum(... validate_strings=True)`` the commit raises a
+``LookupError`` / ``StatementError``.  In production the helper swallows
+the exception in its broad ``except`` clause and rolls back, so the
+breakage is silent - the per-track status never advances and no test
+catches it.
+
+This test pins the contract:
+
+* both abcde failure modes (TimeoutError, CalledProcessError) finish
+  cleanly (no raised LookupError, function returns False),
+* per-track ``status`` stays at its prior value (``"pending"`` from
+  ``Track.__init__``) - i.e. we no longer attempt to coerce a bare
+  ``"fail"`` string into the enum column,
+* ``ripped`` is False (the only field the failure path is allowed to
+  flip).
+"""
+import os
+import unittest.mock
+
+import pytest
+
+import arm.config.config as cfg
+from arm.database import db
+from arm.models.job import Job
+from arm.models.config import Config
+from arm.models.track import Track
+from arm.ripper import utils
+from arm_contracts.enums import TrackStatus
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures (mirrors test_music_rip.music_job to avoid cross-file coupling)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def music_job(app_context):
+    """Create a Job with disctype='music' and the minimal attributes needed
+    to exercise utils.rip_music()."""
+    _, _ = app_context
+
+    with unittest.mock.patch.object(Job, 'parse_udev'), \
+         unittest.mock.patch.object(Job, 'get_pid'):
+        job = Job('/dev/sr0')
+
+    job.arm_version = "test"
+    job.crc_id = ""
+    job.logfile = "music_cd.log"
+    job.start_time = None
+    job.stop_time = None
+    job.job_length = ""
+    job.status = 'ripping'
+    job.stage = "170750493000"
+    job.no_of_titles = 0
+    job.title = "DARK_SIDE"
+    job.title_auto = "DARK_SIDE"
+    job.title_manual = None
+    job.year = ""
+    job.year_auto = ""
+    job.year_manual = None
+    job.video_type = "unknown"
+    job.video_type_auto = "unknown"
+    job.video_type_manual = None
+    job.imdb_id = ""
+    job.imdb_id_auto = ""
+    job.imdb_id_manual = None
+    job.poster_url = ""
+    job.poster_url_auto = ""
+    job.poster_url_manual = None
+    job.devpath = "/dev/sr0"
+    job.mountpoint = "/mnt/dev/sr0"
+    job.hasnicetitle = False
+    job.errors = None
+    job.disctype = "music"
+    job.label = "DARK_SIDE"
+    job.path = None
+    job.raw_path = None
+    job.transcode_path = None
+    job.ejected = False
+    job.updated = False
+    job.pid = os.getpid()
+    job.pid_hash = 0
+    job.is_iso = False
+
+    db.session.add(job)
+    db.session.flush()
+
+    config = Config({
+        'RAW_PATH': '/home/arm/media/raw',
+        'TRANSCODE_PATH': '/home/arm/media/transcode',
+        'COMPLETED_PATH': '/home/arm/media/completed',
+        'LOGPATH': '/tmp/arm_test/logs',
+        'EXTRAS_SUB': 'extras',
+        'MINLENGTH': '600',
+        'MAXLENGTH': '99999',
+        'MAINFEATURE': False,
+        'RIPMETHOD': 'mkv',
+        'NOTIFY_RIP': True,
+        'NOTIFY_TRANSCODE': True,
+        'WEBSERVER_PORT': 8080,
+    }, job.job_id)
+
+    db.session.add(config)
+    db.session.commit()
+    db.session.refresh(job)
+    return job
+
+
+def _seed_tracks(job, count=3):
+    """Insert ``count`` Track rows for ``job``. Each row is left at the
+    Track.__init__ default of status='pending', ripped=False."""
+    tracks = []
+    for i in range(1, count + 1):
+        t = Track(
+            job_id=job.job_id,
+            track_number=str(i),
+            length=180,
+            aspect_ratio="n/a",
+            fps=0.1,
+            main_feature=False,
+            source="MusicBrainz",
+            basename=f"{i:02d} - Track {i}.flac",
+            filename=f"{i:02d} - Track {i}.flac",
+        )
+        db.session.add(t)
+        tracks.append(t)
+    db.session.commit()
+    return tracks
+
+
+# ---------------------------------------------------------------------------
+# Regression tests
+# ---------------------------------------------------------------------------
+
+class TestMusicFailureUsesRippedOnlyHelper:
+    """The abcde failure branches MUST route through
+    ``_update_music_tracks_ripped_only`` and never through
+    ``_update_music_tracks(..., status="fail")``.
+
+    The naive integration test ("status stays pending on failure") is
+    insufficient: the buggy code path also leaves status at 'pending',
+    because ``_update_music_tracks`` swallows the resulting LookupError
+    in its broad try/except and rolls back.  So we additionally assert
+    the helper *call shape*, which is what actually flipped between the
+    buggy and fixed versions.
+    """
+
+    def test_called_process_error_routes_through_ripped_only_helper(
+        self, music_job, tmp_path
+    ):
+        """Non-zero abcde exit -> CalledProcessError branch -> calls
+        ``_update_music_tracks_ripped_only(job, ripped=False)``, never
+        ``_update_music_tracks(..., status="fail")``."""
+        tracks = _seed_tracks(music_job)
+        music_job.config.LOGPATH = str(tmp_path)
+        logfile = "abcde_test.log"
+
+        mock_proc = unittest.mock.MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.wait.return_value = 1
+        mock_proc.returncode = 1
+        mock_proc.stdout = iter([])
+
+        with unittest.mock.patch.dict(cfg.arm_config, {
+                'ABCDE_CONFIG_FILE': '/nonexistent',
+            }), \
+             unittest.mock.patch('subprocess.Popen', return_value=mock_proc), \
+             unittest.mock.patch(
+                 'arm.ripper.utils._update_music_tracks'
+             ) as mock_with_status, \
+             unittest.mock.patch(
+                 'arm.ripper.utils._update_music_tracks_ripped_only'
+             ) as mock_ripped_only:
+            result = utils.rip_music(music_job, logfile)
+
+        assert result is False
+        # The fixed code path uses the ripped-only helper
+        mock_ripped_only.assert_called_once_with(music_job, ripped=False)
+        # And does NOT invoke the helper that would attempt to write
+        # a non-enum 'fail' string into Track.status
+        for call in mock_with_status.call_args_list:
+            assert call.kwargs.get('status') != 'fail', \
+                f"_update_music_tracks called with bare 'fail': {call!r}"
+            assert call.kwargs.get('status') != TrackStatus.pending.value or True
+
+        # And the live tracks remain unchanged on status (no real DB
+        # write of an invalid enum happened either).
+        for t in tracks:
+            db.session.refresh(t)
+            assert t.status == TrackStatus.pending.value
+            assert t.status != "fail"
+
+    def test_timeout_error_routes_through_ripped_only_helper(
+        self, music_job, tmp_path
+    ):
+        """abcde stall -> TimeoutError branch -> calls
+        ``_update_music_tracks_ripped_only(job, ripped=False)``, never
+        ``_update_music_tracks(..., status="fail")``."""
+        tracks = _seed_tracks(music_job)
+        music_job.config.LOGPATH = str(tmp_path)
+        logfile = "abcde_test.log"
+
+        mock_proc = unittest.mock.MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.returncode = None
+        mock_proc.stdout = iter([])
+
+        with unittest.mock.patch.dict(cfg.arm_config, {
+                'ABCDE_CONFIG_FILE': '/nonexistent',
+            }), \
+             unittest.mock.patch('subprocess.Popen', return_value=mock_proc), \
+             unittest.mock.patch(
+                 'arm.ripper.utils._stream_abcde_output',
+                 side_effect=TimeoutError("CD rip stalled - simulated"),
+             ), \
+             unittest.mock.patch(
+                 'arm.ripper.utils._update_music_tracks'
+             ) as mock_with_status, \
+             unittest.mock.patch(
+                 'arm.ripper.utils._update_music_tracks_ripped_only'
+             ) as mock_ripped_only:
+            result = utils.rip_music(music_job, logfile)
+
+        assert result is False
+        mock_ripped_only.assert_called_once_with(music_job, ripped=False)
+        for call in mock_with_status.call_args_list:
+            assert call.kwargs.get('status') != 'fail', \
+                f"_update_music_tracks called with bare 'fail': {call!r}"
+
+        for t in tracks:
+            db.session.refresh(t)
+            assert t.status == TrackStatus.pending.value
+            assert t.status != "fail"
+
+
+class TestUpdateMusicTracksRippedOnly:
+    """Direct unit test of the helper used by both failure branches.
+    Belt-and-braces in case the integration tests above ever get
+    short-circuited by a mock change - this would still catch a
+    regression on the helper itself."""
+
+    def test_helper_does_not_touch_status(self, music_job):
+        tracks = _seed_tracks(music_job, count=2)
+
+        # Sanity: starting state is the constructor default.
+        for t in tracks:
+            assert t.status == TrackStatus.pending.value
+
+        # Should be a no-op on `status` and flip `ripped` to False.
+        utils._update_music_tracks_ripped_only(music_job, ripped=False)
+
+        for t in tracks:
+            db.session.refresh(t)
+            assert t.status == TrackStatus.pending.value
+            assert t.ripped is False

--- a/test/test_music_rip.py
+++ b/test/test_music_rip.py
@@ -36,7 +36,7 @@ def music_job(app_context):
     job.start_time = None
     job.stop_time = None
     job.job_length = ""
-    job.status = "active"
+    job.status='ripping'
     job.stage = "170750493000"
     job.no_of_titles = 0
     job.title = "DARK_SIDE"

--- a/test/test_notifications_flow.py
+++ b/test/test_notifications_flow.py
@@ -21,7 +21,7 @@ class TestNotify:
         job.video_type = 'movie'
         job.disctype = 'bluray'
         job.label = 'SERIAL_MOM'
-        job.status = 'active'
+        job.status='ripping'
         job.path = None
         job.raw_path = None
         job.transcode_path = None

--- a/test/test_notifications_flow.py
+++ b/test/test_notifications_flow.py
@@ -284,6 +284,7 @@ class TestRipMusic:
                  unittest.mock.patch('arm.ripper.utils.database_updater'), \
                  unittest.mock.patch('arm.ripper.utils._stream_abcde_output', return_value=[]), \
                  unittest.mock.patch('arm.ripper.utils._update_music_tracks'), \
+                 unittest.mock.patch('arm.ripper.utils._update_music_tracks_ripped_only'), \
                  unittest.mock.patch('subprocess.Popen', return_value=mock_proc):
                 result = rip_music(job, 'test.log')
                 assert result is False

--- a/test/test_prescan.py
+++ b/test/test_prescan.py
@@ -29,7 +29,7 @@ def sample_job_with_drive(app_context):
     job.start_time = None
     job.stop_time = None
     job.job_length = ""
-    job.status = "active"
+    job.status='ripping'
     job.stage = ""
     job.no_of_titles = 0
     job.title = "TEST_DISC"

--- a/test/test_retry_session.py
+++ b/test/test_retry_session.py
@@ -114,7 +114,7 @@ class TestRetryOnLocked:
 
     def test_dirty_state_preserved_across_retry(self, retry_db):
         """Modified attributes must persist after retry, not revert to DB values."""
-        job = _make_job(title="Original", status="active")
+        job = _make_job(title="Original", status='ripping')
         db.session.add(job)
         db.session.commit()
 
@@ -339,7 +339,7 @@ class TestDatabaseUpdaterSimplified:
     def test_sets_attributes_and_commits(self, retry_db):
         from arm.services.files import database_updater
 
-        job = _make_job(title="Original", status="active")
+        job = _make_job(title="Original", status='ripping')
         db.session.add(job)
         db.session.commit()
 
@@ -359,7 +359,7 @@ class TestDatabaseUpdaterSimplified:
         """wait_time parameter is accepted for backward compat."""
         from arm.services.files import database_updater
 
-        job = _make_job(status="active")
+        job = _make_job(status='ripping')
         db.session.add(job)
         db.session.commit()
 
@@ -391,7 +391,7 @@ class TestProactiveRollback:
 
     def test_rollback_clears_pending_error(self, retry_db):
         """Simulate bad session state and verify rollback recovers it."""
-        job = _make_job(status="active")
+        job = _make_job(status='ripping')
         db.session.add(job)
         db.session.commit()
 
@@ -415,7 +415,7 @@ class TestProactiveRollback:
     def test_remove_gives_clean_session(self, retry_db):
         """After remove(), next access gets a fresh session."""
         # Dirty the session
-        job = _make_job(status="active")
+        job = _make_job(status='ripping')
         db.session.add(job)
         # Don't commit - just remove
         db.session.remove()

--- a/test/test_rip_logic.py
+++ b/test/test_rip_logic.py
@@ -1398,7 +1398,7 @@ class TestCleanOldJobs:
         from arm.ripper.utils import clean_old_jobs
         _, db = app_context
 
-        job = self._make_job(db, "active", pid=99999)
+        job = self._make_job(db, "ripping", pid=99999)
 
         with unittest.mock.patch('arm.ripper.utils.psutil.pid_exists', return_value=False):
             clean_old_jobs()

--- a/test/test_ripmethod_drift_fixed.py
+++ b/test/test_ripmethod_drift_fixed.py
@@ -1,0 +1,42 @@
+"""Regression: backup_dvd was rejected by the API config endpoint
+before the enum extraction. All three RipMethod values must now
+round-trip through PATCH /api/v1/jobs/<id>/config."""
+import unittest.mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(app_context):
+    from arm.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+@pytest.mark.parametrize("value", ["mkv", "backup", "backup_dvd"])
+def test_ripmethod_round_trips_via_api(client, sample_job, app_context, value):
+    """The API must accept every RipMethod value. Before the fix,
+    backup_dvd hit a 400 with 'RIPMETHOD must be one of ...'."""
+    resp = client.patch(
+        f"/api/v1/jobs/{sample_job.job_id}/config",
+        json={"RIPMETHOD": value},
+    )
+    # The failure mode we care about is the 400 with that specific
+    # message. backup_dvd previously failed this; mkv and backup did not.
+    assert resp.status_code == 200, (
+        f"RIPMETHOD={value!r} got {resp.status_code} "
+        f"(expected 200): {resp.text}"
+    )
+    data = resp.json()
+    assert data["success"] is True
+
+
+def test_ripmethod_invalid_still_rejected(client, sample_job, app_context):
+    """Defence-in-depth: a value not in the enum still 400s."""
+    resp = client.patch(
+        f"/api/v1/jobs/{sample_job.job_id}/config",
+        json={"RIPMETHOD": "rsync"},
+    )
+    assert resp.status_code == 400
+    assert "RIPMETHOD" in resp.json().get("error", "")

--- a/test/test_services.py
+++ b/test/test_services.py
@@ -989,7 +989,7 @@ class TestGetXJobsMusic:
             source="abcde", basename="track1.flac", filename="track1.flac",
         )
         track.ripped = True
-        track.status = "ripped"
+        track.status = "success"
         db.session.add(track)
         db.session.commit()
 

--- a/test/test_track_status_backfill.py
+++ b/test/test_track_status_backfill.py
@@ -47,3 +47,47 @@ def test_backfill_splits_prefix_and_message(app_context):
     ), {"jid": job.job_id}).fetchone()
     assert row[0] == TrackStatus.transcode_failed.value
     assert row[1] == "encoder crashed at frame 1234"
+
+
+def test_backfill_job_status_nulls_to_identifying():
+    """A pre-migration Job row with status=NULL must be backfilled to
+    'identifying' before the NOT NULL flip. The migration's _assert_clean
+    pre-check filters WHERE col IS NOT NULL, so NULL rows are invisible
+    to it and would otherwise trip the new NOT NULL constraint
+    mid-ALTER. 'identifying' matches the new Job.__init__ default.
+
+    This test uses a self-contained sqlite engine with a permissive
+    pre-migration schema (status nullable) so it can simulate the exact
+    NULL-row condition the production migration will encounter. Using
+    the post-migration models from app_context would prevent the
+    NULL-row insert that this test exists to cover.
+    """
+    from arm_contracts.enums import JobState
+    import sqlalchemy as sa
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        # Pre-migration shape: status is a nullable string column.
+        conn.execute(sa.text(
+            "CREATE TABLE job (job_id INTEGER PRIMARY KEY, status VARCHAR(32))"
+        ))
+        result = conn.execute(sa.text(
+            "INSERT INTO job (status) VALUES (NULL)"
+        ))
+        job_id = result.lastrowid
+
+        # Sanity: confirm the row really landed with NULL.
+        pre = conn.execute(sa.text(
+            "SELECT status FROM job WHERE job_id=:jid"
+        ), {"jid": job_id}).fetchone()
+        assert pre[0] is None
+
+        # Apply the same backfill the migration applies.
+        conn.execute(sa.text(
+            "UPDATE job SET status = 'identifying' WHERE status IS NULL"
+        ))
+
+        row = conn.execute(sa.text(
+            "SELECT status FROM job WHERE job_id=:jid"
+        ), {"jid": job_id}).fetchone()
+        assert row[0] == JobState.IDENTIFYING.value

--- a/test/test_track_status_backfill.py
+++ b/test/test_track_status_backfill.py
@@ -1,0 +1,49 @@
+"""Verify the transcode_failed:<msg> backfill splits status from error."""
+import unittest.mock
+
+
+def test_backfill_splits_prefix_and_message(app_context):
+    """When a Track had status='transcode_failed: oh no' before the
+    migration, the new schema must hold status='transcode_failed' and
+    error='oh no'."""
+    from arm.database import db
+    from arm.models.job import Job
+    from arm.models.track import Track
+    from arm_contracts.enums import TrackStatus
+    import sqlalchemy as sa
+
+    with unittest.mock.patch.object(Job, 'parse_udev'), \
+         unittest.mock.patch.object(Job, 'get_pid'):
+        job = Job('/dev/sr0')
+    job.status = "ready"
+    db.session.add(job)
+    db.session.flush()
+
+    # Force a "legacy" status value into Track via raw SQL so we
+    # bypass the new enum validator and simulate pre-migration data.
+    db.session.execute(sa.text(
+        "INSERT INTO track (job_id, track_number, length, aspect_ratio, "
+        "fps, main_feature, basename, filename, source, status, error) "
+        "VALUES (:jid, '1', 0, '', 0.0, 0, 'b', 'f', 'x', "
+        "'transcode_failed: encoder crashed at frame 1234', NULL)"
+    ), {"jid": job.job_id})
+    db.session.commit()
+
+    # Apply the same backfill the migration applies.
+    db.session.execute(sa.text("""
+        UPDATE track
+        SET error = CASE
+                      WHEN error IS NULL OR error = ''
+                      THEN SUBSTR(status, LENGTH('transcode_failed: ') + 1)
+                      ELSE error
+                    END,
+            status = 'transcode_failed'
+        WHERE status LIKE 'transcode_failed:%'
+    """))
+    db.session.commit()
+
+    row = db.session.execute(sa.text(
+        "SELECT status, error FROM track WHERE job_id=:jid"
+    ), {"jid": job.job_id}).fetchone()
+    assert row[0] == TrackStatus.transcode_failed.value
+    assert row[1] == "encoder crashed at frame 1234"

--- a/test/test_track_status_split_callback.py
+++ b/test/test_track_status_split_callback.py
@@ -1,0 +1,87 @@
+"""Verify the transcode-callback handler writes plain status + error
+columns rather than the old transcode_failed:<msg> prefix smell.
+
+Before this change, a track-level transcode failure would set
+track.status = "transcode_failed: <error>" (truncated to 200 chars
+because the column was String(32)). After: track.status holds the
+plain enum value and the full error text goes in track.error (db.Text).
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(app_context):
+    from arm.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+def test_callback_writes_split_status_and_error(client, sample_job, app_context):
+    from arm.database import db
+    from arm.models.track import Track
+    from arm_contracts.enums import TrackStatus
+
+    # Seed a track for the sample_job.
+    track = Track(
+        job_id=sample_job.job_id, track_number="1", length=7200,
+        aspect_ratio="16:9", fps=23.976, main_feature=True,
+        source="MakeMKV", basename="t.mkv", filename="t.mkv",
+    )
+    db.session.add(track)
+    db.session.commit()
+
+    # Long error message to verify Track.error is no longer 200-char
+    # truncated (was a side-effect of jamming it into a String(32) status
+    # field with the prefix).
+    long_err = "codec X264 returned -1 at frame 9001 " + ("x" * 500)
+
+    resp = client.post(
+        f"/api/v1/jobs/{sample_job.job_id}/transcode-callback",
+        json={
+            "status": "failed",
+            "error": "job-level error",
+            "track_results": [{
+                "track_number": "1",
+                "status": "failed",
+                "error": long_err,
+            }],
+        },
+        headers={"X-Api-Version": "2"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    db.session.refresh(track)
+    assert track.status == TrackStatus.transcode_failed.value
+    assert track.error == long_err
+    assert ":" not in track.status  # status MUST NOT carry the message
+
+
+def test_callback_writes_transcoded_on_completed(client, sample_job, app_context):
+    from arm.database import db
+    from arm.models.track import Track
+    from arm_contracts.enums import TrackStatus
+
+    track = Track(
+        job_id=sample_job.job_id, track_number="1", length=7200,
+        aspect_ratio="16:9", fps=23.976, main_feature=True,
+        source="MakeMKV", basename="t.mkv", filename="t.mkv",
+    )
+    db.session.add(track)
+    db.session.commit()
+
+    resp = client.post(
+        f"/api/v1/jobs/{sample_job.job_id}/transcode-callback",
+        json={
+            "status": "completed",
+            "track_results": [{
+                "track_number": "1",
+                "status": "completed",
+            }],
+        },
+        headers={"X-Api-Version": "2"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    db.session.refresh(track)
+    assert track.status == TrackStatus.transcoded.value

--- a/test/test_utils_coverage.py
+++ b/test/test_utils_coverage.py
@@ -27,7 +27,7 @@ class TestBuildJobEnv:
         job.video_type = "movie"
         job.disctype = "bluray"
         job.label = "TEST"
-        job.status = "active"
+        job.status='ripping'
         job.path = "/home/arm/media/completed/movies/Test Movie"
         job.raw_path = "/home/arm/media/raw/Test Movie"
         job.transcode_path = "/home/arm/media/transcode/Test Movie"
@@ -401,7 +401,7 @@ class TestCleanOldJobs:
         from arm.ripper.utils import clean_old_jobs
         from arm.database import db
 
-        sample_job.status = 'active'
+        sample_job.status='ripping'
         sample_job.pid = 99999999  # Non-existent PID
         db.session.commit()
 
@@ -415,7 +415,7 @@ class TestCleanOldJobs:
         from arm.ripper.utils import clean_old_jobs
         from arm.database import db
 
-        sample_job.status = 'active'
+        sample_job.status='ripping'
         sample_job.pid = os.getpid()
         sample_job.pid_hash = hash(unittest.mock.MagicMock())
         db.session.commit()
@@ -426,7 +426,7 @@ class TestCleanOldJobs:
             clean_old_jobs()
 
         db.session.refresh(sample_job)
-        assert sample_job.status == 'active'
+        assert sample_job.status == 'ripping'
 
 
 class TestApplyTrackPhases:


### PR DESCRIPTION
## Summary

- Bumps `components/contracts` to v0.7.0 HEAD (`cd13cd8`); imports `JobState`, `SourceType`, `TrackStatus`, `WebhookEventType`, `SkipReason`
- Adds `arm/enums.py` with `RipMethod` and `AudioTitleSource` (ripper-internal)
- Converts 5 DB columns to `db.Enum(native_enum=False, validate_strings=True, values_callable=...)`: Job.status, Job.source_type, Track.status, Track.skip_reason, Config.RIPMETHOD
- Single Alembic migration (`r3s4t5u6v7w8`, down_revision `q2r3s4t5u6v7`) with backfill that splits `Track.status='transcode_failed: <msg>'` into `status='transcode_failed' + error='<msg>'`
- Fixes RIPMETHOD validation drift: API now accepts `backup_dvd` (the ripper already did)
- Track.error is now a real Text field carrying the failure reason; no more 200-char truncation

Spec: `docs/superpowers/specs/2026-05-01-stringly-typed-enum-extraction-design.md`
Plan: `docs/superpowers/plans/2026-05-01-stringly-typed-enum-extraction.md`

## Notes / deviations from plan

- **GET_AUDIO_TITLE is YAML-only**, not a Config DB column. Plan listed 6 columns; we converted 5. The `AudioTitleSource` enum still ships in `arm/enums.py` for documentation/future use.
- Added `values_callable` to all 5 db.Enum columns. Without it SQLAlchemy stores the Python enum NAME (`VIDEO_RIPPING`) instead of VALUE (`ripping`); that would break the wire contract for arm-ui and the migration's backfill.
- Set `Job.__init__` default `status = JobState.IDENTIFYING.value` so the new NOT NULL constraint doesn't trip bare `Job()` constructions in test fixtures (production code overwrites within milliseconds).
- Music rip failure path: `TrackStatus` has no music-rip-failed enum member. Added `_update_music_tracks_ripped_only()` helper that updates only the ripped flag on music rip failure; per-track status stays at its prior value (typically `pending`). The job-level `JobState.FAILURE` is the source of truth. Worth a follow-up: should `TrackStatus` gain a generic `failed` member?

## Test plan

- [x] Full pytest suite green (2113 passed, 1 skipped)
- [x] Migration applies cleanly to a fresh sqlite DB
- [x] Migration verified to store enum VALUES (`ripping`) not NAMES (`VIDEO_RIPPING`)
- [x] Final sweep greps clean (only docstring hit on `skip_reason='makemkv_skipped'`)
- [ ] Migration applies cleanly to dev hifi-server DB (verify with operator)