### PR TITLE
fix(routing): per-track output_path defaults to MOVIES_SUBDIR for video discs

### DIFF
--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -75,6 +75,49 @@ JOB_STATUS_TRANSCODING = {
 }
 
 
+# Disctypes that we treat as video discs when routing to the completed
+# library. Anything not in this set (audio CDs without metadata, data
+# discs, mixed-content, blank disctype) lands in UNIDENTIFIED_SUBDIR
+# for operator triage.
+VIDEO_DISCTYPES = ("dvd", "bluray", "uhd")
+
+
+def resolve_type_subfolder(video_type, disctype):
+    """Pick the completed-library subfolder for a (video_type, disctype) pair.
+
+    Reads MOVIES_SUBDIR / TV_SUBDIR / AUDIO_SUBDIR / UNIDENTIFIED_SUBDIR
+    from arm.yaml so ARM honors the same library-tree organization the
+    transcoder uses. Falls back to legacy hardcoded defaults if
+    arm_config is unavailable (test-isolation safety net).
+
+    When video_type isn't a confirmed enum value (most commonly
+    ``"unknown"`` for DVDs/Blu-rays/UHDs that didn't get an OMDB match
+    before the rip started), fall back to MOVIES_SUBDIR for video
+    discs. Most unidentified video discs are movies; routing them to
+    ``unidentified/`` makes the operator triage every test rip.
+    ``unidentified/`` stays for genuinely unclassifiable content
+    (audio CDs without metadata, data discs).
+
+    Used by :py:attr:`Job.type_subfolder` for the job-level path AND by
+    the webhook builder (``arm.ripper.utils._build_webhook_payload``)
+    for per-track ``WebhookTrackMeta.output_path`` resolution.
+    """
+    import arm.config.config as cfg
+    config_dict = getattr(cfg, 'arm_config', {}) or {}
+    if video_type == "movie":
+        return config_dict.get("MOVIES_SUBDIR", "movies")
+    elif video_type == "series":
+        return config_dict.get("TV_SUBDIR", "tv")
+    elif video_type == "music":
+        return config_dict.get("AUDIO_SUBDIR", "music")
+    # Video disc without a confirmed type - default to MOVIES_SUBDIR.
+    # Audio CDs go through "music" via ripping/abcde, so they reach
+    # this branch only via the AUDIO_SUBDIR clause above.
+    if disctype in VIDEO_DISCTYPES:
+        return config_dict.get("MOVIES_SUBDIR", "movies")
+    return config_dict.get("UNIDENTIFIED_SUBDIR", "unidentified")
+
+
 class Job(db.Model):
     """
     Job Class hold most of the details for each job
@@ -442,35 +485,14 @@ class Job(db.Model):
 
     @property
     def type_subfolder(self):
-        """Map video_type to filesystem subfolder.
+        """Map this job's video_type+disctype to filesystem subfolder.
 
-        Reads MOVIES_SUBDIR / TV_SUBDIR / AUDIO_SUBDIR / UNIDENTIFIED_SUBDIR
-        from arm.yaml so ARM honors the same library-tree organization the
-        transcoder uses. Falls back to legacy hardcoded defaults if
-        arm_config is unavailable (test-isolation safety net).
-
-        When video_type isn't a confirmed enum value (most commonly
-        ``"unknown"`` for DVDs/Blu-rays/UHDs that didn't get an OMDB
-        match before the rip started), fall back to MOVIES_SUBDIR for
-        video discs. Most unidentified video discs are movies; routing
-        them to ``unidentified/`` makes the operator triage every test
-        rip. ``unidentified/`` stays for genuinely unclassifiable
-        content (audio CDs without metadata, data discs).
+        Delegates to :func:`resolve_type_subfolder` so the per-track
+        webhook routing in ``_build_webhook_payload`` can apply the same
+        rules (movie/series/music routing + video-disc fallback to
+        MOVIES_SUBDIR).
         """
-        import arm.config.config as cfg
-        config_dict = getattr(cfg, 'arm_config', {}) or {}
-        if self.video_type == "movie":
-            return config_dict.get("MOVIES_SUBDIR", "movies")
-        elif self.video_type == "series":
-            return config_dict.get("TV_SUBDIR", "tv")
-        elif self.video_type == "music":
-            return config_dict.get("AUDIO_SUBDIR", "music")
-        # Video disc without a confirmed type - default to MOVIES_SUBDIR.
-        # Audio CDs go through "music" via ripping/abcde, so they reach
-        # this branch only via the AUDIO_SUBDIR clause above.
-        if self.disctype in ("dvd", "bluray", "uhd"):
-            return config_dict.get("MOVIES_SUBDIR", "movies")
-        return config_dict.get("UNIDENTIFIED_SUBDIR", "unidentified")
+        return resolve_type_subfolder(self.video_type, self.disctype)
 
     def _pattern_fields_available(self):
         """Check if the structured fields needed for pattern rendering are populated.

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -270,17 +270,12 @@ def _build_webhook_payload(title, body, job, raw_basename):
 
         # Per-track output_path: pick the type subdir from THIS track's
         # video_type (multi-title discs can mix movie + series tracks),
-        # then join with the track's rendered folder. Mirrors
-        # Job.type_subfolder's lookup.
+        # then join with the track's rendered folder. Shares the
+        # job-level resolver so unidentified video discs default to
+        # MOVIES_SUBDIR for both top-level and per-track paths.
+        from arm.models.job import resolve_type_subfolder
         track_video_type = str(track.video_type or job.video_type or '')
-        if track_video_type == 'movie':
-            track_type_sub = (config_dict or {}).get('MOVIES_SUBDIR', 'movies')
-        elif track_video_type == 'series':
-            track_type_sub = (config_dict or {}).get('TV_SUBDIR', 'tv')
-        elif track_video_type == 'music':
-            track_type_sub = (config_dict or {}).get('AUDIO_SUBDIR', 'music')
-        else:
-            track_type_sub = (config_dict or {}).get('UNIDENTIFIED_SUBDIR', 'unidentified')
+        track_type_sub = resolve_type_subfolder(track_video_type, job.disctype)
         track_rendered_folder = r.get("rendered_folder", '')
         track_output_path = (
             os.path.join(track_type_sub, track_rendered_folder)

--- a/test/test_coverage_gaps_2.py
+++ b/test/test_coverage_gaps_2.py
@@ -316,6 +316,73 @@ class TestBuildWebhookPayload:
         assert payload["tracks"][0]["output_path"].startswith("Movies/0.Rips")
         assert payload["tracks"][1]["output_path"].startswith("TV/0.Rips")
 
+    def test_track_output_path_unknown_video_disc_defaults_to_movies(
+        self, app_context, job_with_tracks, monkeypatch,
+    ):
+        """An unidentified DVD/Blu-ray/UHD with no per-track video_type
+        routes each track to MOVIES_SUBDIR, not UNIDENTIFIED_SUBDIR.
+        Mirrors Job.type_subfolder's video-disc fallback so multi-title
+        discs don't get split between Movies/ and unidentified/."""
+        from arm.ripper.utils import _build_webhook_payload
+        import arm.config.config as cfg
+
+        monkeypatch.setattr(cfg, "arm_config", {
+            "RAW_PATH": "/home/arm/media/raw/",
+            "MOVIES_SUBDIR": "Movies/0.Rips",
+            "TV_SUBDIR": "TV/0.Rips",
+            "AUDIO_SUBDIR": "music",
+            "UNIDENTIFIED_SUBDIR": "unidentified",
+        })
+        job, tracks = job_with_tracks
+        # Simulate hifi job 213: DVD, no OMDB match, video_type stayed
+        # 'unknown' on both job and tracks.
+        job.video_type = "unknown"
+        job.disctype = "dvd"
+        for t in tracks:
+            t.video_type = None
+        db.session.commit()
+        db.session.refresh(job)
+
+        payload = _build_webhook_payload("Rip done", "body", job, "raw_dir")
+
+        # Job-level output_path uses MOVIES_SUBDIR (already covered by
+        # Job.type_subfolder tests but assert here for end-to-end clarity).
+        assert payload["output_path"].startswith("Movies/0.Rips")
+        # Per-track output_paths must use the same fallback.
+        for t in payload["tracks"]:
+            assert t["output_path"].startswith("Movies/0.Rips"), (
+                f"track output_path={t['output_path']} should default to "
+                "Movies/0.Rips for unidentified video discs"
+            )
+
+    def test_track_output_path_unknown_audio_disc_stays_unidentified(
+        self, app_context, job_with_tracks, monkeypatch,
+    ):
+        """Tracks on a non-video disc with unknown video_type stay in
+        UNIDENTIFIED_SUBDIR (no Movies fallback for data/CD/etc)."""
+        from arm.ripper.utils import _build_webhook_payload
+        import arm.config.config as cfg
+
+        monkeypatch.setattr(cfg, "arm_config", {
+            "RAW_PATH": "/home/arm/media/raw/",
+            "MOVIES_SUBDIR": "Movies/0.Rips",
+            "TV_SUBDIR": "TV/0.Rips",
+            "AUDIO_SUBDIR": "music",
+            "UNIDENTIFIED_SUBDIR": "unidentified",
+        })
+        job, tracks = job_with_tracks
+        job.video_type = "unknown"
+        job.disctype = "data"  # not dvd/bluray/uhd
+        for t in tracks:
+            t.video_type = None
+        db.session.commit()
+        db.session.refresh(job)
+
+        payload = _build_webhook_payload("Rip done", "body", job, "raw_dir")
+
+        for t in payload["tracks"]:
+            assert t["output_path"].startswith("unidentified")
+
 
 # ── transcode_callback tests ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Extracts the type-subfolder resolver to a module-level \`arm.models.job.resolve_type_subfolder(video_type, disctype)\` function.
- \`Job.type_subfolder\` now delegates to it.
- Webhook builder's per-track loop in \`arm/ripper/utils.py::_build_webhook_payload\` also uses it.
- Same fallback (unidentified DVD/Blu-ray/UHD -> \`MOVIES_SUBDIR\`) now applies at both job-level AND per-track-level paths.
- 2 new tests cover per-track unidentified-video-disc and unidentified-audio-disc paths.

## Why
PR #342 fixed \`Job.type_subfolder\` for the JOB-level path but the webhook builder had a separate, narrower per-track resolver. For multi-title discs the transcoder uses per-track \`output_path\`, not the job-level one — so unidentified DVDs still landed in \`unidentified/\`.

Surfaced on hifi job 213 (Mysterysuspense, dvd, video_type=unknown) deployed against the freshly-fixed 18.0.0-rc:
- Job-level: \`output_path=Movies/0.Rips/Mysterysuspense\` ✓
- Per-track: \`output_path=unidentified/Mysterysuspense\` ✗
- File landed at \`/nfs/files/Video/unidentified/Mysterysuspense/...\`

## Test plan
- [x] \`pytest test/test_coverage_gaps_2.py::TestBuildWebhookPayload\` -> 16 passed (+2 new)
- [x] \`pytest test/test_job_model.py\` -> 44 passed
- [x] Full suite -> 2228 passed (+2 new tests)
- [ ] Smoke verify on hifi after deploy: a fresh DVD/Blu-ray rip without OMDB match lands per-track under \`Movies/0.Rips/<title>/\`