### PR TITLE
fix(setup): exclude stale rows from drive_count

### DIFF
--- a/arm/api/v1/setup.py
+++ b/arm/api/v1/setup.py
@@ -81,7 +81,11 @@ def get_setup_status():
 
     try:
         from arm.models.system_drives import SystemDrives
-        drive_count = SystemDrives.query.count()
+        # stale=True rows are old detections kept for audit history; the
+        # wizard count should reflect drives currently attached.
+        drive_count = SystemDrives.query.filter(
+            (SystemDrives.stale.is_(False)) | (SystemDrives.stale.is_(None))
+        ).count()
     except Exception:
         pass
 

--- a/test/test_setup_api.py
+++ b/test/test_setup_api.py
@@ -56,6 +56,54 @@ class TestSetupStatus:
         data = response.json()
         assert 'detected' in data['setup_steps']['drives']
 
+    def test_drives_count_excludes_stale(self, client):
+        """Stale SystemDrives rows must not inflate the wizard drive count.
+
+        After hot-plug events the cleanup pass marks vanished drives with
+        stale=True but keeps the row for audit history. The wizard count
+        should reflect attached drives, not historical ones.
+        """
+        from arm.database import db
+        from arm.models.system_drives import SystemDrives
+
+        active = SystemDrives()
+        active.name = 'Active'
+        active.mount = '/dev/sr0'
+        active.stale = False
+
+        ghost = SystemDrives()
+        ghost.name = 'Ghost'
+        ghost.mount = ''
+        ghost.stale = True
+
+        db.session.add_all([active, ghost])
+        db.session.commit()
+
+        response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert data['setup_steps']['drives'] == '1 detected'
+
+    def test_drives_count_includes_legacy_null_stale(self, client):
+        """Legacy rows pre-dating the stale column have stale=NULL.
+
+        Those should be counted as attached, not silently dropped, since
+        stale was added later and existing drives never had it written.
+        """
+        from arm.database import db
+        from arm.models.system_drives import SystemDrives
+
+        legacy = SystemDrives()
+        legacy.name = 'Legacy'
+        legacy.mount = '/dev/sr1'
+        legacy.stale = None
+
+        db.session.add(legacy)
+        db.session.commit()
+
+        response = client.get('/api/v1/setup/status')
+        data = response.json()
+        assert data['setup_steps']['drives'] == '1 detected'
+
     def test_first_run_false_after_complete(self, client):
         """After completing setup, first_run should be False."""
         client.post('/api/v1/setup/complete')


### PR DESCRIPTION
## Summary

The setup wizard's \`setup_steps.drives: \"N detected\"\` count was reading \`SystemDrives.query.count()\`, which includes stale rows. After a hot-plug event \`_cleanup_stale_drives()\` marks the vanished drive \`stale=True\` and keeps the row for audit history - inflating the wizard count.

## Surfaced

2026-05-04 hifi smoke after deploying 17.5.1: setup endpoint reported \"2 detected\" but \`/api/v1/drives\` returned only 1. The extra row was a ghost from a previously attached drive.

## Changes

\`arm/api/v1/setup.py:84\` filter now excludes \`stale=True\` rows. \`stale=NULL\` legacy rows remain counted - silently dropping them would hide pre-existing drives whose stale field was never populated.

## Tests

- \`test_drives_count_excludes_stale\` - asserts the stale=True filter
- \`test_drives_count_includes_legacy_null_stale\` - asserts NULL fallback

2154/2154 backend pass (up 2 from new tests).

## Test plan

- [x] Local pytest green
- [ ] Deploy fresh RC to hifi-server, verify \`/api/setup/status\` reports \"1 detected\" (matches \`/api/v1/drives\` count)