### PR TITLE
refactor(maintenance): invariant wire shapes for cleanup endpoints

### DIFF
--- a/arm/services/maintenance.py
+++ b/arm/services/maintenance.py
@@ -110,7 +110,11 @@ def get_orphan_folders() -> dict[str, Any]:
             if subdir.is_dir():
                 _scan_dir(subdir, "completed")
 
-    return {"total_size_bytes": total_size, "folders": orphans}
+    return {
+        "roots": [str(raw_path), str(completed_path)],
+        "total_size_bytes": total_size,
+        "folders": orphans,
+    }
 
 
 def get_counts() -> dict[str, int]:
@@ -156,7 +160,7 @@ def delete_log(path_str: str) -> dict[str, Any]:
 
     try:
         resolved.unlink()
-        return {"success": True, "path": path_str}
+        return {"success": True, "path": path_str, "error": None}
     except OSError as exc:
         log.error("Failed to delete log %s: %s", path_str, exc)
         return {"success": False, "path": path_str, "error": "Failed to delete file"}
@@ -183,14 +187,14 @@ def delete_folder(path_str: str) -> dict[str, Any]:
 
     try:
         shutil.rmtree(resolved)
-        return {"success": True, "path": path_str}
+        return {"success": True, "path": path_str, "error": None}
     except OSError as exc:
         log.error("Failed to delete folder %s: %s", path_str, exc)
         return {"success": False, "path": path_str, "error": "Failed to delete directory"}
 
 
 def bulk_delete_logs(paths: list[str]) -> dict[str, Any]:
-    """Delete multiple log files. Best-effort — continues on failures."""
+    """Delete multiple log files. Best-effort - continues on failures."""
     removed = []
     errors = []
     for p in paths:
@@ -199,11 +203,11 @@ def bulk_delete_logs(paths: list[str]) -> dict[str, Any]:
             removed.append(p)
         else:
             errors.append(f"{Path(p).name}: {result.get('error', 'unknown')}")
-    return {"removed": removed, "errors": errors}
+    return {"success": not errors, "removed": removed, "errors": errors}
 
 
 def bulk_delete_folders(paths: list[str]) -> dict[str, Any]:
-    """Delete multiple folders. Best-effort — continues on failures."""
+    """Delete multiple folders. Best-effort - continues on failures."""
     removed = []
     errors = []
     for p in paths:
@@ -212,7 +216,7 @@ def bulk_delete_folders(paths: list[str]) -> dict[str, Any]:
             removed.append(p)
         else:
             errors.append(f"{Path(p).name}: {result.get('error', 'unknown')}")
-    return {"removed": removed, "errors": errors}
+    return {"success": not errors, "removed": removed, "errors": errors}
 
 
 def clear_raw_directories() -> dict[str, Any]:
@@ -223,7 +227,14 @@ def clear_raw_directories() -> dict[str, Any]:
     """
     raw_path = Path(cfg.arm_config.get("RAW_PATH", ""))
     if not raw_path.is_dir():
-        return {"success": False, "error": "RAW_PATH not configured or does not exist"}
+        return {
+            "success": False,
+            "cleared": 0,
+            "freed_bytes": 0,
+            "errors": [],
+            "path": str(raw_path),
+            "error": "RAW_PATH not configured or does not exist",
+        }
 
     cleared = 0
     freed_bytes = 0
@@ -250,4 +261,5 @@ def clear_raw_directories() -> dict[str, Any]:
         "freed_bytes": freed_bytes,
         "errors": errors,
         "path": str(raw_path),
+        "error": None,
     }

--- a/test/test_maintenance_api.py
+++ b/test/test_maintenance_api.py
@@ -57,6 +57,7 @@ class TestOrphanEndpoints:
         data = resp.json()
         names = [f["name"] for f in data["folders"]]
         assert "Orphan Movie" in names
+        assert data["roots"] == [tmp_media["raw"], tmp_media["completed"]]
 
 
 class TestDeleteEndpoints:
@@ -65,7 +66,9 @@ class TestDeleteEndpoints:
         with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
             resp = maint_client.post("/api/v1/maintenance/delete-log", json={"path": "orphan1.log"})
         assert resp.status_code == 200
-        assert resp.json()["success"] is True
+        body = resp.json()
+        assert body["success"] is True
+        assert body["error"] is None
         assert not target.exists()
 
     def test_delete_log_traversal_rejected(self, app_context, tmp_logs, tmp_path, maint_client):
@@ -90,7 +93,9 @@ class TestDeleteEndpoints:
         with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
             resp = maint_client.post("/api/v1/maintenance/delete-folder", json={"path": "Orphan Movie"})
         assert resp.status_code == 200
-        assert resp.json()["success"] is True
+        body = resp.json()
+        assert body["success"] is True
+        assert body["error"] is None
 
     def test_bulk_delete_logs(self, app_context, tmp_logs, maint_client):
         paths = ["orphan1.log", "orphan2.log", "nonexistent.log"]
@@ -98,5 +103,17 @@ class TestDeleteEndpoints:
             resp = maint_client.post("/api/v1/maintenance/bulk-delete-logs", json={"paths": paths})
         assert resp.status_code == 200
         data = resp.json()
+        assert data["success"] is False  # mixed: 2 removed, 1 error
         assert len(data["removed"]) == 2
         assert len(data["errors"]) == 1
+
+    def test_bulk_delete_logs_all_success(self, app_context, tmp_logs, maint_client):
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            resp = maint_client.post(
+                "/api/v1/maintenance/bulk-delete-logs",
+                json={"paths": ["orphan1.log", "orphan2.log"]},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["errors"] == []

--- a/test/test_maintenance_service.py
+++ b/test/test_maintenance_service.py
@@ -77,6 +77,18 @@ class TestOrphanFolderDetection:
         assert categories.get("Orphan Movie") == "raw"
         assert categories.get("Another Orphan") == "completed"
 
+    def test_returns_roots(self, app_context, sample_job, tmp_media):
+        """Result includes both scanned roots for parity with orphan-logs."""
+        mock_cfg = {
+            "RAW_PATH": tmp_media["raw"],
+            "COMPLETED_PATH": tmp_media["completed"],
+        }
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            from arm.services.maintenance import get_orphan_folders
+            result = get_orphan_folders()
+
+        assert result["roots"] == [tmp_media["raw"], tmp_media["completed"]]
+
     def test_computes_folder_sizes(self, app_context, sample_job, tmp_media):
         mock_cfg = {
             "RAW_PATH": tmp_media["raw"],
@@ -109,6 +121,78 @@ class TestMaintenanceCounts:
         assert result["orphan_folders"] >= 2  # Orphan Movie + Another Orphan
 
 
+class TestDeleteShapeInvariants:
+    """Wire shapes for delete_log/delete_folder must be invariant across success/failure."""
+
+    def test_delete_log_success_includes_error_none(self, app_context, tmp_logs):
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            from arm.services.maintenance import delete_log
+            result = delete_log("orphan1.log")
+
+        assert result["success"] is True
+        assert result["path"] == "orphan1.log"
+        assert result["error"] is None
+        assert set(result.keys()) == {"success", "path", "error"}
+
+    def test_delete_log_failure_keys_match(self, app_context, tmp_logs):
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            from arm.services.maintenance import delete_log
+            result = delete_log("does-not-exist.log")
+
+        assert result["success"] is False
+        assert isinstance(result["error"], str)
+        assert set(result.keys()) == {"success", "path", "error"}
+
+    def test_delete_folder_success_includes_error_none(self, app_context, tmp_media):
+        mock_cfg = {
+            "RAW_PATH": tmp_media["raw"],
+            "COMPLETED_PATH": tmp_media["completed"],
+        }
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            from arm.services.maintenance import delete_folder
+            result = delete_folder("Orphan Movie")
+
+        assert result["success"] is True
+        assert result["error"] is None
+        assert set(result.keys()) == {"success", "path", "error"}
+
+
+class TestBulkDeleteShapeInvariants:
+    """Bulk endpoints carry success: bool for sibling consistency."""
+
+    def test_bulk_delete_logs_all_success(self, app_context, tmp_logs):
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            from arm.services.maintenance import bulk_delete_logs
+            result = bulk_delete_logs(["orphan1.log", "orphan2.log"])
+
+        assert result["success"] is True
+        assert result["removed"] == ["orphan1.log", "orphan2.log"]
+        assert result["errors"] == []
+        assert set(result.keys()) == {"success", "removed", "errors"}
+
+    def test_bulk_delete_logs_partial_failure(self, app_context, tmp_logs):
+        with unittest.mock.patch("arm.config.config.arm_config", {"LOGPATH": str(tmp_logs)}):
+            from arm.services.maintenance import bulk_delete_logs
+            result = bulk_delete_logs(["orphan1.log", "missing.log"])
+
+        assert result["success"] is False
+        assert result["removed"] == ["orphan1.log"]
+        assert len(result["errors"]) == 1
+
+    def test_bulk_delete_folders_all_success(self, app_context, tmp_media):
+        mock_cfg = {
+            "RAW_PATH": tmp_media["raw"],
+            "COMPLETED_PATH": tmp_media["completed"],
+        }
+        with unittest.mock.patch("arm.config.config.arm_config", mock_cfg):
+            from arm.services.maintenance import bulk_delete_folders
+            result = bulk_delete_folders(["Orphan Movie"])
+
+        assert result["success"] is True
+        assert "Orphan Movie" in result["removed"]
+        assert result["errors"] == []
+
+
 class TestClearRawDirectories:
     def test_clears_files_and_dirs(self, tmp_path):
         """Should remove all contents of RAW_PATH and report counts."""
@@ -128,6 +212,8 @@ class TestClearRawDirectories:
         assert result["cleared"] == 3  # 2 files + 1 dir
         assert result["freed_bytes"] == 3500
         assert result["path"] == str(raw)
+        assert result["errors"] == []
+        assert result["error"] is None
         # Directory itself still exists, but empty
         assert raw.is_dir()
         assert list(raw.iterdir()) == []
@@ -146,10 +232,16 @@ class TestClearRawDirectories:
         assert result["freed_bytes"] == 0
 
     def test_missing_raw_path_fails(self):
-        """Non-existent RAW_PATH should return error."""
+        """Non-existent RAW_PATH should return error - with full-shape invariant."""
         with unittest.mock.patch("arm.config.config.arm_config", {"RAW_PATH": "/nonexistent/path"}):
             from arm.services.maintenance import clear_raw_directories
             result = clear_raw_directories()
 
         assert result["success"] is False
         assert "not configured" in result["error"]
+        # Failure path emits the full success-shape with zero defaults
+        assert result["cleared"] == 0
+        assert result["freed_bytes"] == 0
+        assert result["errors"] == []
+        assert result["path"] == "/nonexistent/path"
+        assert set(result.keys()) == {"success", "cleared", "freed_bytes", "errors", "path", "error"}


### PR DESCRIPTION
## Summary

Polish 6 maintenance endpoint shapes flagged during the arm-ui BFF type-codegen sweep (arm-ui PR #284). Goal: consistency across success/failure paths so typed consumers don't need branch logic.

## Changes

- `bulk_delete_logs` / `bulk_delete_folders`: add `success: bool` (= `not errors`) for parity with `delete_log` / `delete_folder`
- `delete_log` / `delete_folder`: always include `error: str | None` on success (None) so wire shape matches failure path
- `clear_raw_directories` failure path: emit full success-shape with zero defaults plus `error`, instead of bare `{success, error}`
- `get_orphan_folders`: add `roots: list[str]` for symmetry with orphan-logs (which carries `root`); since folders scan two roots (RAW + COMPLETED), emit both

## Wire-shape impact

Additive only - new keys, no removals or renames. No consumer breakage:
- arm-ui hand-typed shapes (`OrphanLogsResponse`, `OrphanFoldersResponse`, `BulkDeleteResult`) already tolerate extra fields
- The follow-up arm-ui PR will tighten BFF maintenance models to mirror these shapes for codegen

## Test plan

- [x] 26/26 maintenance tests pass (existing + new invariant assertions)
- [x] 2150/2150 full backend suite passes
- [ ] Manual: verify orphan-folders endpoint includes new \`roots\` field
- [ ] Manual: verify bulk-delete returns \`success: true\` on all-success and \`success: false\` on partial-failure