### PR TITLE
fix(setup): unwrap alembic Row in db_version

### DIFF
--- a/arm/api/v1/setup.py
+++ b/arm/api/v1/setup.py
@@ -25,6 +25,21 @@ def _read_version() -> str:
     return "unknown"
 
 
+def _row_version(revision) -> str:
+    """Extract the version string from an alembic revision row, or 'unknown'.
+
+    arm_db_check() puts an alembic Row (from arm_db_get) into ``db_revision``.
+    The Row carries a ``version_num`` column; when serialized directly to
+    JSON it becomes ``{}``, which fails the BFF's typed setup contract.
+    """
+    if revision is None:
+        return "unknown"
+    version = getattr(revision, "version_num", None)
+    if isinstance(version, str) and version:
+        return version
+    return "unknown"
+
+
 @router.get("/setup/status")
 def get_setup_status():
     """Return setup state for the wizard.
@@ -74,8 +89,8 @@ def get_setup_status():
         "db_exists": db_status.get("db_exists", False),
         "db_initialized": db_initialized,
         "db_current": db_initialized,
-        "db_version": db_status.get("db_revision", "unknown"),
-        "db_head": db_status.get("head_revision", "unknown"),
+        "db_version": _row_version(db_status.get("db_revision")),
+        "db_head": db_status.get("head_revision") or "unknown",
         "first_run": first_run,
         "arm_version": _read_version(),
         "setup_steps": {

--- a/test/test_setup_api.py
+++ b/test/test_setup_api.py
@@ -76,6 +76,46 @@ class TestSetupStatus:
         data = response.json()
         assert isinstance(data['arm_version'], str)
 
+    def test_db_version_is_string_when_revision_present(self, client):
+        """db_version must always serialize as a string.
+
+        arm_db_check() returns the alembic Row in db_revision; that row
+        carries a .version_num column. Without unwrapping, JSON serializes
+        it as `{}` and breaks the BFF's typed setup contract.
+        """
+        fake_row = MagicMock()
+        fake_row.version_num = "abc123def456"
+        with patch(
+            'arm.api.v1.setup.arm_db_check',
+            return_value={
+                'db_exists': True,
+                'db_current': True,
+                'db_revision': fake_row,
+                'head_revision': 'abc123def456',
+            },
+        ):
+            response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert data['db_version'] == 'abc123def456'
+        assert isinstance(data['db_version'], str)
+        assert data['db_head'] == 'abc123def456'
+
+    def test_db_version_unknown_when_revision_missing(self, client):
+        """When db_revision is None, db_version returns the literal 'unknown'."""
+        with patch(
+            'arm.api.v1.setup.arm_db_check',
+            return_value={
+                'db_exists': False,
+                'db_current': False,
+                'db_revision': None,
+                'head_revision': None,
+            },
+        ):
+            response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert data['db_version'] == 'unknown'
+        assert data['db_head'] == 'unknown'
+
 
 class TestSetupComplete:
     """Test POST /api/v1/setup/complete endpoint."""


### PR DESCRIPTION
## Summary

\`/api/v1/setup/status\` was emitting \`db_version: {}\` because \`arm_db_check()\` returns the alembic revision Row (not a version string). JSON serialization dropped the Row to an empty dict, which the arm-ui BFF's typed SetupStatus model correctly rejected with a 500.

Surfaced live during 2026-05-04 hifi smoke after deploying 17.5.0-rc + 17.4.0-rc - arm-ui BFF logs showed:

\`\`\`
fastapi.exceptions.ResponseValidationError: 1 validation error:
  {'type': 'string_type', 'loc': ('response', 'db_version'),
   'msg': 'Input should be a valid string', 'input': {}}
\`\`\`

This is a real upstream bug, not a regression - the strict response_model in arm-ui PR #284 simply made it visible. Pre-codegen the BFF accepted the bogus value silently.

## Changes

- \`_row_version()\` helper extracts \`.version_num\` from a Row, falls back to \`'unknown'\` when None or missing the attribute
- \`db_head\` similarly hardened with \`or 'unknown'\` so a None head doesn't silently emit None

## Tests

- 2152/2152 backend pass (up 2 with the new contract tests)
- New: test_db_version_is_string_when_revision_present
- New: test_db_version_unknown_when_revision_missing

## Test plan

- [x] Local pytest green
- [ ] Deploy fresh RC to hifi-server, verify \`/api/setup/status\` returns 200 with \`db_version: \"<alembic SHA>\"\`
- [ ] Verify arm-ui BFF \`/api/setup/status\` no longer 500s