### PR TITLE
ci(prerelease): allow manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -12,6 +12,11 @@ on:
       - "Dockerfile"
       - "requirements*.txt"
       - "VERSION"
+  workflow_dispatch:
+    # Manual trigger to rebuild the RC from main between release-please
+    # PRs (e.g. after a chore(deps) bump that doesn't refresh the
+    # release-please PR). Reads VERSION from the dispatched ref and
+    # publishes <VERSION>-rc.
 
 permissions:
   contents: read
@@ -19,7 +24,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: prerelease-${{ github.head_ref }}
+  group: prerelease-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -28,7 +33,7 @@ env:
 
 jobs:
   prerelease:
-    if: startsWith(github.head_ref, 'release-please')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -73,6 +78,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}-rc
 
       - name: Find existing pre-release comment
+        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v4
         id: find-comment
         with:
@@ -81,6 +87,7 @@ jobs:
           body-includes: Pre-release image published
 
       - name: Comment on PR
+        if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

The publish-prerelease workflow only runs on release-please PRs. Commits that don't bump the release version (`chore(deps):`, `chore:`) don't refresh the release-please PR and so the RC image isn't rebuilt — meaning the RC drifts from main between release cycles.

Add `workflow_dispatch:` so an RC build can be triggered manually from main whenever needed.

## Test plan

- [x] YAML parses
- [ ] After merge: dispatch the workflow on `main`, confirm `automatic-ripping-machine:<version>-rc` is rebuilt