### PR TITLE
fix(prescan): skip mdisc resolution for ISO imports

### DIFF
--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -1151,8 +1151,10 @@ def prescan_track_info(job, timeout=300, cache_mb=1, enum_timeout=60):
     db.session.flush()
 
     # Resolve disc index for later rip phase (best-effort, non-critical)
-    # Skip for folder imports - no physical drive to resolve
-    if not getattr(job, 'is_folder_import', False):
+    # Skip for folder + ISO imports - no physical drive to resolve, and
+    # disc:9999 enumeration would warn "did not return drive for None"
+    # then waste ~10s on a second makemkvcon info pass.
+    if not getattr(job, 'is_folder_import', False) and not getattr(job, 'is_iso_import', False):
         try:
             prescan_resolve_mdisc(job, timeout=enum_timeout)
         except Exception as exc:

--- a/test/test_folder_scan.py
+++ b/test/test_folder_scan.py
@@ -321,6 +321,27 @@ class TestPrescanFolderGuard:
 
         job = MagicMock()
         job.is_folder_import = True
+        job.is_iso_import = False
+        job.job_id = 99
+
+        mock_track_cls = MagicMock()
+        mock_track_cls.query.filter_by.return_value.delete.return_value = 0
+
+        with patch("arm.ripper.makemkv.prescan_resolve_mdisc") as mock_mdisc, \
+             patch("arm.ripper.makemkv.prescan_disc_info", return_value=iter([])), \
+             patch("arm.ripper.makemkv.TrackInfoProcessor"), \
+             patch("arm.models.track.Track", mock_track_cls), \
+             patch("arm.ripper.makemkv.db"):
+            from arm.ripper.makemkv import prescan_track_info
+            prescan_track_info(job)
+            mock_mdisc.assert_not_called()
+
+    def test_prescan_skips_mdisc_for_iso_job(self):
+        from unittest.mock import MagicMock, patch
+
+        job = MagicMock()
+        job.is_folder_import = False
+        job.is_iso_import = True
         job.job_id = 99
 
         mock_track_cls = MagicMock()
@@ -340,6 +361,7 @@ class TestPrescanFolderGuard:
 
         job = MagicMock()
         job.is_folder_import = False
+        job.is_iso_import = False
         job.job_id = 99
 
         mock_track_cls = MagicMock()


### PR DESCRIPTION
## Summary
- ISO imports were triggering `prescan_resolve_mdisc` (which runs `makemkvcon info disc:9999` to enumerate physical drives), wasting ~10s and emitting a misleading `disc:9999 did not return drive for None` warning on every ISO prescan
- Extend the existing folder-import guard to also skip ISO imports
- Add parallel skip-test for ISO + harden both existing folder/disc tests by setting `is_iso_import` explicitly so they don't silently rely on MagicMock attribute defaults

## Why
ISO jobs have `devpath=None` (no physical drive), so `disc:9999` enumeration can never match. The prescan title scan uses `iso:{path}` directly via `job.makemkv_source` and doesn't need an mdisc index.

Spotted on hifi job 196:
```
warning  disc:9999 did not return drive for None
info     MakeMKV info exits.
info     Found 37 titles
info     Auto-disabled 34 tracks shorter than 600s
info     Prescan complete for job 196 - 37 tracks found, waiting for review
```

## Test plan
- [x] `pytest test/test_folder_scan.py::TestPrescanFolderGuard -v` - 3 passed (folder skip, iso skip, disc still resolves)
- [x] `pytest test/test_folder_scan.py test/test_prescan.py -q` - 44 passed