### PR TITLE
fix(routing)!: unidentified video discs route to UNIDENTIFIED_SUBDIR

### DIFF
--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -75,13 +75,6 @@ JOB_STATUS_TRANSCODING = {
 }
 
 
-# Disctypes that we treat as video discs when routing to the completed
-# library. Anything not in this set (audio CDs without metadata, data
-# discs, mixed-content, blank disctype) lands in UNIDENTIFIED_SUBDIR
-# for operator triage.
-VIDEO_DISCTYPES = ("dvd", "bluray", "uhd")
-
-
 def resolve_type_subfolder(video_type, disctype):
     """Pick the completed-library subfolder for a (video_type, disctype) pair.
 
@@ -90,17 +83,20 @@ def resolve_type_subfolder(video_type, disctype):
     transcoder uses. Falls back to legacy hardcoded defaults if
     arm_config is unavailable (test-isolation safety net).
 
-    When video_type isn't a confirmed enum value (most commonly
-    ``"unknown"`` for DVDs/Blu-rays/UHDs that didn't get an OMDB match
-    before the rip started), fall back to MOVIES_SUBDIR for video
-    discs. Most unidentified video discs are movies; routing them to
-    ``unidentified/`` makes the operator triage every test rip.
-    ``unidentified/`` stays for genuinely unclassifiable content
-    (audio CDs without metadata, data discs).
+    Anything that is not a confirmed movie/series/music classification
+    lands in UNIDENTIFIED_SUBDIR. The operator picks up the rip from
+    the triage bucket, fills in metadata, and re-imports. UNIDENTIFIED_SUBDIR
+    is configurable so it can point anywhere the operator wants
+    (e.g. ``unidentified/``, ``Triage/``, ``Movies/0.Rips/Pending``).
 
     Used by :py:attr:`Job.type_subfolder` for the job-level path AND by
     the webhook builder (``arm.ripper.utils._build_webhook_payload``)
     for per-track ``WebhookTrackMeta.output_path`` resolution.
+
+    The ``disctype`` argument is retained for callers that pre-resolve
+    a track's effective video_type from ``track.video_type`` falling
+    back to ``job.disctype``; the resolver itself does not branch on
+    it.
     """
     import arm.config.config as cfg
     config_dict = getattr(cfg, 'arm_config', {}) or {}
@@ -110,11 +106,6 @@ def resolve_type_subfolder(video_type, disctype):
         return config_dict.get("TV_SUBDIR", "tv")
     elif video_type == "music":
         return config_dict.get("AUDIO_SUBDIR", "music")
-    # Video disc without a confirmed type - default to MOVIES_SUBDIR.
-    # Audio CDs go through "music" via ripping/abcde, so they reach
-    # this branch only via the AUDIO_SUBDIR clause above.
-    if disctype in VIDEO_DISCTYPES:
-        return config_dict.get("MOVIES_SUBDIR", "movies")
     return config_dict.get("UNIDENTIFIED_SUBDIR", "unidentified")
 
 

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -271,8 +271,8 @@ def _build_webhook_payload(title, body, job, raw_basename):
         # Per-track output_path: pick the type subdir from THIS track's
         # video_type (multi-title discs can mix movie + series tracks),
         # then join with the track's rendered folder. Shares the
-        # job-level resolver so unidentified video discs default to
-        # MOVIES_SUBDIR for both top-level and per-track paths.
+        # job-level resolver so unclassified tracks land in
+        # UNIDENTIFIED_SUBDIR for operator triage.
         from arm.models.job import resolve_type_subfolder
         track_video_type = str(track.video_type or job.video_type or '')
         track_type_sub = resolve_type_subfolder(track_video_type, job.disctype)

--- a/test/test_coverage_gaps_2.py
+++ b/test/test_coverage_gaps_2.py
@@ -316,13 +316,14 @@ class TestBuildWebhookPayload:
         assert payload["tracks"][0]["output_path"].startswith("Movies/0.Rips")
         assert payload["tracks"][1]["output_path"].startswith("TV/0.Rips")
 
-    def test_track_output_path_unknown_video_disc_defaults_to_movies(
+    def test_track_output_path_unknown_video_disc_lands_in_unidentified(
         self, app_context, job_with_tracks, monkeypatch,
     ):
         """An unidentified DVD/Blu-ray/UHD with no per-track video_type
-        routes each track to MOVIES_SUBDIR, not UNIDENTIFIED_SUBDIR.
-        Mirrors Job.type_subfolder's video-disc fallback so multi-title
-        discs don't get split between Movies/ and unidentified/."""
+        routes each track to UNIDENTIFIED_SUBDIR. The operator picks up
+        the rip from the triage bucket, fills in metadata, and re-imports
+        - presuming Movies on the wire misroutes series box-sets and
+        hides misclassification under the Movies tree."""
         from arm.ripper.utils import _build_webhook_payload
         import arm.config.config as cfg
 
@@ -345,21 +346,18 @@ class TestBuildWebhookPayload:
 
         payload = _build_webhook_payload("Rip done", "body", job, "raw_dir")
 
-        # Job-level output_path uses MOVIES_SUBDIR (already covered by
-        # Job.type_subfolder tests but assert here for end-to-end clarity).
-        assert payload["output_path"].startswith("Movies/0.Rips")
-        # Per-track output_paths must use the same fallback.
+        assert payload["output_path"].startswith("unidentified")
         for t in payload["tracks"]:
-            assert t["output_path"].startswith("Movies/0.Rips"), (
+            assert t["output_path"].startswith("unidentified"), (
                 f"track output_path={t['output_path']} should default to "
-                "Movies/0.Rips for unidentified video discs"
+                "unidentified for unclassified video discs"
             )
 
-    def test_track_output_path_unknown_audio_disc_stays_unidentified(
+    def test_track_output_path_unknown_data_disc_stays_unidentified(
         self, app_context, job_with_tracks, monkeypatch,
     ):
-        """Tracks on a non-video disc with unknown video_type stay in
-        UNIDENTIFIED_SUBDIR (no Movies fallback for data/CD/etc)."""
+        """Tracks on a data disc with unknown video_type stay in
+        UNIDENTIFIED_SUBDIR (same fallback as video discs)."""
         from arm.ripper.utils import _build_webhook_payload
         import arm.config.config as cfg
 
@@ -372,7 +370,7 @@ class TestBuildWebhookPayload:
         })
         job, tracks = job_with_tracks
         job.video_type = "unknown"
-        job.disctype = "data"  # not dvd/bluray/uhd
+        job.disctype = "data"
         for t in tracks:
             t.video_type = None
         db.session.commit()

--- a/test/test_job_model.py
+++ b/test/test_job_model.py
@@ -36,27 +36,27 @@ class TestTypeSubfolder:
         sample_job.video_type = "music"
         assert sample_job.type_subfolder == "music"
 
-    def test_unknown_video_disc_defaults_to_movies(self, sample_job):
-        """An unidentified DVD/Blu-ray/UHD routes to MOVIES_SUBDIR. Most
-        unidentified video discs are movies; reserving 'unidentified/'
-        for them would force operator triage on every test rip."""
+    def test_unknown_video_disc_lands_in_unidentified(self, sample_job):
+        """An unidentified DVD/Blu-ray/UHD routes to UNIDENTIFIED_SUBDIR.
+        The operator picks up the rip from the triage bucket, fills in
+        metadata, and re-imports; presuming 'movie' on the wire
+        misrouted series box-sets and hid misclassification under the
+        Movies tree."""
         sample_job.video_type = "unknown"
         sample_job.disctype = "bluray"
-        assert sample_job.type_subfolder == "movies"
+        assert sample_job.type_subfolder == "unidentified"
 
-    def test_unknown_dvd_defaults_to_movies(self, sample_job):
+    def test_unknown_dvd_lands_in_unidentified(self, sample_job):
         sample_job.video_type = "unknown"
         sample_job.disctype = "dvd"
-        assert sample_job.type_subfolder == "movies"
+        assert sample_job.type_subfolder == "unidentified"
 
-    def test_unknown_uhd_defaults_to_movies(self, sample_job):
+    def test_unknown_uhd_lands_in_unidentified(self, sample_job):
         sample_job.video_type = "unknown"
         sample_job.disctype = "uhd"
-        assert sample_job.type_subfolder == "movies"
+        assert sample_job.type_subfolder == "unidentified"
 
-    def test_unknown_non_video_disc_stays_unidentified(self, sample_job):
-        """Truly unclassifiable content (data discs, mixed media, no
-        disctype set) lands in unidentified/ for operator triage."""
+    def test_unknown_data_disc_stays_unidentified(self, sample_job):
         sample_job.video_type = "unknown"
         sample_job.disctype = "data"
         assert sample_job.type_subfolder == "unidentified"


### PR DESCRIPTION
## Summary

Reverts the video-disc fallback introduced in #342/#343. An unidentified DVD/Blu-ray/UHD now lands in \`UNIDENTIFIED_SUBDIR\` instead of \`MOVIES_SUBDIR\`.

The earlier fallback presumed unidentified video discs are movies and quietly routed them under \`Movies/\`. Three problems surfaced:

- A series box-set with no metadata match landed in \`Movies/\` with \`Track N\` filenames instead of \`Show SxxEyy.mkv\`. Operators had to notice + manually rework the whole rip.
- Operators lost the cheap "is anything stuck in unidentified/?" triage check; misclassified rips silently mixed with real movies.
- The UI inherited the same presumption, rendering "Movie" on a pill for content where ARM hadn't actually classified anything.

\`UNIDENTIFIED_SUBDIR\` is already operator-configurable via \`arm.yaml\` + env, so anyone who wants the old behavior can point it at \`Movies/0.Rips/Pending\` or similar.

Audio CDs and data discs are unaffected - they were never inside the removed \`VIDEO_DISCTYPES\` branch.

## Breaking change

Webhook \`output_path\` for unidentified video discs flips from \`MOVIES_SUBDIR/<title>\` to \`UNIDENTIFIED_SUBDIR/<title>\`. The 18.0.0-rc deployed on hifi has the wrong behavior; this revert lands before any 18.0.0 GA so the released wire never ships the fallback.

## Test plan

- [x] \`pytest test/\` - 2228 passed, 1 skipped, 39 deselected, 2 xfailed
- [ ] After build: redeploy 18.0.0-rc on hifi + transcoder-server
- [ ] Smoke test a labeled DVD with no OMDB match - rip should land at \`/nfs/files/Video/unidentified/<Title>/<Title> - Track N.mkv\`
- [ ] Confirm release-please #334 picks up this commit before merging GA