### PR TITLE
fix(routing): unidentified DVD/Blu-ray/UHD rips default to MOVIES_SUBDIR

### DIFF
--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -448,6 +448,14 @@ class Job(db.Model):
         from arm.yaml so ARM honors the same library-tree organization the
         transcoder uses. Falls back to legacy hardcoded defaults if
         arm_config is unavailable (test-isolation safety net).
+
+        When video_type isn't a confirmed enum value (most commonly
+        ``"unknown"`` for DVDs/Blu-rays/UHDs that didn't get an OMDB
+        match before the rip started), fall back to MOVIES_SUBDIR for
+        video discs. Most unidentified video discs are movies; routing
+        them to ``unidentified/`` makes the operator triage every test
+        rip. ``unidentified/`` stays for genuinely unclassifiable
+        content (audio CDs without metadata, data discs).
         """
         import arm.config.config as cfg
         config_dict = getattr(cfg, 'arm_config', {}) or {}
@@ -457,6 +465,11 @@ class Job(db.Model):
             return config_dict.get("TV_SUBDIR", "tv")
         elif self.video_type == "music":
             return config_dict.get("AUDIO_SUBDIR", "music")
+        # Video disc without a confirmed type - default to MOVIES_SUBDIR.
+        # Audio CDs go through "music" via ripping/abcde, so they reach
+        # this branch only via the AUDIO_SUBDIR clause above.
+        if self.disctype in ("dvd", "bluray", "uhd"):
+            return config_dict.get("MOVIES_SUBDIR", "movies")
         return config_dict.get("UNIDENTIFIED_SUBDIR", "unidentified")
 
     def _pattern_fields_available(self):

--- a/test/test_job_model.py
+++ b/test/test_job_model.py
@@ -36,8 +36,34 @@ class TestTypeSubfolder:
         sample_job.video_type = "music"
         assert sample_job.type_subfolder == "music"
 
-    def test_unknown(self, sample_job):
+    def test_unknown_video_disc_defaults_to_movies(self, sample_job):
+        """An unidentified DVD/Blu-ray/UHD routes to MOVIES_SUBDIR. Most
+        unidentified video discs are movies; reserving 'unidentified/'
+        for them would force operator triage on every test rip."""
         sample_job.video_type = "unknown"
+        sample_job.disctype = "bluray"
+        assert sample_job.type_subfolder == "movies"
+
+    def test_unknown_dvd_defaults_to_movies(self, sample_job):
+        sample_job.video_type = "unknown"
+        sample_job.disctype = "dvd"
+        assert sample_job.type_subfolder == "movies"
+
+    def test_unknown_uhd_defaults_to_movies(self, sample_job):
+        sample_job.video_type = "unknown"
+        sample_job.disctype = "uhd"
+        assert sample_job.type_subfolder == "movies"
+
+    def test_unknown_non_video_disc_stays_unidentified(self, sample_job):
+        """Truly unclassifiable content (data discs, mixed media, no
+        disctype set) lands in unidentified/ for operator triage."""
+        sample_job.video_type = "unknown"
+        sample_job.disctype = "data"
+        assert sample_job.type_subfolder == "unidentified"
+
+    def test_unknown_blank_disctype_stays_unidentified(self, sample_job):
+        sample_job.video_type = "unknown"
+        sample_job.disctype = ""
         assert sample_job.type_subfolder == "unidentified"
 
 
@@ -290,9 +316,11 @@ class TestTypeSubfolderConfigurable:
         assert sample_job.type_subfolder == "Music/0.Rips"
 
     def test_unidentified_custom(self, sample_job, monkeypatch):
+        """Truly-unidentifiable rips (no video disctype) honor UNIDENTIFIED_SUBDIR."""
         import arm.config.config as cfg
         monkeypatch.setitem(cfg.arm_config, "UNIDENTIFIED_SUBDIR", "0.Inbox")
         sample_job.video_type = "unknown"
+        sample_job.disctype = "data"  # not dvd/bluray/uhd
         assert sample_job.type_subfolder == "0.Inbox"
 
     def test_build_final_path_uses_custom_movies_subdir(self, sample_job, monkeypatch):


### PR DESCRIPTION
## Summary
- \`Job.type_subfolder\` falls back to \`MOVIES_SUBDIR\` when video_type is not movie/series/music AND disctype is dvd/bluray/uhd.
- \`unidentified/\` is now reserved for genuinely unclassifiable content (data discs, mixed media, audio CDs without metadata).
- 4 new tests cover the new behavior + the unidentified-stays-unidentified path.

## Why
Surfaced 2026-05-07 deploying 18.0.0-rc on hifi: job 212 (Mysterysuspense DVD test rip with no OMDB match) landed at \`/nfs/files/Video/unidentified/Mysterysuspense/\` because video_type stayed \`unknown\` through the whole rip lifecycle. Most unidentified video discs are movies; reserving \`unidentified/\` for them forced operator triage on every test rip and breaks the user's library convention (\`Movies/0.Rips\`).

## Test plan
- [x] \`pytest test/test_job_model.py\` -> 44 passed
- [x] Full suite -> 2226 passed (+4 new tests)
- [ ] Smoke verify on hifi after deploy: a fresh DVD/Blu-ray rip without OMDB match lands under \`Movies/0.Rips/<title>/\`