### PR TITLE
fix(import): honor track.process=False on folder + ISO rips

### DIFF
--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -142,6 +142,35 @@ def rip_folder(job):
     kick_off_import_rip(job)
 
 
+def _remove_deselected_track_files(job, rawpath):
+    """Delete output files for tracks where process=False.
+
+    MakeMKV's `all` mode rips every title above its minlength threshold;
+    the user's per-track process=False choice in review must still win.
+    Reconciliation runs first so each output file is matched to a track
+    row, making process==False the authoritative discard signal.
+    """
+    if not os.path.isdir(rawpath):
+        return
+    for track in job.tracks:
+        if track.process is not False or not track.filename:
+            continue
+        fpath = os.path.join(rawpath, track.filename)
+        if not os.path.isfile(fpath):
+            continue
+        try:
+            os.remove(fpath)
+            log.info(
+                "Removed deselected track #%s output: %s",
+                track.track_number, track.filename,
+            )
+        except OSError as exc:
+            log.warning(
+                "Failed to remove deselected track #%s file %s: %s",
+                track.track_number, fpath, exc,
+            )
+
+
 def kick_off_import_rip(job):
     """Shared entry point for folder + ISO imports.
 
@@ -224,27 +253,8 @@ def kick_off_import_rip(job):
         # 7. Reconcile filenames using deterministic title_map.
         _reconcile_filenames(job, rawpath, title_map=title_map)
 
-        # Drop output files for tracks the user (or auto-filter) deselected.
-        # MakeMKV's `all` mode rips every title above its minlength threshold;
-        # the user's per-track process=False choice in review must still win.
-        # Reconciliation runs first so each output file is now matched to a
-        # track row, making "process==False" the authoritative discard signal.
-        if os.path.isdir(rawpath):
-            for track in job.tracks:
-                if track.process is False and track.filename:
-                    fpath = os.path.join(rawpath, track.filename)
-                    if os.path.isfile(fpath):
-                        try:
-                            os.remove(fpath)
-                            log.info(
-                                "Removed deselected track #%s output: %s",
-                                track.track_number, track.filename,
-                            )
-                        except OSError as exc:
-                            log.warning(
-                                "Failed to remove deselected track #%s file %s: %s",
-                                track.track_number, fpath, exc,
-                            )
+        # Drop output files the user (or auto-filter) deselected.
+        _remove_deselected_track_files(job, rawpath)
 
         # Mark tracks as ripped only if their file actually exists on disk
         # (after reconciliation + deselection filter so filenames are correct).

--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -224,8 +224,30 @@ def kick_off_import_rip(job):
         # 7. Reconcile filenames using deterministic title_map.
         _reconcile_filenames(job, rawpath, title_map=title_map)
 
+        # Drop output files for tracks the user (or auto-filter) deselected.
+        # MakeMKV's `all` mode rips every title above its minlength threshold;
+        # the user's per-track process=False choice in review must still win.
+        # Reconciliation runs first so each output file is now matched to a
+        # track row, making "process==False" the authoritative discard signal.
+        if os.path.isdir(rawpath):
+            for track in job.tracks:
+                if track.process is False and track.filename:
+                    fpath = os.path.join(rawpath, track.filename)
+                    if os.path.isfile(fpath):
+                        try:
+                            os.remove(fpath)
+                            log.info(
+                                "Removed deselected track #%s output: %s",
+                                track.track_number, track.filename,
+                            )
+                        except OSError as exc:
+                            log.warning(
+                                "Failed to remove deselected track #%s file %s: %s",
+                                track.track_number, fpath, exc,
+                            )
+
         # Mark tracks as ripped only if their file actually exists on disk
-        # (after reconciliation so filenames are corrected).
+        # (after reconciliation + deselection filter so filenames are correct).
         actual_files = set(os.listdir(rawpath)) if os.path.isdir(rawpath) else set()
         for track in job.tracks:
             if track.filename and track.filename in actual_files:

--- a/arm/ripper/import_prescan.py
+++ b/arm/ripper/import_prescan.py
@@ -27,13 +27,15 @@ log = logging.getLogger(__name__)
 def auto_disable_short_tracks(job, minlength: int) -> int:
     """Disable tracks below `minlength` seconds and tag with skip_reason.
 
-    MakeMKV silently skips short tracks during rip regardless of the
-    checkbox state, so disabling them keeps the UI honest. Returns the
-    count disabled.
+    Sets both process=False (the rip-time gate) and enabled=False
+    (the UI-checkbox state), and tags skip_reason=too_short so the
+    review widget renders the row as filtered. Returns the count
+    disabled.
     """
     disabled_count = 0
     for track in job.tracks:
         if track.length is not None and track.length < minlength:
+            track.process = False
             track.enabled = False
             track.skip_reason = SkipReason.too_short.value
             disabled_count += 1

--- a/test/test_folder_ripper.py
+++ b/test/test_folder_ripper.py
@@ -297,3 +297,44 @@ class TestRipFolder:
             "reconcile",
             "post_rip_handoff",
         ]
+
+    @patch("arm.ripper.folder_ripper.db")
+    @patch("arm.ripper.folder_ripper._reconcile_filenames")
+    @patch("arm.ripper.makemkv.run")
+    @patch("arm.ripper.folder_ripper.prescan_track_info")
+    @patch("arm.ripper.folder_ripper.prep_mkv")
+    def test_deselected_track_files_are_removed(
+        self, mock_prep, mock_prescan, mock_run,
+        mock_reconcile, mock_db, tmp_path
+    ):
+        """Output files for tracks with process=False are deleted post-rip.
+
+        MakeMKV's `all` mode rips every title above its minlength filter.
+        The user (or auto-disable) may set process=False on tracks they
+        don't want; without this filter those files would still rsync to
+        media + reach the transcoder. Repro on hifi 17.6.0-rc job 200:
+        user selected only track 0 in review; rip produced 28 mkv files.
+        """
+        from arm.ripper.folder_ripper import rip_folder
+
+        rawpath = tmp_path / "raw" / "Test Movie"
+        rawpath.mkdir(parents=True)
+        kept = rawpath / "kept.mkv"
+        dropped = rawpath / "dropped.mkv"
+        kept.write_bytes(b"keep me")
+        dropped.write_bytes(b"discard me")
+
+        job = self._make_job(tmp_path)
+        kept_track = MagicMock(track_number="0", filename="kept.mkv", process=True)
+        dropped_track = MagicMock(track_number="1", filename="dropped.mkv", process=False)
+        job.tracks = [kept_track, dropped_track]
+        mock_run.return_value = iter([])
+
+        with patch("arm.ripper.folder_ripper.setup_rawpath", return_value=str(rawpath)), \
+             patch("arm.ripper.folder_ripper.cfg") as mock_cfg, \
+             patch("arm.ripper.arm_ripper._post_rip_handoff"):
+            mock_cfg.arm_config = {"TRANSCODER_URL": ""}
+            rip_folder(job)
+
+        assert kept.exists(), "kept track file should not be deleted"
+        assert not dropped.exists(), "deselected track file should be removed"

--- a/test/test_import_helpers.py
+++ b/test/test_import_helpers.py
@@ -119,8 +119,8 @@ class TestAutoDisableShortTracks:
     def test_disables_tracks_below_minlength(self):
         from arm.ripper.import_prescan import auto_disable_short_tracks
 
-        short = MagicMock(length=30, enabled=True)
-        long_ = MagicMock(length=3000, enabled=True)
+        short = MagicMock(length=30, enabled=True, process=True)
+        long_ = MagicMock(length=3000, enabled=True, process=True)
         job = MagicMock()
         job.tracks = [short, long_]
 
@@ -128,7 +128,11 @@ class TestAutoDisableShortTracks:
 
         assert count == 1
         assert short.enabled is False
+        # process must also flip to False so kick_off_import_rip's
+        # post-rip deselection filter discards the output file.
+        assert short.process is False
         assert long_.enabled is True
+        assert long_.process is True
 
     def test_skips_tracks_with_none_length(self):
         from arm.ripper.import_prescan import auto_disable_short_tracks

--- a/test/test_track_skip_reason.py
+++ b/test/test_track_skip_reason.py
@@ -165,8 +165,13 @@ def test_all_tracks_path_marks_long_tracks_as_process_true(app_context, sample_j
 
 
 def test_folder_prescan_auto_disable_sets_too_short(app_context, sample_job):
-    """The folder-import prescan auto-disable should set both enabled=False
-    AND skip_reason='too_short' on tracks below MINLENGTH."""
+    """The folder-import prescan auto-disable should set process=False,
+    enabled=False AND skip_reason='too_short' on tracks below MINLENGTH.
+
+    process=False is the rip-time gate honored by kick_off_import_rip's
+    deselection filter; without it short tracks were ripped despite the
+    auto-filter (observed during 17.6.0-rc ISO smoke on hifi).
+    """
     from arm.models.track import Track
     from arm.api.v1.folder import auto_disable_short_tracks
 
@@ -183,9 +188,12 @@ def test_folder_prescan_auto_disable_sets_too_short(app_context, sample_job):
     rows = {t.track_number: t for t in db.session.query(Track).filter_by(job_id=sample_job.job_id)}
     assert rows["0"].enabled is True
     assert rows["0"].skip_reason is None
+    # process is left at its default (None or True) for the kept track
     assert rows["1"].enabled is False
+    assert rows["1"].process is False
     assert rows["1"].skip_reason == "too_short"
     assert rows["2"].enabled is False
+    assert rows["2"].process is False
     assert rows["2"].skip_reason == "too_short"
 
 


### PR DESCRIPTION
## Summary
Two-part bug. MakeMKV's \`all\` mode rips every title above its minlength filter; the per-track \`process=False\` selection (both manual user deselection and auto-short-track filter) was being ignored, so deselected tracks were rsync'd to media and handed to the transcoder.

1. \`auto_disable_short_tracks\` was setting \`enabled=False\` but leaving \`process=True\`. Now flips both, matching the lifecycle convention used in the disc-rip code path.
2. \`kick_off_import_rip\` never consulted \`process\` post-rip. After \`_reconcile_filenames\` matches output files to track rows, walk \`job.tracks\` and \`os.remove()\` the file for any track with \`process=False\`. Subsequent ripped-flag computation already filters by \`actual_files\`.

## Why
Hifi 17.6.0-rc smoke (job 200, MirrorMask 2005 ISO): user picked only track 0 in review; rip produced 28 mkv files in scratch and rsynced all of them to media. Track 0 was the only intended main feature; the rest were short clips/extras the user explicitly deselected.

Auto-disable was the first vector (it set enabled=False but not process=False so the user's filter was being shown in the UI but not actually applied). Even with that fixed, manual deselection wouldn't have been honored either - hence both fixes.

## Test plan
- [x] \`pytest test/test_folder_ripper.py test/test_import_helpers.py test/test_track_skip_reason.py test/test_prescan.py test/test_folder_scan.py -q\` - 80 passed
- [x] New: \`test_deselected_track_files_are_removed\` (folder_ripper) - verifies process=False output file is deleted, process=True is preserved
- [x] New assertions on \`test_folder_prescan_auto_disable_sets_too_short\` + \`test_disables_tracks_below_minlength\` - process flips to False alongside enabled
- [ ] Smoke on hifi: re-ingest the same ISO, deselect all but track 0 in review, verify only one file lands in /home/arm/media