### PR TITLE
feat!: switch webhook to input_path/output_path

### DIFF
--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -211,10 +211,7 @@ def _build_webhook_payload(title, body, job, raw_basename):
         # WebhookPayload requires job_id, so we hand-build the dict here -
         # the typed model is only meaningful for the job-bound transcode
         # webhook the transcoder actually receives.
-        payload = {"title": title, "body": body, "type": WebhookEventType.info.value}
-        if raw_basename:
-            payload["path"] = raw_basename
-        return payload
+        return {"title": title, "body": body, "type": WebhookEventType.info.value}
 
     config_dict = cfg.arm_config if hasattr(cfg, 'arm_config') else None
     # Route through _parse_transcode_overrides so corrupt/legacy rows are
@@ -224,9 +221,38 @@ def _build_webhook_payload(title, body, job, raw_basename):
     from arm.api.v1.jobs import _parse_transcode_overrides
     overrides_dict = _parse_transcode_overrides(job.transcode_overrides)
 
-    # Pre-rendered names from ARM's naming engine. render_folder may contain
-    # '/' for nested dirs (e.g. "Title/Season 01") - it already sanitizes
-    # each segment, so don't strip slashes here.
+    # Resolve the raw share root. SHARED_RAW_PATH wins when local+shared
+    # scratch staging is configured; otherwise fall back to RAW_PATH.
+    raw_root = (config_dict or {}).get('SHARED_RAW_PATH') or (config_dict or {}).get('RAW_PATH') or ''
+
+    # input_path: job.raw_path relative to the raw share root. Falls
+    # back to raw_basename when raw_path / raw_root aren't set, which
+    # keeps notification-only style payloads (no real job dir) working.
+    input_path = None
+    if job.raw_path and raw_root:
+        try:
+            rel = os.path.relpath(str(job.raw_path), str(raw_root))
+            # relpath returns a string starting with '..' when raw_path is
+            # outside raw_root; that fails the contract validator. Treat
+            # as missing input rather than raising.
+            if not rel.startswith('..'):
+                input_path = rel
+        except ValueError:
+            input_path = None
+    if input_path is None and raw_basename:
+        # No raw_root or relpath escaped: ship the basename as a
+        # last-resort relative path. Rare; transcoder will fail
+        # _wait_for_stable if the dir doesn't exist under raw_path.
+        input_path = raw_basename
+
+    # output_path: job.type_subfolder joined with rendered folder name.
+    # render_folder returns the leaf with sanitized segments and may
+    # contain '/' for nested dirs ('Title/Season 01').
+    type_sub = job.type_subfolder if hasattr(job, 'type_subfolder') else 'unidentified'
+    rendered_folder = render_folder(job, config_dict)
+    output_path = os.path.join(type_sub, rendered_folder) if rendered_folder else type_sub
+
+    # Pre-rendered per-track names from ARM's naming engine.
     rendered = render_all_tracks(job, config_dict)
     rendered_map = {r["track_number"]: r for r in rendered}
     tracks_meta = []
@@ -241,14 +267,34 @@ def _build_webhook_payload(title, body, job, raw_basename):
         # sanitizes custom_filename but raw pattern output needs it here.
         rendered_title = r.get("rendered_title", '')
         track_title_name = clean_for_filename(rendered_title) if rendered_title else ''
+
+        # Per-track output_path: pick the type subdir from THIS track's
+        # video_type (multi-title discs can mix movie + series tracks),
+        # then join with the track's rendered folder. Mirrors
+        # Job.type_subfolder's lookup.
+        track_video_type = str(track.video_type or job.video_type or '')
+        if track_video_type == 'movie':
+            track_type_sub = (config_dict or {}).get('MOVIES_SUBDIR', 'movies')
+        elif track_video_type == 'series':
+            track_type_sub = (config_dict or {}).get('TV_SUBDIR', 'tv')
+        elif track_video_type == 'music':
+            track_type_sub = (config_dict or {}).get('AUDIO_SUBDIR', 'music')
+        else:
+            track_type_sub = (config_dict or {}).get('UNIDENTIFIED_SUBDIR', 'unidentified')
+        track_rendered_folder = r.get("rendered_folder", '')
+        track_output_path = (
+            os.path.join(track_type_sub, track_rendered_folder)
+            if track_rendered_folder else track_type_sub
+        )
+
         tracks_meta.append(WebhookTrackMeta(
             track_number=str(track.track_number or ''),
             title=str(title_str),
             year=str(track.year or job.year or ''),
-            video_type=str(track.video_type or job.video_type or ''),
+            video_type=track_video_type,
             filename=str(track.filename or ''),
             has_custom_title=bool(track.title) or bool(getattr(track, 'custom_filename', None)),
-            folder_name=r.get("rendered_folder", ''),
+            output_path=track_output_path,
             title_name=track_title_name,
             episode_number=str(getattr(track, 'episode_number', '') or ''),
             episode_name=str(getattr(track, 'episode_name', '') or ''),
@@ -258,14 +304,14 @@ def _build_webhook_payload(title, body, job, raw_basename):
         title=title,
         body=body,
         type=WebhookEventType.info,
-        path=raw_basename or None,
+        input_path=input_path,
+        output_path=output_path,
         job_id=str(job.job_id),  # WebhookPayload coerces str -> int.
         video_type=str(job.video_type or ''),
         year=str(job.year or ''),
         disctype=str(job.disctype or ''),
         status=str(job.status or ''),
         poster_url=str(job.poster_url or ''),
-        folder_name=render_folder(job, config_dict),
         title_name=clean_for_filename(render_title(job, config_dict)),
         config_overrides=overrides_dict,  # Pydantic coerces dict -> TranscodeJobConfig.
         multi_title=True if getattr(job, 'multi_title', False) else None,

--- a/test/test_coverage_gaps_2.py
+++ b/test/test_coverage_gaps_2.py
@@ -65,7 +65,16 @@ class TestBuildWebhookPayload:
         payload = _build_webhook_payload("Rip done", "body text", sample_job, "SERIAL_MOM")
         assert payload["title"] == "Rip done"
         assert payload["body"] == "body text"
-        assert payload["path"] == "SERIAL_MOM"
+        # input_path falls back to raw_basename when job.raw_path is unset
+        # (sample_job sets raw_path=None) — keeps notification-style
+        # payloads working until a real ripper run populates raw_path.
+        assert payload["input_path"] == "SERIAL_MOM"
+        # output_path = type_subfolder + rendered folder. sample_job is a
+        # movie with title SERIAL_MOM and year 1994.
+        assert payload["output_path"].startswith("movies")
+        # Legacy fields are gone.
+        assert "path" not in payload
+        assert "folder_name" not in payload
         # arm_contracts.WebhookPayload coerces job_id to int on the wire
         # (contract decision; transcoder receiver accepts the int form).
         assert payload["job_id"] == sample_job.job_id
@@ -88,10 +97,12 @@ class TestBuildWebhookPayload:
         # Tracks are always included — ARM controls naming
         assert "tracks" in payload
         assert len(payload["tracks"]) == 3
-        # Each track has title_name from naming engine
+        # Each track has title_name from naming engine + output_path
+        # (the per-track output dir relative to completed_path).
         for t_meta in payload["tracks"]:
             assert "title_name" in t_meta
-            assert "folder_name" in t_meta
+            assert "output_path" in t_meta
+            assert "folder_name" not in t_meta  # field removed in v3.0.0
             assert "filename" in t_meta
 
     def test_multi_title_with_custom_titles(self, app_context, job_with_tracks):
@@ -154,22 +165,29 @@ class TestBuildWebhookPayload:
         assert payload["config_overrides"]["overrides"]["shared"]["video_quality"] == 22
 
     def test_job_is_none(self):
-        """When job is None, payload has only basic fields."""
+        """When job is None, payload has only basic fields. Notification-
+        only payloads carry no path info (nothing to transcode)."""
         from arm.ripper.utils import _build_webhook_payload
 
         payload = _build_webhook_payload("Test", "body", None, "some_path")
         assert payload["title"] == "Test"
         assert payload["body"] == "body"
-        assert payload["path"] == "some_path"
+        # Legacy 'path' field is gone in contracts v3.0.0; the
+        # notification-only branch carries no path keys at all.
+        assert "path" not in payload
+        assert "input_path" not in payload
+        assert "output_path" not in payload
         assert "job_id" not in payload
         assert "tracks" not in payload
 
     def test_no_raw_basename(self, app_context, sample_job):
-        """When raw_basename is empty, no path key in payload."""
+        """When raw_basename is empty AND raw_path is None, input_path
+        is omitted from the payload."""
         from arm.ripper.utils import _build_webhook_payload
 
         payload = _build_webhook_payload("Test", "body", sample_job, "")
         assert "path" not in payload
+        assert "input_path" not in payload
 
     def test_episode_name_preferred_over_track_title(self, app_context, job_with_tracks):
         """Webhook title field prefers episode_name over track.title (stale auto-match fix)."""
@@ -219,6 +237,84 @@ class TestBuildWebhookPayload:
 
         payload = _build_webhook_payload("Rip done", "body", job, "raw_dir")
         assert payload["tracks"][0]["title"] == "My Title"
+
+    def test_input_path_resolves_relative_to_raw_root(self, app_context, sample_job, monkeypatch):
+        """input_path is job.raw_path made relative to RAW_PATH (or
+        SHARED_RAW_PATH when local-shared scratch staging is configured)."""
+        from arm.ripper.utils import _build_webhook_payload
+        import arm.config.config as cfg
+
+        monkeypatch.setattr(cfg, "arm_config", {
+            "RAW_PATH": "/home/arm/media/raw/",
+            "MOVIES_SUBDIR": "Movies/0.Rips",
+            "TV_SUBDIR": "TV/0.Rips",
+            "AUDIO_SUBDIR": "music",
+            "UNIDENTIFIED_SUBDIR": "unidentified",
+        })
+        sample_job.raw_path = "/home/arm/media/raw/movies/Foo_xyz"
+        db.session.commit()
+
+        payload = _build_webhook_payload("Rip done", "body", sample_job, "Foo_xyz")
+
+        assert payload["input_path"] == "movies/Foo_xyz"
+
+    def test_output_path_uses_type_subfolder_for_movies(self, app_context, sample_job, monkeypatch):
+        """output_path = job.type_subfolder / render_folder(job, cfg)."""
+        from arm.ripper.utils import _build_webhook_payload
+        import arm.config.config as cfg
+
+        monkeypatch.setattr(cfg, "arm_config", {
+            "RAW_PATH": "/home/arm/media/raw/",
+            "MOVIES_SUBDIR": "Movies/0.Rips",
+            "TV_SUBDIR": "TV/0.Rips",
+            "AUDIO_SUBDIR": "music",
+            "UNIDENTIFIED_SUBDIR": "unidentified",
+        })
+        # sample_job is a movie titled SERIAL_MOM, year 1994.
+        sample_job.raw_path = "/home/arm/media/raw/movies/SERIAL_MOM_xyz"
+        db.session.commit()
+
+        payload = _build_webhook_payload("Rip done", "body", sample_job, "SERIAL_MOM_xyz")
+
+        assert payload["output_path"].startswith("Movies/0.Rips/")
+
+    def test_legacy_fields_not_in_payload(self, app_context, sample_job):
+        """folder_name and path no longer ship on the wire (contracts v3.0.0)."""
+        from arm.ripper.utils import _build_webhook_payload
+
+        payload = _build_webhook_payload("Rip done", "body", sample_job, "raw_dir")
+
+        assert "folder_name" not in payload
+        assert "path" not in payload
+        # Per-track too.
+        if "tracks" in payload:
+            for t in payload["tracks"]:
+                assert "folder_name" not in t
+
+    def test_track_output_path_uses_track_video_type_subdir(self, app_context, job_with_tracks, monkeypatch):
+        """Per-track output_path picks the subdir from the track's
+        video_type, supporting mixed multi-title discs."""
+        from arm.ripper.utils import _build_webhook_payload
+        import arm.config.config as cfg
+
+        monkeypatch.setattr(cfg, "arm_config", {
+            "RAW_PATH": "/home/arm/media/raw/",
+            "MOVIES_SUBDIR": "Movies/0.Rips",
+            "TV_SUBDIR": "TV/0.Rips",
+            "AUDIO_SUBDIR": "music",
+            "UNIDENTIFIED_SUBDIR": "unidentified",
+        })
+        job, tracks = job_with_tracks
+        tracks[0].video_type = "movie"
+        tracks[1].video_type = "series"
+        db.session.commit()
+        db.session.refresh(job)
+
+        payload = _build_webhook_payload("Rip done", "body", job, "raw_dir")
+
+        # Track 0 (movie) -> Movies subdir; Track 1 (series) -> TV subdir.
+        assert payload["tracks"][0]["output_path"].startswith("Movies/0.Rips")
+        assert payload["tracks"][1]["output_path"].startswith("TV/0.Rips")
 
 
 # ── transcode_callback tests ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Webhook builder resolves `input_path` (raw_path relative to `RAW_PATH` / `SHARED_RAW_PATH`) and `output_path` (`type_subfolder` joined with `render_folder`) per job.
- Per-track `output_path` resolves with each track's own `video_type` subdir (supports mixed multi-title discs).
- Drops `path` / `folder_name` from the payload (now removed in contracts v3.0.0).
- Includes the auto-bump of `components/contracts` to `37d3fd4` (v3.0.0).

## Test plan
- [x] `test/test_coverage_gaps_2.py::TestBuildWebhookPayload` — 14 passed (10 existing + 4 new)
- [x] Full arm-neu suite — 2222 passed, 1 skipped, 2 xfailed
- [ ] arm-transcoder breaking PR (companion) must ship in the same deploy window

## Spec / Plan
- Spec: `arm-neu/docs/superpowers/specs/2026-05-07-webhook-input-output-paths-design.md`
- Plan: `arm-neu/docs/superpowers/plans/2026-05-07-webhook-input-output-paths.md` (Plan B)

## BREAKING CHANGE
Webhook payloads no longer include `folder_name` or `path`. Consumers must read `input_path` / `output_path`.