### PR TITLE
chore: align compose env passthroughs + sample env files; opt-in NFS-readiness overlay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # All-in-one deployment: ARM + UI + Transcoder on a single machine
-# Copy to .env and adjust values before running: docker compose up -d
-# For GPU transcoding: docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+#
+# Use with:
+#   docker compose -f docker-compose.yml up -d
+#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d            # NVIDIA GPU
+#   docker compose -f docker-compose.yml -f docker-compose.nfs.yml up -d            # NFS-backed (gates startup on NFS readiness)
+#
+# Copy to .env and adjust values before running.
 
 # --- Version Pinning ---
 # Pin to a specific release (e.g. 15.0.0) or use "latest"
@@ -27,6 +32,10 @@ TZ=America/New_York
 
 # Host paths (must exist and be owned by ARM_UID:ARM_GID)
 ARM_MUSIC_PATH=/home/arm/music
+# Recommended: a local path on the ripper host. Avoid putting logs on
+# NFS - the logger writes during rips and NFS hiccups can stall the rip
+# pipeline. For NFS-backed deployments, point ARM_MEDIA_PATH at the
+# share, but keep ARM_LOGS_PATH local.
 ARM_LOGS_PATH=/home/arm/logs
 ARM_MEDIA_PATH=/home/arm/media
 ARM_CONFIG_PATH=/etc/arm/config
@@ -35,6 +44,15 @@ ARM_MAKEMKV_PATH=/home/arm/.MakeMKV
 # Folder import ingress - host directory containing BDMV/VIDEO_TS folders.
 # Mounted read-only into the container. Leave default to use ARM_MEDIA_PATH/ingress.
 # ARM_INGRESS_PATH=/path/to/disc/backups
+
+# Local SSD scratch staging for video rips (ripper-side, optional).
+# When BOTH ARM_LOCAL_RAW_PATH and ARM_SHARED_RAW_PATH are set, ARM rips
+# to LOCAL (fast SSD), then rsyncs to SHARED (NFS / shared storage)
+# before notifying the transcoder. Leave empty to rip directly to
+# ARM_MEDIA_PATH.
+# ARM_SCRATCH_PATH=/home/arm/scratch
+# ARM_LOCAL_RAW_PATH=/home/arm/scratch/raw/
+# ARM_SHARED_RAW_PATH=/home/arm/media/raw/
 
 # Completed-output root (where final transcoded files land).
 # Mounted into both ripper (/home/arm/media/completed) and transcoder (/data/completed).
@@ -106,14 +124,6 @@ STABILIZE_SECONDS=60
 MINIMUM_FREE_SPACE_GB=10
 MAX_RETRY_COUNT=3
 
-# Local SSD scratch for ripping (rip to fast local disk, then move to shared storage)
-# Set ARM_SCRATCH_PATH to a local SSD directory. ARM rips to this fast local disk,
-# then moves the output to shared/NFS storage before notifying the transcoder.
-# Leave unset to rip directly to ARM_MEDIA_PATH.
-# ARM_SCRATCH_PATH=/home/arm/scratch
-# ARM_LOCAL_RAW_PATH=/home/arm/scratch/raw/
-# ARM_SHARED_RAW_PATH=/home/arm/media/raw/
-
 # Transcoder work directory (fast SSD recommended, relative to compose file)
 TRANSCODER_WORK_PATH=./work
 TRANSCODER_PRESET_PATH=./presets
@@ -122,6 +132,15 @@ TRANSCODER_PRESET_PATH=./presets
 # In all-in-one mode, ARM reaches the transcoder via Docker network name.
 # Override for remote transcoder (e.g. http://192.168.0.92:5000/webhook/arm)
 # ARM_TRANSCODER_URL=http://arm-transcoder:5000/webhook/arm
+
+# How the UI's BFF reaches the transcoder. In all-in-one mode this
+# defaults to the Docker network name. Override for split deployments.
+# ARM_UI_TRANSCODER_URL=http://arm-transcoder:5000
+
+# How the transcoder calls back into ARM when jobs complete/fail.
+# In all-in-one mode the Docker network name works. Override for split
+# deployments (the transcoder host needs to reach the ripper host).
+# ARM_CALLBACK_URL=http://arm-rippers:8080
 
 # ARM callback URL - how the transcoder notifies ARM when jobs complete.
 # In all-in-one mode, uses Docker network name. Override for split deployments.

--- a/.env.remote-transcoder.example
+++ b/.env.remote-transcoder.example
@@ -1,7 +1,11 @@
 # Split deployment: ARM + UI on this machine, Transcoder on a remote host.
 # The transcoder runs its own docker-compose from the arm-transcoder repo.
-# Copy to .env and adjust values before running:
+#
+# Use with:
 #   docker compose -f docker-compose.remote-transcoder.yml up -d
+#   docker compose -f docker-compose.remote-transcoder.yml -f docker-compose.nfs.yml up -d   # NFS-backed (recommended for split deployments)
+#
+# Copy this file to .env and adjust values before running.
 
 # --- Version Pinning ---
 # Pin to a specific release (e.g. 13.0.0) or use "latest"
@@ -15,10 +19,36 @@ TZ=America/New_York
 
 # Host paths
 ARM_MUSIC_PATH=/home/arm/music
+# Recommended: a local path on the ripper host. Avoid putting logs on
+# NFS - the logger writes during rips and NFS hiccups can stall the rip
+# pipeline.
 ARM_LOGS_PATH=/home/arm/logs
+# ARM_MEDIA_PATH is typically the NFS share root in split deployments,
+# so the transcoder host can read raw files and write completed files
+# at the same paths the ripper sees.
 ARM_MEDIA_PATH=/home/arm/media
 ARM_CONFIG_PATH=/etc/arm/config
 ARM_MAKEMKV_PATH=/home/arm/.MakeMKV
+
+# Folder import ingress - host directory containing BDMV/VIDEO_TS folders.
+# Mounted read-only into the container. Leave default to use ARM_MEDIA_PATH/ingress.
+# ARM_INGRESS_PATH=/path/to/disc/backups
+
+# Completed-output root (where final transcoded files land).
+# Mounted to /home/arm/media/completed in the container; the transcoder
+# on the remote host should mount the same NFS path at /data/completed.
+# Combine with MOVIES_SUBDIR / TV_SUBDIR / AUDIO_SUBDIR for nested
+# library trees (e.g. ARM_COMPLETED_PATH=/nfs/files/Video,
+# MOVIES_SUBDIR=Movies/0.Rips, TV_SUBDIR=TV/0.Rips).
+# Defaults to ${ARM_MEDIA_PATH}/completed.
+# ARM_COMPLETED_PATH=
+
+# Output organization subdirs.
+# Each value may contain '/' for nested dirs.
+MOVIES_SUBDIR=movies
+TV_SUBDIR=tv
+AUDIO_SUBDIR=music
+UNIDENTIFIED_SUBDIR=unidentified
 
 # Ports
 ARM_PORT=8080
@@ -30,12 +60,14 @@ ARM_CPUSET=2,3,4,5,6,7
 # Download FindVUK community keydb for Blu-ray decryption (true/false)
 ARM_COMMUNITY_KEYDB=true
 
-# Optical drives (uncomment and adjust)
-# ARM_DEVICE_0=/dev/sr0
-# ARM_DEVICE_1=/dev/sr1
+# Optical drives: the compose file mounts /dev:/dev so ALL drives are
+# visible automatically. No per-device configuration is needed.
 
-# Local SSD scratch for ripping (rip to fast local disk, then move to shared storage)
-# Leave unset to rip directly to ARM_MEDIA_PATH.
+# Local SSD scratch for ripping (recommended for NFS-backed deployments).
+# When BOTH ARM_LOCAL_RAW_PATH and ARM_SHARED_RAW_PATH are set, ARM rips
+# to LOCAL (fast SSD), then rsyncs to SHARED (NFS) before notifying the
+# remote transcoder. Without this, MakeMKV writes track-by-track to NFS
+# during the rip - workable but slower.
 # ARM_SCRATCH_PATH=/home/arm/scratch
 # ARM_LOCAL_RAW_PATH=/home/arm/scratch/raw/
 # ARM_SHARED_RAW_PATH=/home/arm/media/raw/
@@ -44,10 +76,21 @@ ARM_COMMUNITY_KEYDB=true
 # IP or hostname of the machine running arm-transcoder
 TRANSCODER_HOST=192.168.0.100
 TRANSCODER_PORT=5000
-TRANSCODER_VERSION=latest
+
+# Override webhook URL only if not the default
+# http://${TRANSCODER_HOST}:${TRANSCODER_PORT}/webhook/arm
+# ARM_TRANSCODER_URL=
+
+# Override how the UI's BFF reaches the transcoder, if not the default
+# http://${TRANSCODER_HOST}:${TRANSCODER_PORT}
+# ARM_UI_TRANSCODER_URL=
+
+# Note: TRANSCODER_VERSION is NOT set here. The transcoder runs from
+# its own repo on the remote host with its own .env file - pin the
+# version there. This file is for the ripper host only.
 
 # --- Authentication ---
-# Shared secret for ARM → transcoder webhook calls.
+# Shared secret for ARM -> transcoder webhook calls.
 # Must match WEBHOOK_SECRET in the transcoder's .env.
 # Generate with: openssl rand -hex 32
 WEBHOOK_SECRET=

--- a/.env.ripper-only.example
+++ b/.env.ripper-only.example
@@ -1,9 +1,12 @@
 # Ripper-only deployment: ARM + UI on a single machine, no transcoder.
-# Copy to .env and adjust values before running:
+#
+# Use with:
 #   docker compose -f docker-compose.ripper-only.yml up -d --build
+#   docker compose -f docker-compose.ripper-only.yml -f docker-compose.nfs.yml up -d --build   # NFS-backed
 #
 # Note: TRANSCODER_ENABLED is hardcoded to false in the compose file.
 # To re-enable the transcoder, switch to docker-compose.yml instead.
+# Copy this file to .env and adjust values before running.
 
 # --- Version Pinning ---
 # Pin to a specific release (e.g. 16.1.0) or use "latest"
@@ -17,6 +20,9 @@ TZ=America/New_York
 
 # Host paths (must exist and be owned by ARM_UID:ARM_GID)
 ARM_MUSIC_PATH=/home/arm/music
+# Recommended: a local path on the ripper host. Avoid putting logs on
+# NFS - the logger writes during rips and NFS hiccups can stall the rip
+# pipeline.
 ARM_LOGS_PATH=/home/arm/logs
 ARM_MEDIA_PATH=/home/arm/media
 ARM_CONFIG_PATH=/etc/arm/config
@@ -25,6 +31,19 @@ ARM_MAKEMKV_PATH=/home/arm/.MakeMKV
 # Folder import ingress - host directory containing BDMV/VIDEO_TS folders.
 # Mounted read-only into the container. Leave default to use ARM_MEDIA_PATH/ingress.
 # ARM_INGRESS_PATH=/path/to/disc/backups
+
+# Completed-output root (where final files land in ripper-only mode).
+# Mounted to /home/arm/media/completed in the container. Combine with
+# MOVIES_SUBDIR / TV_SUBDIR / AUDIO_SUBDIR (see below) to land output
+# in arbitrary library trees. Defaults to ${ARM_MEDIA_PATH}/completed.
+# ARM_COMPLETED_PATH=
+
+# Output organization subdirs under the completed-path root.
+# Each value may contain '/' for nested dirs (e.g. "Movies/0.Rips").
+MOVIES_SUBDIR=movies
+TV_SUBDIR=tv
+AUDIO_SUBDIR=music
+UNIDENTIFIED_SUBDIR=unidentified
 
 # Ports
 ARM_PORT=8080

--- a/docker-compose.nfs.yml
+++ b/docker-compose.nfs.yml
@@ -1,0 +1,42 @@
+# Opt-in overlay for NFS-backed deployments.
+#
+# Adds an NFS-readiness gate so arm-rippers will not start if the NFS
+# mount is missing or stale. Without this gate, when docker starts
+# before NFS is mounted on the host, container binds capture the
+# local-disk shadow of the mount point, rips silently land on the
+# wrong filesystem, and the remote transcoder never sees the files.
+#
+# Setup (one-time, on the NFS server):
+#   touch /path/to/share/.arm-nfs-heartbeat
+#
+# The sentinel must be visible at ${ARM_MEDIA_PATH}/.arm-nfs-heartbeat
+# inside arm-rippers' bind. If NFS isn't mounted at that path, the
+# sentinel is missing and arm-rippers refuses to start with a clear
+# error instead of silently fossilizing.
+#
+# Usage (apply on top of any primary compose):
+#   docker compose -f docker-compose.yml                    -f docker-compose.nfs.yml up -d
+#   docker compose -f docker-compose.remote-transcoder.yml  -f docker-compose.nfs.yml up -d
+#   docker compose -f docker-compose.ripper-only.yml        -f docker-compose.nfs.yml up -d
+
+services:
+  arm-nfs-check:
+    image: alpine
+    container_name: arm-nfs-check
+    volumes:
+      - ${ARM_MEDIA_PATH}:/nfs-check:ro
+    command:
+      - sh
+      - -c
+      - |
+        if [ ! -f /nfs-check/.arm-nfs-heartbeat ]; then
+          echo "ERROR: NFS readiness sentinel missing at \${ARM_MEDIA_PATH}/.arm-nfs-heartbeat" >&2
+          echo "       Run on the NFS server: touch <share-path>/.arm-nfs-heartbeat" >&2
+          exit 1
+        fi
+    restart: "no"
+
+  arm-rippers:
+    depends_on:
+      arm-nfs-check:
+        condition: service_completed_successfully

--- a/docker-compose.remote-transcoder.yml
+++ b/docker-compose.remote-transcoder.yml
@@ -32,11 +32,23 @@ services:
       # Local SSD scratch for ripping (moved to shared storage after rip)
       - ARM_LOCAL_RAW_PATH=${ARM_LOCAL_RAW_PATH:-}
       - ARM_SHARED_RAW_PATH=${ARM_SHARED_RAW_PATH:-}
+      # Output organization subdirs (entrypoint rewrites arm.yaml at boot
+      # so ARM honors them; transcoder reads its own env from its host).
+      - MOVIES_SUBDIR=${MOVIES_SUBDIR:-movies}
+      - TV_SUBDIR=${TV_SUBDIR:-tv}
+      - AUDIO_SUBDIR=${AUDIO_SUBDIR:-music}
+      - UNIDENTIFIED_SUBDIR=${UNIDENTIFIED_SUBDIR:-unidentified}
+      # Host path mapping for preflight health checks
+      - ARM_MEDIA_PATH=${ARM_MEDIA_PATH}
+      - ARM_CONFIG_PATH=${ARM_CONFIG_PATH}
+      - ARM_LOGS_PATH=${ARM_LOGS_PATH}
+      - ARM_MUSIC_PATH=${ARM_MUSIC_PATH}
     volumes:
       - /dev:/dev
       - ${ARM_MUSIC_PATH}:/home/arm/music
       - ${ARM_LOGS_PATH}:/home/arm/logs
       - ${ARM_MEDIA_PATH}:/home/arm/media
+      - ${ARM_COMPLETED_PATH:-${ARM_MEDIA_PATH}/completed}:/home/arm/media/completed
       - ${ARM_SCRATCH_PATH:-/home/arm/media}:/home/arm/scratch
       - ${ARM_INGRESS_PATH:-/home/arm/media/ingress}:/home/arm/media/ingress:ro
       - ${ARM_CONFIG_PATH}:/etc/arm/config
@@ -56,7 +68,7 @@ services:
       - "${UI_PORT:-8888}:8888"
     environment:
       - ARM_UI_ARM_URL=http://arm-rippers:8080
-      - ARM_UI_TRANSCODER_URL=http://${TRANSCODER_HOST}:${TRANSCODER_PORT:-5000}
+      - ARM_UI_TRANSCODER_URL=${ARM_UI_TRANSCODER_URL:-http://${TRANSCODER_HOST}:${TRANSCODER_PORT:-5000}}
       - ARM_UI_TRANSCODER_API_KEY=${TRANSCODER_API_KEY:-}
       - ARM_UI_TRANSCODER_WEBHOOK_SECRET=${WEBHOOK_SECRET:-}
       - ARM_UI_THEMES_PATH=/data/themes

--- a/docs/folder-paths.md
+++ b/docs/folder-paths.md
@@ -31,10 +31,11 @@ which knob wins.
   - [11. Ripper-only](#11-ripper-only)
   - [12. Remote transcoder](#12-remote-transcoder)
   - [13. Dev overlay](#13-dev-overlay)
+  - [14. NFS-readiness overlay](#14-nfs-readiness-overlay)
 - [Part E: Skim tables](#part-e-skim-tables)
-  - [14. Where does X live?](#14-where-does-x-live)
-  - [15. Where do I change X?](#15-where-do-i-change-x)
-  - [16. Env var quick index](#16-env-var-quick-index)
+  - [15. Where does X live?](#15-where-does-x-live)
+  - [16. Where do I change X?](#16-where-do-i-change-x)
+  - [17. Env var quick index](#17-env-var-quick-index)
 
 ---
 
@@ -509,11 +510,38 @@ from sibling source repos.
 > `components/contracts` re-mount, `import arm_contracts` fails inside the
 > dev transcoder container.
 
+### 14. NFS-readiness overlay
+
+`docker-compose.nfs.yml` (opt-in overlay). Apply on top of any primary
+compose for NFS-backed deployments where docker may start before NFS is
+mounted.
+
+```bash
+docker compose -f docker-compose.yml                    -f docker-compose.nfs.yml up -d
+docker compose -f docker-compose.remote-transcoder.yml  -f docker-compose.nfs.yml up -d
+docker compose -f docker-compose.ripper-only.yml        -f docker-compose.nfs.yml up -d
+```
+
+**What it does**: adds an `arm-nfs-check` init container that fails
+fast if the sentinel file `${ARM_MEDIA_PATH}/.arm-nfs-heartbeat` is
+not visible. `arm-rippers` `depends_on` it, so it won't start (and
+won't silently fossilize binds to local disk) if NFS isn't mounted.
+
+**One-time setup**: on the NFS server, `touch
+<share-path>/.arm-nfs-heartbeat`.
+
+**Why this matters**: when `_netdev` in `/etc/fstab` doesn't gate
+docker's start order, a host reboot can leave docker running with
+binds captured against the empty local-disk shadow of an unmounted NFS
+path. Rips land on local disk, the remote transcoder never sees them,
+jobs fail with "Source path does not exist". The overlay turns this
+silent failure into a loud refusal-to-start.
+
 ---
 
 ## Part E: Skim tables
 
-### 14. Where does X live?
+### 15. Where does X live?
 
 | Concept | Container | Host (default) |
 |---|---|---|
@@ -525,7 +553,7 @@ from sibling source repos.
 | Music CDs (raw rip target) | `/home/arm/music/` | `${ARM_MUSIC_PATH}` |
 | ARM SQLite | `/home/arm/db/arm.db` | named volume `arm-db` |
 | Transcoder SQLite | `/data/db/transcoder.db` | named volume `transcoder-db` |
-| ARM logs | `/home/arm/logs/` | `${ARM_LOGS_PATH}` |
+| ARM logs | `/home/arm/logs/` | `${ARM_LOGS_PATH}` (recommend local; avoid NFS for in-progress rip log writes) |
 | Transcoder logs | `/data/logs/` | named volume `transcoder-logs` |
 | ARM config (`arm.yaml`, `apprise.yaml`, `abcde.conf`) | `/etc/arm/config/` | `${ARM_CONFIG_PATH}` |
 | MakeMKV settings + keydb | `/home/arm/.MakeMKV/` | named volume `makemkv-settings` (or `${ARM_MAKEMKV_PATH}`) |
@@ -538,7 +566,7 @@ from sibling source repos.
 | MakeMKV heartbeat / faulthandler | `/home/arm/logs/progress/` + `faulthandler.log` | `${ARM_LOGS_PATH}/...` |
 | abcde tmp config | `/tmp/abcde_custom_*.conf` | (ephemeral, container tmpfs) |
 
-### 15. Where do I change X?
+### 16. Where do I change X?
 
 | Setting | Source of truth | How to change |
 |---|---|---|
@@ -555,11 +583,12 @@ from sibling source repos.
 | UI themes / image cache paths | env (`ARM_UI_THEMES_PATH`, `ARM_UI_IMAGE_CACHE_PATH`) | Edit compose, restart UI |
 | UI -> transcoder credentials | env (`ARM_UI_TRANSCODER_API_KEY`, `ARM_UI_TRANSCODER_WEBHOOK_SECRET`) | Edit `.env`, **restart UI** (loaded once - rotation needs a restart) |
 
-### 16. Env var quick index
+### 17. Env var quick index
 
 | Env var | Read by | Notes |
 |---|---|---|
 | `ARM_VERSION`, `UI_VERSION`, `TRANSCODER_VERSION` | docker-compose only | Image tag pinning |
+| `TRANSCODER_HOST`, `TRANSCODER_PORT` | `docker-compose.remote-transcoder.yml` | Construct `ARM_TRANSCODER_URL` and `ARM_UI_TRANSCODER_URL` for split deployments |
 | `ARM_UID`, `ARM_GID` | ripper entrypoint, `file_browser.py`, init containers | UID/GID alignment |
 | `TRANSCODER_UID`, `TRANSCODER_GID` | transcoder entrypoint | Should match `ARM_UID`/`ARM_GID` |
 | `TZ` | All three entrypoints (symlinks `/etc/localtime`) | Also re-baked into tzdata |


### PR DESCRIPTION
## Summary

Cleanup PR motivated by a production incident on hifi-server where
docker started before NFS mounted, container binds captured the empty
local-disk shadow of the mount point, and rips silently landed on
local disk while the remote transcoder failed every job with 'Source
path does not exist'. Investigation surfaced four related drift /
documentation issues that this PR addresses together.

### What's in here

1. **Compose parity** - PR #339 added MOVIES_SUBDIR / TV_SUBDIR /
   AUDIO_SUBDIR / UNIDENTIFIED_SUBDIR and ARM_COMPLETED_PATH to the
   all-in-one and ripper-only composes but missed
   docker-compose.remote-transcoder.yml. Operators on split
   deployments couldn't customize library layout. Fixed.

2. **ARM_UI_TRANSCODER_URL operator-overridable in remote compose** -
   was hardcoded to construct from TRANSCODER_HOST:TRANSCODER_PORT
   with no override slot, asymmetric with all-in-one.

3. **Opt-in NFS-readiness overlay** (new file:
   docker-compose.nfs.yml) - alpine init container fails fast if the
   sentinel file \${ARM_MEDIA_PATH}/.arm-nfs-heartbeat is not
   visible. arm-rippers depends_on it. Closes the silent-
   fossilization mode that fired on hifi-server. Single-host SSD
   installs don't need this overlay.

4. **Sample env file alignment** - drift matrix (compose refs vs
   sample defines) is now clean for all three primary deployments.
   Headers in each sample point at the matching compose so operators
   can't silently mis-pair (which fired on hifi-server when the
   operator was running docker-compose.yml instead of
   docker-compose.remote-transcoder.yml).

5. **Log-on-NFS warning** in all three samples: 'Recommended: a local
   path on the ripper host. Avoid putting logs on NFS - the logger
   writes during rips and NFS hiccups can stall the rip pipeline.'

6. **Docs** - new section 14 in docs/folder-paths.md describing the
   NFS overlay; skim-table numbering shifted 14/15/16 -> 15/16/17;
   TRANSCODER_HOST entry in env-var quick index.

### What's NOT in here

- No code changes. Job.type_subfolder etc. is stable from #339.
- No structural refactor of compose files (e.g. profiles).
- No host-level systemd config; readiness is enforced at compose level.
- No 'logs to named volume' - we settled on plain host bind (default
  /home/arm/logs) so logs survive container restart without docker-
  volume opacity.

## Spec

\`~/src/ai/arm-neu/docs/superpowers/specs/2026-05-06-compose-sample-alignment-design.md\`

## Test plan

- [x] \`docker compose -f docker-compose.yml config --quiet\` - clean
- [x] \`docker compose -f docker-compose.ripper-only.yml config --quiet\` - clean
- [x] \`docker compose -f docker-compose.remote-transcoder.yml config --quiet\` - clean
- [x] All three primary composes + \`-f docker-compose.nfs.yml\` overlay - clean
- [x] Drift matrix re-check: every compose-referenced var has a sample
      line, every sample line is consumed
- [x] \`pytest test/test_job_model.py\` - 40 passed (no code changes; sanity)

## Operator migration after merge

Existing operators see no behavior change unless they opt in.

To enable the NFS-readiness gate on hifi-server (post-deploy):

\`\`\`bash
# One-time, on the NFS server:
touch /nfs/files/Video/Import/.arm-nfs-heartbeat

# Add the overlay flag to deploy commands:
ssh hifi-server 'cd ~/src/automatic-ripping-machine-neu && \\
  docker compose -f docker-compose.remote-transcoder.yml -f docker-compose.nfs.yml down && \\
  docker compose -f docker-compose.remote-transcoder.yml -f docker-compose.nfs.yml up -d'
\`\`\`

After this, any host reboot where NFS is missing at docker start fails
loud and fast instead of silently fossilizing. Update
deployment.md memory to reflect the new flag.