### PR TITLE
fix(prescan): mark too-short/too-long tracks as filtered before review

### DIFF
--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -197,14 +197,14 @@ def main():
                 tracks = list(job.tracks)
                 if len(tracks) == 0:
                     raise RuntimeError("MakeMKV returned 0 titles")
-                # Apply length-based filter so the disc-review widget
-                # renders short titles as 'skip' before rip starts.
-                # Without this, every track shows as rippable until the
-                # rip phase decides per-track via process_single_tracks
-                # (manual mode) or apply_makemkv_skips (all-tracks mode).
-                # arm-ui's DiscReviewWidget.isFiltered() trusts backend
-                # truth (track.process / skip_reason) per commit fb08d0a.
-                from arm_contracts.enums import SkipReason
+                for t in tracks:
+                    t.enabled = True
+                # Stamp process=False + skip_reason on out-of-bounds
+                # tracks so the disc-review widget renders them as 'skip'
+                # before the rip phase decides. arm-ui's
+                # DiscReviewWidget.isFiltered() trusts backend truth
+                # (track.process / skip_reason) per fb08d0a; long-enough
+                # tracks keep process=None and render rippable.
                 try:
                     minlength = int(job.config.MINLENGTH)
                 except (TypeError, ValueError):
@@ -213,16 +213,7 @@ def main():
                     maxlength = int(job.config.MAXLENGTH)
                 except (TypeError, ValueError):
                     maxlength = 99999
-                for t in tracks:
-                    t.enabled = True
-                    if t.length is None:
-                        continue
-                    if t.length < minlength:
-                        t.process = False
-                        t.skip_reason = SkipReason.too_short.value
-                    elif t.length > maxlength:
-                        t.process = False
-                        t.skip_reason = SkipReason.too_long.value
+                utils.mark_prescan_filter_state(job, minlength, maxlength)
                 db.session.commit()
                 logging.info("Pre-scan complete: %d tracks found", len(tracks))
                 break

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -197,8 +197,32 @@ def main():
                 tracks = list(job.tracks)
                 if len(tracks) == 0:
                     raise RuntimeError("MakeMKV returned 0 titles")
+                # Apply length-based filter so the disc-review widget
+                # renders short titles as 'skip' before rip starts.
+                # Without this, every track shows as rippable until the
+                # rip phase decides per-track via process_single_tracks
+                # (manual mode) or apply_makemkv_skips (all-tracks mode).
+                # arm-ui's DiscReviewWidget.isFiltered() trusts backend
+                # truth (track.process / skip_reason) per commit fb08d0a.
+                from arm_contracts.enums import SkipReason
+                try:
+                    minlength = int(job.config.MINLENGTH)
+                except (TypeError, ValueError):
+                    minlength = 0
+                try:
+                    maxlength = int(job.config.MAXLENGTH)
+                except (TypeError, ValueError):
+                    maxlength = 99999
                 for t in tracks:
                     t.enabled = True
+                    if t.length is None:
+                        continue
+                    if t.length < minlength:
+                        t.process = False
+                        t.skip_reason = SkipReason.too_short.value
+                    elif t.length > maxlength:
+                        t.process = False
+                        t.skip_reason = SkipReason.too_long.value
                 db.session.commit()
                 logging.info("Pre-scan complete: %d tracks found", len(tracks))
                 break

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -989,6 +989,38 @@ def put_track(job, t_no, seconds, aspect, fps, mainfeature, source, filename="",
     database_adder(job_track)
 
 
+def mark_prescan_filter_state(job, minlength: int, maxlength: int) -> None:
+    """Apply length-based filter to job tracks immediately after pre-scan.
+
+    Before this runs, fresh Track rows have process=None (the
+    'not yet decided' default). The serializer at
+    arm/api/v1/jobs.py:_track_to_dict treats None as True, so
+    every track would render as rippable in the disc-review widget.
+
+    This helper stamps process=False + skip_reason for tracks
+    outside the configured length bounds, so the widget's
+    isFiltered(track) check (track.process === false) shows them
+    as 'skip'. Long-enough tracks keep process=None and render
+    rippable. The rip-time filter (process_single_tracks for
+    manual mode, the all-tracks loop for auto mode) still runs
+    afterward and refines the decision per track.
+
+    No-ops on tracks with length=None (music CDs, unscanned
+    folder imports). Caller is responsible for db.session.commit().
+    """
+    from arm_contracts.enums import SkipReason
+
+    for t in job.tracks:
+        if t.length is None:
+            continue
+        if t.length < minlength:
+            t.process = False
+            t.skip_reason = SkipReason.too_short.value
+        elif t.length > maxlength:
+            t.process = False
+            t.skip_reason = SkipReason.too_long.value
+
+
 def arm_setup(arm_log: Logger) -> None:
     """
     Setup arm - Create all the directories we need for arm to run

--- a/test/test_track_skip_reason.py
+++ b/test/test_track_skip_reason.py
@@ -254,3 +254,82 @@ def test_manual_patch_without_enabled_leaves_skip_reason_alone(client, app_conte
     db.session.refresh(t)
     assert t.filename == "renamed.mkv"
     assert t.skip_reason == "makemkv_skipped"
+
+
+def test_mark_prescan_filter_state_skips_short_tracks(app_context, sample_job):
+    """mark_prescan_filter_state stamps process=False + skip_reason=too_short
+    on tracks below the configured MINLENGTH so the disc-review widget
+    renders them as 'skip' before the rip phase starts."""
+    from arm.models.track import Track
+    from arm.ripper.utils import mark_prescan_filter_state
+
+    short = Track(
+        job_id=sample_job.job_id, track_number="0", length=33,
+        aspect_ratio="16:9", fps=23.976, main_feature=False,
+        source="MakeMKV", basename="t0", filename="t0.mkv",
+    )
+    long_track = Track(
+        job_id=sample_job.job_id, track_number="1", length=5400,
+        aspect_ratio="16:9", fps=23.976, main_feature=True,
+        source="MakeMKV", basename="t1", filename="t1.mkv",
+    )
+    db.session.add_all([short, long_track])
+    db.session.commit()
+    db.session.refresh(sample_job)
+
+    mark_prescan_filter_state(sample_job, minlength=600, maxlength=99999)
+    db.session.commit()
+
+    db.session.refresh(short)
+    db.session.refresh(long_track)
+    assert short.process is False
+    assert short.skip_reason == "too_short"
+    # Long-enough tracks keep process=None (the serializer's NULL->True
+    # default makes the widget render them as rippable).
+    assert long_track.process is None
+    assert long_track.skip_reason is None
+
+
+def test_mark_prescan_filter_state_skips_too_long_tracks(app_context, sample_job):
+    """Tracks above MAXLENGTH get process=False + skip_reason=too_long."""
+    from arm.models.track import Track
+    from arm.ripper.utils import mark_prescan_filter_state
+
+    too_long = Track(
+        job_id=sample_job.job_id, track_number="0", length=12345,
+        aspect_ratio="16:9", fps=23.976, main_feature=False,
+        source="MakeMKV", basename="t0", filename="t0.mkv",
+    )
+    db.session.add(too_long)
+    db.session.commit()
+    db.session.refresh(sample_job)
+
+    mark_prescan_filter_state(sample_job, minlength=600, maxlength=5000)
+    db.session.commit()
+
+    db.session.refresh(too_long)
+    assert too_long.process is False
+    assert too_long.skip_reason == "too_long"
+
+
+def test_mark_prescan_filter_state_skips_tracks_with_null_length(app_context, sample_job):
+    """Tracks with length=None (music CDs, unscanned folders) are not
+    touched - process stays None, skip_reason stays None."""
+    from arm.models.track import Track
+    from arm.ripper.utils import mark_prescan_filter_state
+
+    no_length = Track(
+        job_id=sample_job.job_id, track_number="0", length=None,
+        aspect_ratio="", fps=0.0, main_feature=False,
+        source="MakeMKV", basename="t0", filename="t0.mkv",
+    )
+    db.session.add(no_length)
+    db.session.commit()
+    db.session.refresh(sample_job)
+
+    mark_prescan_filter_state(sample_job, minlength=600, maxlength=5000)
+    db.session.commit()
+
+    db.session.refresh(no_length)
+    assert no_length.process is None
+    assert no_length.skip_reason is None


### PR DESCRIPTION
## Summary

Production hifi: after PR #320 fixed the Track.process init default, all tracks in disc-review now show as rippable - including the 21s/48s/60s tracks that should be filtered by MINLENGTH=600.

## Root cause

arm-ui PR `fb08d0a` (May 1) deliberately replaced the client-side `track.length < MINLENGTH` check with backend-truth via `track.process` / `skip_reason`. Commit message said 'the actual filter decision is made by the backend' but no backend code was added at pre-scan time to set `process=False` for short tracks. `process` is set later by:
- `process_single_tracks` (manual mode, after `manual_wait` returns)
- the all-tracks loop in `makemkv.py:757` (auto mode, post-prescan)
- `apply_makemkv_skips` (after MakeMKV refuses titles)

None of those run before the user sees the review widget.

The bug was masked by the broken `Track.__init__` default (`self.process = False` since 2024) plus the legacy NULL-row fallback in `_track_to_dict`'s serializer (`process if not None else True`). PR #320 fixed the init default, which exposed this missing pre-scan filter step.

## Fix

After pre-scan in `arm/ripper/main.py`, iterate the tracks once and stamp `process=False` + `skip_reason='too_short'`/`'too_long'` for out-of-bounds lengths. Long-enough tracks keep `process=None`, which the serializer treats as True, so the widget renders them rippable.

This matches the design intent of `fb08d0a`: the backend is the source of truth for filter decisions; the widget just consumes.

## Test plan

- [x] Full pytest suite green (2139 passed)
- [ ] Smoke: insert a real disc on hifi; verify long tracks render rippable AND short tracks (under MINLENGTH) render as 'skip' in the review widget