### PR TITLE
feat(folder): drop {success: true, ...} envelope from folder endpoints

### DIFF
--- a/arm/api/v1/folder.py
+++ b/arm/api/v1/folder.py
@@ -3,8 +3,7 @@ import logging
 import threading
 from typing import Optional
 
-from fastapi import APIRouter
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 import arm.config.config as cfg
@@ -30,6 +29,8 @@ __all__ = [
     "auto_disable_short_tracks",
     "FolderScanRequest",
     "FolderCreateRequest",
+    "FolderScanResult",
+    "FolderJobCreated",
     "scan_folder_endpoint",
     "create_folder_job",
 ]
@@ -53,53 +54,62 @@ class FolderCreateRequest(BaseModel):
     disc_total: Optional[int] = None
 
 
-@router.post("/jobs/folder/scan")
+class FolderScanResult(BaseModel):
+    """Folder scan response.
+
+    Mirrors the maintenance + jobs endpoints' invariant: HTTP status
+    carries the success/failure signal, the body carries the data.
+    Callers reading legacy `success`/`error` keys: failure paths now
+    return a FastAPI error envelope (`{"detail": "..."}`) with the
+    appropriate 4xx status code.
+    """
+    disc_type: str
+    label: Optional[str] = None
+    title_suggestion: Optional[str] = None
+    year_suggestion: Optional[str] = None
+    folder_size_bytes: int = 0
+    stream_count: int = 0
+    disc_number: Optional[int] = None
+    disc_total: Optional[int] = None
+    season: Optional[int] = None
+
+
+class FolderJobCreated(BaseModel):
+    """Folder import job creation response."""
+    job_id: int
+    status: str
+    source_type: str
+    source_path: str
+
+
+@router.post("/jobs/folder/scan", response_model=FolderScanResult)
 def scan_folder_endpoint(req: FolderScanRequest):
     """Scan a folder and return disc type and metadata. No job created."""
     ingress_path = cfg.arm_config.get("INGRESS_PATH", "")
     if not ingress_path:
-        return JSONResponse(
-            {"success": False, "error": "INGRESS_PATH not configured"},
-            status_code=400,
-        )
+        raise HTTPException(status_code=400, detail="INGRESS_PATH not configured")
     try:
-        result = scan_folder(req.path, ingress_path)
+        return scan_folder(req.path, ingress_path)
     except FileNotFoundError:
-        return JSONResponse(
-            {"success": False, "error": "Folder not found or path is not accessible"},
-            status_code=400,
-        )
+        raise HTTPException(status_code=400, detail="Folder not found or path is not accessible")
     except ValueError:
-        return JSONResponse(
-            {"success": False, "error": "Not a valid disc folder (no BDMV or VIDEO_TS structure found)"},
-            status_code=422,
-        )
-    return {"success": True, **result}
+        raise HTTPException(status_code=422, detail="Not a valid disc folder (no BDMV or VIDEO_TS structure found)")
 
 
-@router.post("/jobs/folder", status_code=201)
+@router.post("/jobs/folder", status_code=201, response_model=FolderJobCreated)
 def create_folder_job(req: FolderCreateRequest):
     """Create a folder import job in review state."""
     ingress_path = cfg.arm_config.get("INGRESS_PATH", "")
     if not ingress_path:
-        return JSONResponse(
-            {"success": False, "error": "INGRESS_PATH not configured"},
-            status_code=400,
-        )
+        raise HTTPException(status_code=400, detail="INGRESS_PATH not configured")
 
     # Validate path is under ingress root
     try:
         validate_ingress_path(req.source_path, ingress_path)
     except FileNotFoundError:
-        return JSONResponse(
-            {"success": False, "error": "Source folder not found"},
-            status_code=400,
-        )
+        raise HTTPException(status_code=400, detail="Source folder not found")
     except ValueError:
-        return JSONResponse(
-            {"success": False, "error": "Path is outside the configured ingress directory"},
-            status_code=400,
-        )
+        raise HTTPException(status_code=400, detail="Path is outside the configured ingress directory")
 
     # Check for duplicate active job with same source_path
     existing = Job.query.filter(
@@ -107,12 +117,9 @@ def create_folder_job(req: FolderCreateRequest):
         ~Job.finished,
     ).first()
     if existing:
-        return JSONResponse(
-            {
-                "success": False,
-                "error": f"Active job already exists for this path (job_id={existing.job_id})",
-            },
+        raise HTTPException(
             status_code=409,
+            detail=f"Active job already exists for this path (job_id={existing.job_id})",
         )
 
     # Create job
@@ -137,7 +144,6 @@ def create_folder_job(req: FolderCreateRequest):
     thread.start()
 
     return {
-        "success": True,
         "job_id": job.job_id,
         "status": job.status,
         "source_type": job.source_type,

--- a/test/test_folder_api.py
+++ b/test/test_folder_api.py
@@ -44,7 +44,9 @@ class TestFolderScan:
         resp = client.post("/api/v1/jobs/folder/scan", json={"path": "/ingress/movie"})
         assert resp.status_code == 200
         data = resp.json()
-        assert data["success"] is True
+        # Wire shape: HTTP status carries success/failure; body is the
+        # FolderScanResult model. No `success` envelope as of v18.
+        assert "success" not in data
         assert data["disc_type"] == "bluray"
         mock_scan.assert_called_once_with("/ingress/movie", "/ingress")
 
@@ -58,7 +60,7 @@ class TestFolderScan:
 
         resp = client.post("/api/v1/jobs/folder/scan", json={"path": "/some/path"})
         assert resp.status_code == 400
-        assert "INGRESS_PATH" in resp.json()["error"]
+        assert "INGRESS_PATH" in resp.json()["detail"]
 
     @patch("arm.api.v1.folder.cfg")
     @patch("arm.api.v1.folder.scan_folder", side_effect=FileNotFoundError("Path does not exist"))
@@ -119,7 +121,8 @@ class TestFolderCreate:
         })
         assert resp.status_code == 201
         data = resp.json()
-        assert data["success"] is True
+        # Wire shape: 201 carries success; no `success` envelope as of v18.
+        assert "success" not in data
         assert data["job_id"] == 42
         assert data["source_type"] == "folder"
         assert data["status"] == "identifying"
@@ -185,7 +188,7 @@ class TestFolderCreate:
             "disctype": "bluray",
         })
         assert resp.status_code == 409
-        assert "Active job already exists" in resp.json()["error"]
+        assert "Active job already exists" in resp.json()["detail"]
 
     @patch("arm.api.v1.folder.validate_ingress_path", side_effect=FileNotFoundError("not found"))
     @patch("arm.api.v1.folder.cfg")
@@ -204,7 +207,7 @@ class TestFolderCreate:
             "disctype": "bluray",
         })
         assert resp.status_code == 400
-        assert "Source folder not found" in resp.json()["error"]
+        assert "Source folder not found" in resp.json()["detail"]
 
     @patch("arm.api.v1.folder.threading")
     @patch("arm.api.v1.folder.db")
@@ -241,7 +244,7 @@ class TestFolderCreate:
         })
         assert resp.status_code == 201
         data = resp.json()
-        assert data["success"] is True
+        assert "success" not in data
         assert data["job_id"] == 55
         # Verify season fields
         assert mock_job.season == "1"


### PR DESCRIPTION
## Summary

POST \`/api/v1/jobs/folder/scan\` and POST \`/api/v1/jobs/folder\` now return typed Pydantic models (\`FolderScanResult\`, \`FolderJobCreated\`) and use \`HTTPException\` for error paths. The success/failure signal is the HTTP status code; the body is the data. Brings the folder endpoints in line with the rest of the v18 maintenance + jobs surface (\`feedback_arm_neu_response_shape_drift\`).

## Why

The two folder endpoints were the last v18 endpoints still emitting the legacy \`{"success": True, ...}\` envelope while every sibling endpoint (maintenance, jobs, transcoder) had been cleaned up in PR #322. The mixed convention forced the BFF to handle two different patterns and made the schema inconsistent for the codegen pipeline.

## Wire compatibility

Non-breaking on the consumer side. Verified:

- arm-ui's BFF \`FolderScanResult\` and \`FolderCreateResponse\` Pydantic models declared \`success: bool = True\` as optional, so absence is silently filled with \`True\`. \`extra="ignore"\` was already in place.
- arm-ui's frontend \`ImportWizard.svelte\` does not read \`.success\` - errors are surfaced via \`httpx.HTTPStatusError\` to \`apiFetch\` throw. The frontend \`apiFetch\` already reads \`body.detail\` from FastAPI error envelopes; arm-ui's BFF \`arm_client._parse_error_response\` already accepts both \`error\` and \`detail\`.

If anything in arm-ui still reads \`response.success\`, it'll see \`True\` (the model default), not break. There are no production callers that would.

## Implementation

- \`arm/api/v1/folder.py\`: 
  - New \`FolderScanResult\` and \`FolderJobCreated\` response models.
  - \`@router.post\` decorators now declare \`response_model=\`.
  - Error paths switched from \`JSONResponse({"success": False, "error": ...})\` to \`raise HTTPException(status_code=..., detail=...)\`. Cleaner, FastAPI-native, and matches the rest of the v18 surface.
  - \`__all__\` extended with the new model names.
- \`test/test_folder_api.py\`: tests updated to assert no \`success\` key in success responses and \`detail\` instead of \`error\` in error responses.

## Test plan

- [x] \`pytest test/test_folder_api.py\` - 15/15.
- [x] Full suite \`pytest test/\` - 2228 passed, 1 skipped, 39 deselected, 2 xfailed.
- [ ] Smoke: ImportWizard folder import flow on hifi (companion arm-ui PR not needed; consumer is already shape-tolerant).