### PR TITLE
fix(migration): remap legacy track.status='fail' rows to 'failed'

### DIFF
--- a/arm/migrations/versions/r3s4t5u6v7w8_enum_columns.py
+++ b/arm/migrations/versions/r3s4t5u6v7w8_enum_columns.py
@@ -28,8 +28,18 @@ JOB_STATE_VALUES = (
 SOURCE_TYPE_VALUES = ('disc', 'folder')
 TRACK_STATUS_VALUES = (
     'pending', 'ripping', 'encoding', 'success',
-    'transcoded', 'transcode_failed',
+    'transcoded', 'transcode_failed', 'failed',
 )
+# Legacy values that arm-neu wrote to track.status before the enum was
+# introduced, mapped to their nearest TrackStatus member. 'fail' was
+# JobState.FAILURE.value being mistakenly written to track.status by the
+# pre-disambiguation music-rip failure path (fixed in s4t5u6v7w8x9 along
+# with the TrackStatus.failed enum addition). Real production rows
+# observed on hifi 2026-05-03; the backfill migrates them to 'failed' so
+# the column constraint passes.
+LEGACY_TRACK_STATUS_REMAP = {
+    'fail': 'failed',
+}
 SKIP_REASON_VALUES = (
     'too_short', 'too_long', 'makemkv_skipped',
     'user_disabled', 'below_main_feature',
@@ -80,6 +90,21 @@ def upgrade() -> None:
     conn.execute(sa.text(
         "UPDATE job SET status = 'identifying' WHERE status IS NULL"
     ))
+
+    # 1c. Remap legacy track.status values to their TrackStatus equivalents.
+    #     Pre-disambiguation, the music-rip failure path wrote
+    #     JobState.FAILURE.value ('fail') into track.status. The fix
+    #     ('failed' member + helper retirement) shipped in s4t5u6v7w8x9, but
+    #     real production rows from before that fix already exist and need
+    #     remapping for the CHECK constraint to accept them. Add 'failed' to
+    #     TRACK_STATUS_VALUES too so the constraint allows it post-migration
+    #     (s4t5u6v7w8x9 also lists 'failed' in its set, so the value
+    #     persists through the next migration unchanged).
+    for old_value, new_value in LEGACY_TRACK_STATUS_REMAP.items():
+        conn.execute(
+            sa.text("UPDATE track SET status = :new WHERE status = :old"),
+            {"old": old_value, "new": new_value},
+        )
 
     # 2. Pre-checks: refuse to migrate if any column has an out-of-band
     #    value. Better to fail loudly here than to silently truncate or

--- a/test/test_track_status_backfill.py
+++ b/test/test_track_status_backfill.py
@@ -91,3 +91,44 @@ def test_backfill_job_status_nulls_to_identifying():
             "SELECT status FROM job WHERE job_id=:jid"
         ), {"jid": job_id}).fetchone()
         assert row[0] == JobState.IDENTIFYING.value
+
+
+def test_backfill_remaps_legacy_track_status_fail_to_failed():
+    """Pre-disambiguation, the music-rip failure path wrote
+    JobState.FAILURE.value ('fail') into track.status. The TrackStatus
+    enum has no 'fail' member - the right value is 'failed' (the new
+    member added in s4t5u6v7w8x9). Real production rows from before the
+    fix were observed on hifi 2026-05-03 (12 rows in job_id=123).
+
+    The r3s4t5u6v7w8 backfill must remap them so the column constraint
+    accepts them; otherwise the migration's _assert_clean pre-check
+    blocks the upgrade.
+    """
+    from arm_contracts.enums import TrackStatus
+    import sqlalchemy as sa
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        # Pre-migration shape: status is a nullable string column.
+        conn.execute(sa.text(
+            "CREATE TABLE track (track_id INTEGER PRIMARY KEY, "
+            "status VARCHAR(32))"
+        ))
+        # Seed 3 rows with the legacy 'fail' value (mirroring the prod
+        # artifact: multiple tracks from a single failed music job).
+        conn.execute(sa.text(
+            "INSERT INTO track (status) VALUES ('fail'), ('fail'), ('fail')"
+        ))
+
+        # Apply the same backfill the migration applies. Mirrors
+        # arm/migrations/versions/r3s4t5u6v7w8_enum_columns.py upgrade()
+        # step 1c.
+        conn.execute(
+            sa.text("UPDATE track SET status = :new WHERE status = :old"),
+            {"old": "fail", "new": "failed"},
+        )
+
+        rows = conn.execute(sa.text(
+            "SELECT status, COUNT(*) FROM track GROUP BY status"
+        )).fetchall()
+        assert rows == [(TrackStatus.failed.value, 3)]


### PR DESCRIPTION
## Summary

Production deploy to hifi (2026-05-03 00:28 UTC) of r3s4t5u6v7w8 surfaced 12 real `track.status='fail'` rows on a single failed music job (job_id=123). These came from the pre-disambiguation music-rip failure path mistakenly writing `JobState.FAILURE.value` to `track.status`. The migration's `_assert_clean` pre-check correctly refused to migrate, leaving the DB at `q2r3s4t5u6v7`.

## Fix

Extends `r3s4t5u6v7w8_enum_columns.py`:

1. Adds `'failed'` to `TRACK_STATUS_VALUES` so the column constraint accepts it post-migration. (`s4t5u6v7w8x9` also has `'failed'` in its set, so this value persists through the next migration unchanged.)
2. Adds a step 1c backfill that `UPDATE`s `track.status='fail'` rows to `'failed'`.

The disambiguation batch's helper retirement (PR #314 commit `fbebacc`) prevents NEW rows from acquiring this state. This commit handles the historical artifact already in production DBs.

## Test plan

- [x] New regression test (`test_backfill_remaps_legacy_track_status_fail_to_failed`) seeds the exact production artifact shape and asserts the remap
- [x] Full pytest suite green (2128 passed, +1 new)
- [ ] Re-deploy to hifi after merge; confirm migration applies cleanly + 12 rows now report `'failed'`

## Why this isn't a new migration

The migration history `q2r3s4t5u6v7 -> r3s4t5u6v7w8 -> s4t5u6v7w8x9` hasn't successfully applied past `q2r3s4t5u6v7` on hifi - the pre-check blocked it. So we can amend `r3s4t5u6v7w8` to handle this case before any environment has applied the constraint. Dev environments that already migrated past `r3s4t5u6v7w8` are fine because they had no `'fail'` rows (the test fixtures + dev sqlite paths never wrote that value).