### PR TITLE
fix(jobs): include track_counts in /jobs/paginated response

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -242,8 +242,17 @@ def get_jobs_paginated(
     jobs = query.offset((page - 1) * per_page).limit(per_page).all()
     pages = max(1, math.ceil(total / per_page)) if total else 1
 
+    job_dicts = []
+    for j in jobs:
+        d = _job_to_dict(j)
+        # Surface rippable-subset counts so the list UI can render
+        # "ripped/total" without a per-row roundtrip. Matches the shape
+        # /jobs/active and /jobs/{id}/detail emit.
+        d["track_counts"] = svc_jobs.track_counts(j)
+        job_dicts.append(d)
+
     return {
-        "jobs": [_job_to_dict(j) for j in jobs],
+        "jobs": job_dicts,
         "total": total,
         "page": page,
         "per_page": per_page,

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -2982,6 +2982,40 @@ class TestApiJobsPaginated:
         assert len(data["jobs"]) == 1
         assert data["jobs"][0]["title"] == "SERIAL_MOM"
 
+    def test_paginated_includes_track_counts(self, client, sample_job, app_context):
+        """Each job in the list carries track_counts so the UI can render
+        ripped/total without a per-row roundtrip."""
+        from arm.database import db
+        from arm.models.track import Track
+        # 3 tracks: 1 ripped, 1 enabled (rippable), 1 disabled
+        t1 = Track(job_id=sample_job.job_id, track_number="0", length=3600,
+                   aspect_ratio="16:9", fps=23.976, main_feature=True,
+                   source="MakeMKV", basename="t1.mkv", filename="t1.mkv",
+                   chapters=20, filesize=10000000)
+        t1.enabled = True
+        t1.ripped = True
+        t2 = Track(job_id=sample_job.job_id, track_number="1", length=3600,
+                   aspect_ratio="16:9", fps=23.976, main_feature=False,
+                   source="MakeMKV", basename="t2.mkv", filename="t2.mkv",
+                   chapters=10, filesize=5000000)
+        t2.enabled = True
+        t2.ripped = False
+        t3 = Track(job_id=sample_job.job_id, track_number="2", length=3600,
+                   aspect_ratio="16:9", fps=23.976, main_feature=False,
+                   source="MakeMKV", basename="t3.mkv", filename="t3.mkv",
+                   chapters=5, filesize=1000000)
+        t3.enabled = False
+        t3.ripped = False
+        db.session.add_all([t1, t2, t3])
+        db.session.commit()
+
+        response = client.get('/api/v1/jobs/paginated')
+        data = response.json()
+        job = data["jobs"][0]
+        assert "track_counts" in job
+        assert job["track_counts"]["total"] == 2  # rippable subset
+        assert job["track_counts"]["ripped"] == 1
+
     def test_filter_by_status(self, client, sample_job, app_context):
         response = client.get('/api/v1/jobs/paginated?status=active')
         assert response.status_code == 200


### PR DESCRIPTION
## Summary

\`/api/v1/jobs/paginated\` was emitting Job rows without \`track_counts\`, so the UI's JobCard fell through to \`job.no_of_titles\` (raw MakeMKV disc title count) and displayed \"{N} titles\".

On a disc where only 2 of 7 titles are rippable (the other 5 makemkv-skipped), this rendered as **\"7 titles\"** - misleading since only 2 are actually being ripped.

## Surfaced

2026-05-04 hifi smoke watching job 190 (7 titles detected, 2 rippable). Frontend showed \"7 titles\" instead of the actual rippable count.

## Changes

\`/jobs/paginated\` now mirrors \`/jobs/active\` and \`/jobs/{id}/detail\` by attaching \`{total, ripped}\` from \`svc_jobs.track_counts()\` per row. The UI already prefers this branch over \`no_of_titles\` in \`JobCard.svelte:75\`:

\`\`\`svelte
{:else if job.track_counts && (job.track_counts.total ?? 0) > 0}
    <span>{job.track_counts.ripped ?? 0} / {job.track_counts.total ?? 0} titles</span>
{:else if job.no_of_titles != null}
    <span>{job.no_of_titles} title{...}</span>
\`\`\`

## Tests

- \`test_paginated_includes_track_counts\` asserts both keys are present and the rippable subset is computed correctly (excluding disabled tracks)
- 2155/2155 backend pass (up 1)

## Test plan

- [x] Local pytest green
- [ ] Deploy fresh RC to hifi-server, verify Jobs list shows \"X / Y titles\" instead of bare \"N titles\"