### PR TITLE
chore: source API validation tuples from enums; add migration row counts

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -29,7 +29,8 @@ from arm.api.dependencies import require_api_version
 import arm.config.config as cfg
 from arm.constants import SINGLE_TRACK_VIDEO_TYPES
 from arm.database import db
-from arm.enums import RipMethod
+from arm.enums import AudioFormat, RipMethod, SpeedProfile
+from arm_contracts.enums import Disctype
 from arm.models.job import Job, JobState
 from arm.models.track import Track
 from arm.models.notifications import Notifications
@@ -388,12 +389,12 @@ def change_job_config(job_id: int, body: dict):
     config_updates = {}  # collected for atomic apply under lock
 
     valid_ripmethods = tuple(m.value for m in RipMethod)
-    valid_disctypes = ('dvd', 'bluray', 'bluray4k', 'music', 'data')
-    valid_audio_formats = (
-        'flac', 'mp3', 'vorbis', 'opus', 'm4a', 'wav', 'mka',
-        'wv', 'ape', 'mpc', 'spx', 'mp2', 'tta', 'aiff',
-    )
-    valid_speed_profiles = ('safe', 'fast', 'fastest')
+    # Disctype enum has an 'unknown' member but the API rejects it as a
+    # PATCH target - 'unknown' is the initial state for unidentified discs,
+    # not something operators set deliberately.
+    valid_disctypes = tuple(m.value for m in Disctype if m.value != 'unknown')
+    valid_audio_formats = tuple(m.value for m in AudioFormat)
+    valid_speed_profiles = tuple(m.value for m in SpeedProfile)
 
     if 'RIPMETHOD' in body:
         val = str(body['RIPMETHOD']).lower()

--- a/arm/enums.py
+++ b/arm/enums.py
@@ -36,3 +36,40 @@ class AudioTitleSource(_StrValueEnum):
     none = "none"
     musicbrainz = "musicbrainz"
     freecddb = "freecddb"
+
+
+class AudioFormat(_StrValueEnum):
+    """abcde audio output format. Used for Job.config.AUDIO_FORMAT.
+
+    Closed set; matches the formats abcde itself supports. Validated at the
+    API boundary (arm/api/v1/jobs.py PUT /jobs/{id}/config) so a typo in a
+    PATCH body fails fast rather than landing in the DB and surfacing later
+    when abcde rejects the format.
+    """
+    flac = "flac"
+    mp3 = "mp3"
+    vorbis = "vorbis"
+    opus = "opus"
+    m4a = "m4a"
+    wav = "wav"
+    mka = "mka"
+    wv = "wv"
+    ape = "ape"
+    mpc = "mpc"
+    spx = "spx"
+    mp2 = "mp2"
+    tta = "tta"
+    aiff = "aiff"
+
+
+class SpeedProfile(_StrValueEnum):
+    """cdparanoia error-correction profile. Used for Job.config.RIP_SPEED_PROFILE.
+
+    Maps to cdparanoia flags via _SPEED_PROFILES in arm/ripper/utils.py:
+      safe    -> "" (full paranoia, slowest, best for scratched discs)
+      fast    -> "-Y" (disable extra paranoia, ~2-4x faster)
+      fastest -> "-Z" (no error correction, pristine discs only, ~5-10x faster)
+    """
+    safe = "safe"
+    fast = "fast"
+    fastest = "fastest"

--- a/arm/migrations/versions/s4t5u6v7w8x9_jobstate_disambiguation.py
+++ b/arm/migrations/versions/s4t5u6v7w8x9_jobstate_disambiguation.py
@@ -94,16 +94,25 @@ def upgrade() -> None:
 
     # 2. Refuse to migrate if any row still holds a value not in the new
     #    enum set after backfill. Better to fail loudly here than to
-    #    silently truncate.
+    #    silently truncate. Report row counts per bad value so the
+    #    operator can decide between manual fix vs. restore-from-backup.
     rows = conn.execute(sa.text(
-        "SELECT DISTINCT status FROM job WHERE status IS NOT NULL"
-    )).fetchall()
-    bad = sorted({r[0] for r in rows if r[0] not in NEW_JOB_STATE_VALUES})
-    if bad:
+        "SELECT status, COUNT(*) FROM job "
+        "WHERE status IS NOT NULL AND status NOT IN :allowed "
+        "GROUP BY status"
+    ).bindparams(sa.bindparam('allowed', expanding=True)),
+        {'allowed': list(NEW_JOB_STATE_VALUES)}
+    ).fetchall()
+    if rows:
+        bad_summary = ', '.join(
+            f"{value!r}: {count} row(s)" for value, count in sorted(rows)
+        )
+        total = sum(count for _, count in rows)
         raise RuntimeError(
-            f"job.status contains values not in the new JobState set: "
-            f"{bad}. Allowed: {sorted(NEW_JOB_STATE_VALUES)}. Fix the "
-            f"rows manually then retry."
+            f"job.status contains {total} row(s) with values not in the "
+            f"new JobState set ({bad_summary}). Allowed: "
+            f"{sorted(NEW_JOB_STATE_VALUES)}. Fix the rows manually then "
+            f"retry."
         )
 
     # 3. Swap the CHECK constraint on job.status to the new value set.

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -31,6 +31,7 @@ import psutil
 
 from netifaces import interfaces, ifaddresses, AF_INET
 
+from arm.enums import SpeedProfile
 from arm_contracts.enums import TrackStatus, WebhookEventType
 
 import arm.config.config as cfg
@@ -678,11 +679,14 @@ def _apply_track_phases(job, grabbing, encoding, tagging):
         db.session.rollback()
 
 
-# cdparanoia options keyed by RIP_SPEED_PROFILE
+# cdparanoia flags keyed by RIP_SPEED_PROFILE. Keys MUST stay in lockstep
+# with arm.enums.SpeedProfile members; the dict-comprehension form below
+# would catch a rename via KeyError, but the explicit literal is easier
+# for grep + faster to read.
 _SPEED_PROFILES = {
-    "safe": "",                # full paranoia — slowest, best for scratched discs
-    "fast": "-Y",              # disable extra paranoia — good balance, ~2-4x faster
-    "fastest": "-Z",           # disable all paranoia — pristine discs only, ~5-10x faster
+    SpeedProfile.safe.value: "",       # full paranoia, slowest, best for scratched discs
+    SpeedProfile.fast.value: "-Y",     # disable extra paranoia, ~2-4x faster
+    SpeedProfile.fastest.value: "-Z",  # no error correction, pristine discs only
 }
 
 

--- a/test/test_arm_enums.py
+++ b/test/test_arm_enums.py
@@ -17,3 +17,26 @@ def test_audio_title_source_members():
     assert {m.value for m in AudioTitleSource} == {
         "none", "musicbrainz", "freecddb",
     }
+
+
+def test_audio_format_members():
+    from arm.enums import AudioFormat
+    assert {m.value for m in AudioFormat} == {
+        "flac", "mp3", "vorbis", "opus", "m4a", "wav", "mka",
+        "wv", "ape", "mpc", "spx", "mp2", "tta", "aiff",
+    }
+
+
+def test_speed_profile_members():
+    from arm.enums import SpeedProfile
+    assert {m.value for m in SpeedProfile} == {"safe", "fast", "fastest"}
+
+
+def test_speed_profile_drives_cdparanoia_dict():
+    """The _SPEED_PROFILES dict in arm/ripper/utils.py keys MUST match
+    SpeedProfile members. A rename to either side without the other
+    would mean a config value passes API validation but yields no
+    cdparanoia flags (silently falls back to default behavior)."""
+    from arm.enums import SpeedProfile
+    from arm.ripper.utils import _SPEED_PROFILES
+    assert set(_SPEED_PROFILES.keys()) == {m.value for m in SpeedProfile}

--- a/test/test_jobstate_disambiguation_migration.py
+++ b/test/test_jobstate_disambiguation_migration.py
@@ -164,36 +164,56 @@ def test_unknown_status_value_is_left_alone_for_assert_clean_to_catch():
 
 def test_assert_clean_post_check_raises_on_bogus_value():
     """The migration's post-backfill RuntimeError must fire when an
-    out-of-band value remains. We re-implement the post-check in this
-    test so a bug in the production check can't silently pass."""
-    NEW_JOB_STATE_VALUES = {
+    out-of-band value remains, and the message must include row counts
+    so the operator can decide between manual fix vs. restore-from-backup.
+    """
+    NEW_JOB_STATE_VALUES = (
         'success', 'fail', 'manual_paused', 'identifying', 'ready',
         'video_ripping', 'audio_ripping', 'info', 'copying', 'ejecting',
         'transcoding', 'waiting_transcode', 'makemkv_throttled',
-    }
+    )
 
     engine = _make_engine_with_legacy_job_table()
     with engine.begin() as conn:
+        # Two rows of the same bad value to confirm count aggregation.
         conn.execute(sa.text(
-            "INSERT INTO job (status, disctype) VALUES ('totally-bogus', 'dvd')"
+            "INSERT INTO job (status, disctype) VALUES "
+            "('totally-bogus', 'dvd'), ('totally-bogus', 'bluray'), "
+            "('also-bogus', 'music')"
         ))
 
         _backfill_job_status(conn)
 
+        # Mirror the production post-check (must stay in lockstep with
+        # arm/migrations/versions/s4t5u6v7w8x9_jobstate_disambiguation.py).
         rows = conn.execute(sa.text(
-            "SELECT DISTINCT status FROM job WHERE status IS NOT NULL"
-        )).fetchall()
-        bad = sorted({r[0] for r in rows if r[0] not in NEW_JOB_STATE_VALUES})
+            "SELECT status, COUNT(*) FROM job "
+            "WHERE status IS NOT NULL AND status NOT IN :allowed "
+            "GROUP BY status"
+        ).bindparams(sa.bindparam('allowed', expanding=True)),
+            {'allowed': list(NEW_JOB_STATE_VALUES)}
+        ).fetchall()
 
-        # Mirror the production check.
-        if not bad:
-            pytest.fail("Expected the bogus status to remain in the bad set")
-        with pytest.raises(RuntimeError, match="totally-bogus"):
-            raise RuntimeError(
-                f"job.status contains values not in the new JobState set: "
-                f"{bad}. Allowed: {sorted(NEW_JOB_STATE_VALUES)}. Fix the "
-                f"rows manually then retry."
-            )
+    # Verify: aggregation produced (value, count) pairs, total is 3.
+    assert rows, "Expected the bogus rows to remain in the bad set"
+    summary = {value: count for value, count in rows}
+    assert summary == {'totally-bogus': 2, 'also-bogus': 1}
+
+    # Verify the message format: includes counts AND value, raises RuntimeError.
+    bad_summary = ', '.join(
+        f"{value!r}: {count} row(s)" for value, count in sorted(rows)
+    )
+    total = sum(count for _, count in rows)
+    with pytest.raises(RuntimeError, match=r"3 row\(s\)") as exc_info:
+        raise RuntimeError(
+            f"job.status contains {total} row(s) with values not in the "
+            f"new JobState set ({bad_summary}). Allowed: "
+            f"{sorted(NEW_JOB_STATE_VALUES)}. Fix the rows manually then "
+            f"retry."
+        )
+    msg = str(exc_info.value)
+    assert "'totally-bogus': 2 row(s)" in msg
+    assert "'also-bogus': 1 row(s)" in msg
 
 
 def test_real_migration_module_executes_backfill_against_seeded_db(tmp_path):


### PR DESCRIPTION
## Summary

Followup #3+#4 from the 2026-05-02 enum-extraction batch:

**#3 - API validation tuple cleanup** (`arm/api/v1/jobs.py:391-396`)

The `valid_disctypes`, `valid_audio_formats`, `valid_speed_profiles` tuples were hand-coded literals. Now sourced from enums:

- `valid_disctypes` from `arm_contracts.enums.Disctype` (filtering out `unknown` per existing API behavior)
- `valid_audio_formats` from new `arm.enums.AudioFormat` (14 members)
- `valid_speed_profiles` from new `arm.enums.SpeedProfile` (3 members)

`RIPMETHOD` already used `RipMethod` from PR #311.

The new `_SPEED_PROFILES` regression test (`test_speed_profile_drives_cdparanoia_dict`) catches a rename mismatch between `arm/enums.SpeedProfile` and the dict in `arm/ripper/utils.py:682` - which would otherwise silently fall through to default cdparanoia behavior.

**#4 - Migration row count hint**

The `s4t5u6v7w8x9_jobstate_disambiguation` migration's leftover-check `RuntimeError` now reports per-value row counts (e.g. `'totally-bogus': 2 row(s), 'also-bogus': 1 row(s)`) so an operator hitting the error can decide between manual fix vs. restore-from-backup.

Future migrations following this pattern should copy the new shape.

**Lockstep**

Bumps `components/contracts` submodule to v2.0.0 release tag (0bf389f) - the release-please tag-only commit, no API changes.

## Test plan

- [x] Full pytest suite green (2127 passed, +3 new tests)
- [x] Migration tests still pass with the new error format
- [x] _SPEED_PROFILES regression test would catch a one-sided rename