### PR TITLE
fix(track): default process=None on init so review widget renders rippable

### DIFF
--- a/arm/models/track.py
+++ b/arm/models/track.py
@@ -62,7 +62,15 @@ class Track(db.Model):
         self.filename = filename
         self.status = TrackStatus.pending.value
         self.ripped = False
-        self.process = False
+        # process=None means "not yet decided"; the serializer at
+        # arm/api/v1/jobs.py:_track_to_dict treats NULL as True so the
+        # disc-review widget can render fresh tracks as rippable until
+        # the rip path explicitly sets True/False (process_single_tracks
+        # for manual-mode, the all-tracks loop for auto-mode, or
+        # apply_makemkv_skips for tracks MakeMKV refuses).
+        # If we set False here, fresh-from-prescan tracks would render
+        # as 'skip' in the review UI for the entire wait phase.
+        self.process = None
         self.enabled = True
         self.chapters = chapters
         self.filesize = filesize

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -258,7 +258,10 @@ class TestTrackCreation:
         assert track.length == 5400
         assert track.main_feature is True
         assert track.ripped is False  # default
-        assert track.process is False  # default
+        # process=None means "not yet decided" - the API serializer
+        # defaults None to True so the disc-review widget renders fresh
+        # tracks as rippable until the rip path explicitly sets True/False.
+        assert track.process is None
 
     def test_track_str(self, app_context):
         from arm.models.track import Track


### PR DESCRIPTION
## Summary

Production bug observed on hifi after redeploying with PR-A: every track in a fresh disc-review showed 'skip' in the DiscReviewWidget, including the long main-feature tracks well above MINLENGTH=600s. Discs would be marked unrippable in review and the user couldn't proceed.

## Root cause

`Track.__init__` has set `self.process = False` since 2024. The API serializer at `arm/api/v1/jobs.py:_track_to_dict` has lifecycle-aware semantics:

```python
process=track.process if track.process is not None else True
```

NULL means 'not yet decided' (default to True for review-phase display); False means 'definitively skipped'. Fresh tracks with the init-default False get classified as 'skip' by the widget (which checks `track.process === false`) even though no skip decision has been made yet.

This bug existed since PR #311 added the `Track.process` column. It went undetected because pre-PR-#311 job rows had `process=NULL` (no backfill), so the serializer's NULL->True default kicked in. New jobs created after that migration hit the bug.

## Fix

`Track.__init__` now sets `self.process = None` instead of `False`. The lifecycle-aware default in `_track_to_dict` then renders fresh tracks as rippable until the rip path explicitly decides:
- `process_single_tracks` for manual mode (sets True/False per length-bounds)
- The all-tracks loop in makemkv.py:757 (sets True optimistically)
- `apply_makemkv_skips` for tracks MakeMKV refuses (sets False with skip_reason)

Updated `test_models.py:261` assertion to reflect the new init default. The 5 other tests asserting `process is False` are unchanged because they exercise rip-time setters (post-explicit-decision), not the init default.

## Test plan

- [x] Full pytest suite green (2139 passed)
- [ ] Smoke: deploy to hifi, insert a real disc, verify the long tracks show as rippable in review