### PR TITLE
fix(drives): silence repeating warning for already-cleaned phantom rows

### DIFF
--- a/arm/services/drives.py
+++ b/arm/services/drives.py
@@ -261,6 +261,17 @@ def _cleanup_stale_drives():
     """Clear stale drives that have no active jobs. Returns count of unavailable drives."""
     stale_count = 0
     for stale_drive in SystemDrives.query.filter_by(stale=True).all():
+        # Already-blanked phantom rows (cleaned in a prior tick) still re-stale
+        # every cycle since drives_update marks every non-processing row stale.
+        # Skip them silently - the audit row is preserved but no log noise.
+        already_cleaned = (
+            not (stale_drive.serial_id or "").strip()
+            and not (stale_drive.mount or "").strip()
+            and not (stale_drive.location or "").strip()
+            and not stale_drive.processing
+        )
+        if already_cleaned:
+            continue
         log.warning("Drive '%s' on '%s' is not available.", stale_drive.serial_id, stale_drive.mount)
         if stale_drive.processing:
             log.warning(f"Drive '{stale_drive.mount}' has an active job and might be blocked.")

--- a/test/test_drives_service.py
+++ b/test/test_drives_service.py
@@ -629,3 +629,33 @@ class TestCleanupStaleDrives:
         db.session.refresh(d)
         # Stale flag should be cleared for active drives
         assert d.stale is False
+
+    def test_skips_already_blanked_phantom(self, app_context, caplog):
+        """A stale row already blanked in a prior tick should be ignored silently.
+
+        Repro: hifi accumulated a SystemDrives row whose serial_id, mount,
+        and location were all empty (cleaned in an earlier cycle). Every
+        subsequent drives_update tick re-marked it stale and re-fired
+        `Drive '' on '' is not available.` indefinitely.
+        """
+        import logging as _logging
+        from arm.services.drives import _cleanup_stale_drives
+        from arm.models import SystemDrives
+        from arm.database import db
+
+        d = SystemDrives()
+        d.mount = ""
+        d.location = ""
+        d.stale = True
+        d.job_id_current = None  # not processing
+        db.session.add(d)
+        db.session.commit()
+
+        with caplog.at_level(_logging.WARNING, logger="arm.services.drives"):
+            count = _cleanup_stale_drives()
+        # Phantom is not counted as a freshly-cleaned drive.
+        assert count == 0
+        # And no warning is emitted for it.
+        assert not any(
+            "is not available" in rec.getMessage() for rec in caplog.records
+        )


### PR DESCRIPTION
## Summary
- `_cleanup_stale_drives` blanks mount/location on a stale non-processing row but leaves the row in place for audit history. The next `drives_update` tick re-marks it stale, and the warning fires again -- forever
- Skip rows where `serial_id`, `mount`, and `location` are all empty AND the row isn't processing. These are phantoms with nothing left to clean
- Pure log-noise reduction; no behavior change for live or processing drives

## Why
Spotted during 17.6.0-rc ISO smoke on hifi:
```
Drive rescan: 2 before, 2 after, 0 removed
1 drives are unavailable.
Drive '' on '' is not available.
Optical drive detected: /dev/sr0
[every ~16s, forever]
```

Pre-existing bug. Hifi has 1 real drive + 1 phantom row from a previously-attached drive whose blanked record was never expunged. The periodic drives_update kept rediscovering it as "stale" and emitting the warning on every cycle. Setup-status drive_count fix from `feature_setup_drive_count_excludes_stale.md` would also benefit from the same row class being detected.

## Test plan
- [x] `pytest test/test_drives_service.py::TestCleanupStaleDrives -v` - 3 passed (existing + new phantom-skip test)