### PR TITLE
fix(iso): spawn rip thread when starting ISO job from review

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -35,6 +35,7 @@ from arm.models.job import Job, JobState
 from arm.models.track import Track
 from arm.models.notifications import Notifications
 from arm.ripper.folder_ripper import rip_folder
+from arm.ripper.iso_ripper import rip_iso
 from arm.services import jobs as svc_jobs
 from arm.services import files as svc_files
 from arm.services import progress_reader
@@ -54,6 +55,20 @@ def _rip_folder_by_id(job_id: int):
             logging.error("rip_folder thread: job %s not found", job_id)
             return
         rip_folder(job)
+    finally:
+        db.session.remove()
+
+
+def _rip_iso_by_id(job_id: int):
+    """Re-query job by ID in the thread's own session, then run rip_iso."""
+    import logging
+    db.session.commit_timeout = 90
+    try:
+        job = Job.query.get(job_id)
+        if not job:
+            logging.error("rip_iso thread: job %s not found", job_id)
+            return
+        rip_iso(job)
     finally:
         db.session.remove()
 
@@ -316,14 +331,19 @@ def start_waiting_job(job_id: int):
     if job.status != JobState.MANUAL_PAUSED.value:
         return JSONResponse({"success": False, "error": _NOT_WAITING}, status_code=409)
 
-    if job.source_type == SourceType.folder.value:
-        # Folder jobs: launch rip_folder in a background thread.
-        # Pass job_id, not the ORM object — the thread has its own session
-        # scope and the original object would be detached.
+    if job.source_type in (SourceType.folder.value, SourceType.iso.value):
+        # Import jobs (folder + ISO) have no running ripper thread - the
+        # prescan ran synchronously and parked the job in MANUAL_PAUSED.
+        # Spawn a fresh thread to drive the rip phase. Pass job_id, not
+        # the ORM object — the thread has its own session scope and the
+        # original object would be detached.
         job.status = JobState.VIDEO_RIPPING.value
         db.session.commit()
         job_id = job.job_id
-        thread = threading.Thread(target=_rip_folder_by_id, args=(job_id,), daemon=True)
+        target = (
+            _rip_iso_by_id if job.source_type == SourceType.iso.value else _rip_folder_by_id
+        )
+        thread = threading.Thread(target=target, args=(job_id,), daemon=True)
         thread.start()
         return {"success": True, "job_id": job_id, "status": job.status}
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1982,6 +1982,35 @@ class TestApiJobStart:
         assert response.status_code == 200
         assert response.json()["success"] is True
 
+    def test_start_waiting_folder_job_spawns_folder_thread(self, client, sample_job, app_context):
+        from arm.ripper.utils import database_updater
+        database_updater(
+            {"status": "manual_paused", "source_type": "folder", "source_path": "/tmp/x"},
+            sample_job,
+        )
+        with unittest.mock.patch("arm.api.v1.jobs.threading.Thread") as mock_thread:
+            response = client.post(f'/api/v1/jobs/{sample_job.job_id}/start')
+        assert response.status_code == 200
+        assert response.json()["status"] == "video_ripping"
+        # Verify it dispatched to the folder helper, not the ISO helper.
+        from arm.api.v1 import jobs as jobs_module
+        kwargs = mock_thread.call_args.kwargs
+        assert kwargs["target"] is jobs_module._rip_folder_by_id
+
+    def test_start_waiting_iso_job_spawns_iso_thread(self, client, sample_job, app_context):
+        from arm.ripper.utils import database_updater
+        database_updater(
+            {"status": "manual_paused", "source_type": "iso", "source_path": "/tmp/x.iso"},
+            sample_job,
+        )
+        with unittest.mock.patch("arm.api.v1.jobs.threading.Thread") as mock_thread:
+            response = client.post(f'/api/v1/jobs/{sample_job.job_id}/start')
+        assert response.status_code == 200
+        assert response.json()["status"] == "video_ripping"
+        from arm.api.v1 import jobs as jobs_module
+        kwargs = mock_thread.call_args.kwargs
+        assert kwargs["target"] is jobs_module._rip_iso_by_id
+
 
 class TestApiJobCancel:
     """Test POST /api/v1/jobs/<id>/cancel endpoint."""

--- a/test/test_async_safety.py
+++ b/test/test_async_safety.py
@@ -162,6 +162,57 @@ class TestRipFolderSessionCleanup:
 
 
 # =====================================================================
+# _rip_iso_by_id - session cleanup (parallel to folder helper)
+# =====================================================================
+
+
+class TestRipIsoSessionCleanup:
+    """Test that _rip_iso_by_id cleans up the DB session."""
+
+    def test_session_removed_on_success(self, app_context, sample_job):
+        """db.session.remove() called after successful rip."""
+        from arm.api.v1.jobs import _rip_iso_by_id
+
+        with unittest.mock.patch("arm.api.v1.jobs.rip_iso") as mock_rip, \
+             unittest.mock.patch("arm.api.v1.jobs.db") as mock_db:
+            mock_db.session.remove = unittest.mock.MagicMock()
+            mock_job = unittest.mock.MagicMock()
+            with unittest.mock.patch("arm.api.v1.jobs.Job") as MockJob:
+                MockJob.query.get.return_value = mock_job
+                _rip_iso_by_id(1)
+
+            mock_rip.assert_called_once_with(mock_job)
+            mock_db.session.remove.assert_called_once()
+
+    def test_session_removed_on_exception(self, app_context):
+        """db.session.remove() called even when rip_iso raises."""
+        from arm.api.v1.jobs import _rip_iso_by_id
+
+        with unittest.mock.patch("arm.api.v1.jobs.rip_iso", side_effect=RuntimeError("boom")), \
+             unittest.mock.patch("arm.api.v1.jobs.db") as mock_db:
+            mock_db.session.remove = unittest.mock.MagicMock()
+            mock_job = unittest.mock.MagicMock()
+            with unittest.mock.patch("arm.api.v1.jobs.Job") as MockJob:
+                MockJob.query.get.return_value = mock_job
+                with pytest.raises(RuntimeError, match="boom"):
+                    _rip_iso_by_id(1)
+
+            mock_db.session.remove.assert_called_once()
+
+    def test_session_removed_when_job_not_found(self, app_context):
+        """db.session.remove() called even when job is not found."""
+        from arm.api.v1.jobs import _rip_iso_by_id
+
+        with unittest.mock.patch("arm.api.v1.jobs.db") as mock_db:
+            mock_db.session.remove = unittest.mock.MagicMock()
+            with unittest.mock.patch("arm.api.v1.jobs.Job") as MockJob:
+                MockJob.query.get.return_value = None
+                _rip_iso_by_id(999)
+
+            mock_db.session.remove.assert_called_once()
+
+
+# =====================================================================
 # _with_session_cleanup - executor thread session safety
 # =====================================================================
 


### PR DESCRIPTION
## Summary
- ISO jobs in MANUAL_PAUSED never started ripping when the user clicked Start in review - the UI bounced them right back to review
- Extend the folder branch in `start_waiting_job` to also handle ISO jobs, spawning `rip_iso` in a fresh thread mirroring `_rip_folder_by_id`
- Adds test coverage for both folder + ISO thread dispatch (and the existing disc path is untouched)

## Why
ISO jobs are created via `/api/v1/jobs/iso` which prescans synchronously then parks the job at `MANUAL_PAUSED`. There is **no running ripper thread**. The /start endpoint had two branches:
- folder: spawn a fresh thread running `rip_folder` 
- everything else: signal `manual_start=True` via database_updater (only watched by an already-running disc rip thread)

ISO jobs hit the second branch, so the flag was set but no thread ever read it. Repro on hifi job 198 (MirrorMask 2005 ISO):
```
04:04:41 Prescan complete for job 198 - 37 tracks found, waiting for review
[click Start]
... no rip activity, job remains in manual_paused, UI returns to review screen
```

## Test plan
- [x] `pytest test/test_api.py::TestApiJobStart -v` - 5 passed (existing 3 + new folder thread test + new iso thread test)
- [ ] Smoke on hifi: start job 198, verify rip_iso thread spawns and job advances to video_ripping