### PR TITLE
fix(system/restart): graceful shutdown via background SIGTERM

### DIFF
--- a/arm/api/v1/system.py
+++ b/arm/api/v1/system.py
@@ -6,7 +6,7 @@ import subprocess
 import psutil
 from alembic.config import Config
 from alembic.script import ScriptDirectory
-from fastapi import APIRouter
+from fastapi import APIRouter, BackgroundTasks
 from fastapi.responses import JSONResponse
 from sqlalchemy import create_engine, inspect, text
 
@@ -41,9 +41,13 @@ def get_system_info():
 
 
 @router.post('/system/restart')
-def restart():
-    """Restart the ARM UI service."""
-    return svc_jobs.restart_ui()
+def restart(background_tasks: BackgroundTasks):
+    """Restart the ARM ripping service.
+
+    Schedules SIGTERM on this process as a background task so the response
+    flushes first. Docker's restart policy brings the container back."""
+    background_tasks.add_task(svc_jobs.schedule_self_shutdown)
+    return {"success": True, "message": "ARM ripping service is restarting"}
 
 
 @router.get('/system/stats')

--- a/arm/services/jobs.py
+++ b/arm/services/jobs.py
@@ -4,9 +4,11 @@ Job management services — extracted from arm/ui/json_api.py.
 All app.logger calls replaced with standard logging.
 """
 import os
+import signal
 import subprocess
 import re
 import html
+import time
 from pathlib import Path
 import datetime
 import logging
@@ -496,12 +498,12 @@ def get_notify_timeout(notify_timeout):
     return return_json
 
 
-def restart_ui():
-    log.debug("Arm ui shutdown....")
-    shutdown_code = subprocess.check_output(
-        "pkill python3",
-        shell=True
-    ).decode("utf-8")
-    log.debug(f"Arm ui shutdown ran into a problem... exit code: {shutdown_code}")
-    return_json = {'success': False, 'error': f"Shutting down A.R.M UI....exit code: {shutdown_code}"}
-    return return_json
+def schedule_self_shutdown(delay_seconds: float = 0.5) -> None:
+    """Send our own process SIGTERM after a short delay so the in-flight HTTP
+    response has time to flush. Docker's restart policy brings us back."""
+    log.info("Restart requested - scheduling self-SIGTERM in %ss", delay_seconds)
+    time.sleep(delay_seconds)
+    try:
+        os.kill(os.getpid(), signal.SIGTERM)
+    except OSError:
+        log.exception("Failed to signal self for restart")

--- a/test/test_services.py
+++ b/test/test_services.py
@@ -1040,18 +1040,37 @@ class TestSearchConfigNotFound:
         assert first["config"] == "config not found"
 
 
-class TestRestartUi:
-    """Test restart_ui."""
+class TestScheduleSelfShutdown:
+    """Test schedule_self_shutdown.
 
-    def test_restart_returns_json(self):
-        from arm.services.jobs import restart_ui
+    The previous restart_ui() ran pkill python3 inline inside the request
+    handler, which killed the API server before the HTTP response could be
+    flushed and always returned success=False. The replacement is a
+    background-safe SIGTERM-self that lets the response flush first."""
 
-        with patch("arm.services.jobs.subprocess.check_output",
-                   return_value=b"0"):
-            result = restart_ui()
+    def test_schedules_sigterm_after_delay(self):
+        from arm.services.jobs import schedule_self_shutdown
 
-        assert result["success"] is False  # always returns False
-        assert "Shutting down" in result["error"]
+        with patch("arm.services.jobs.os.kill") as mock_kill, \
+             patch("arm.services.jobs.time.sleep") as mock_sleep:
+            schedule_self_shutdown(delay_seconds=0.25)
+
+        mock_sleep.assert_called_once_with(0.25)
+        assert mock_kill.call_count == 1
+        # signaled this PID with SIGTERM
+        args, _ = mock_kill.call_args
+        assert args[0] == os.getpid()
+        import signal as _signal
+        assert args[1] == _signal.SIGTERM
+
+    def test_swallows_oserror_from_kill(self):
+        """If os.kill raises (e.g. permissions), we log and don't bubble up."""
+        from arm.services.jobs import schedule_self_shutdown
+
+        with patch("arm.services.jobs.os.kill", side_effect=OSError("nope")), \
+             patch("arm.services.jobs.time.sleep"):
+            # Must not raise
+            schedule_self_shutdown(delay_seconds=0)
 
 
 class TestGenerateLogEncoding:


### PR DESCRIPTION
## Summary

The Settings -> Restart ARM Ripping Service button never works from the user's perspective: even when the container does come back, the toast always says "Failed to restart ARM ripping service".

Root cause - \`arm/services/jobs.py:restart_ui()\` did:

\`\`\`python
def restart_ui():
    log.debug("Arm ui shutdown....")
    shutdown_code = subprocess.check_output("pkill python3", shell=True).decode("utf-8")
    log.debug(f"Arm ui shutdown ran into a problem... exit code: {shutdown_code}")
    return_json = {'success': False, 'error': f"Shutting down A.R.M UI....exit code: {shutdown_code}"}
    return return_json
\`\`\`

Three problems:

1. \`pkill python3\` runs **synchronously inside the FastAPI request handler**, killing uvicorn before it can flush the response. The browser sees a connection-reset error and the BFF surfaces \`Failed to restart\` even when the supervisor respawns the server cleanly.
2. The return body **hardcodes \`success: False\`**.
3. The handler is named \`restart_ui()\` and described as "Restart the ARM UI service", but \`arm-ui\` is a separate container and this handler restarts the ARM ripping service. Comment-rot from the Flask era.

## Fix

Use the FastAPI \`BackgroundTasks\` pattern (same approach the transcoder service uses for its own \`/system/restart\`):

\`\`\`python
@router.post('/system/restart')
def restart(background_tasks: BackgroundTasks):
    background_tasks.add_task(svc_jobs.schedule_self_shutdown)
    return {"success": True, "message": "ARM ripping service is restarting"}
\`\`\`

\`schedule_self_shutdown\` sleeps briefly (so the response flushes), then sends SIGTERM to the current PID. Phusion baseimage's runit supervisor respawns uvicorn cleanly. The container itself stays up.

## Local verification

\`\`\`
$ curl -X POST http://localhost:8080/api/v1/system/restart
HTTP 200
{"success":true,"message":"ARM ripping service is restarting"}

# arm-rippers logs
INFO:     172.19.0.1:54184 - "POST /api/v1/system/restart HTTP/1.1" 200 OK
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Started server process [276]   # fresh PID after runit respawn

# API recovers in ~2 seconds
+1 s | api=000  (process gone)
+2 s | api=200  (back up)
\`\`\`

## Test plan

- [x] Replaced \`TestRestartUi\` (which asserted \`success is False\` - encoded the bug) with \`TestScheduleSelfShutdown\` covering the new behavior + OSError swallowing
- [x] All 2156 tests pass
- [x] Local smoke: POSTed against arm-rippers and watched the response flush, the in-container API restart, and recovery