### PR TITLE
feat(metadata): unify key-test endpoints under /metadata/test-key

### DIFF
--- a/arm/api/v1/metadata.py
+++ b/arm/api/v1/metadata.py
@@ -64,9 +64,16 @@ async def get_music_detail(release_id: str):
 @router.get("/test-key")
 async def test_metadata_key(
     key: str | None = Query(None, description="API key to test (uses saved config if omitted)"),
-    provider: str | None = Query(None, description="Provider to test against: omdb or tmdb (uses saved config if omitted)"),
+    provider: str | None = Query(None, description="Provider to test: omdb, tmdb, tvdb, or makemkv (uses METADATA_PROVIDER from arm.yaml if omitted)"),
 ):
-    """Test a metadata API key by making a real API call."""
+    """Test an external-service API key by making a real upstream call.
+
+    Unified endpoint covering OMDB, TMDB, TVDB, and MakeMKV; returns
+    ``{success, message, provider, checked_at}``. ``checked_at`` is
+    ``None`` for the metadata providers (no caching) and the AppState
+    timestamp for makemkv. The legacy ``POST /system/makemkv-key-check``
+    is retained as a deprecated alias.
+    """
     return await test_configured_key(override_key=key, override_provider=provider)
 
 

--- a/arm/api/v1/system.py
+++ b/arm/api/v1/system.py
@@ -272,9 +272,6 @@ def get_paths():
     return results
 
 
-from arm.ripper.makemkv import prep_mkv
-
-
 @router.post('/system/ripping-enabled')
 def set_ripping_enabled(body: dict):
     """Toggle global ripping pause."""
@@ -294,37 +291,28 @@ def set_ripping_enabled(body: dict):
     }
 
 
-@router.post('/system/makemkv-key-check')
-def check_makemkv_key():
-    """Run prep_mkv() to validate/update the MakeMKV key."""
-    from arm.ripper.makemkv import UpdateKeyRunTimeError, UpdateKeyErrorCodes
+@router.post('/system/makemkv-key-check', deprecated=True)
+async def check_makemkv_key():
+    """Validate/update the MakeMKV key.
 
-    message = "MakeMKV key is valid"
-    try:
-        prep_mkv()
-    except UpdateKeyRunTimeError as exc:
-        code = UpdateKeyErrorCodes(exc.returncode)
-        messages = {
-            UpdateKeyErrorCodes.URL_ERROR: (
-                "Could not reach forum.makemkv.com — set MAKEMKV_PERMA_KEY "
-                "in arm.yaml to use a purchased key"
-            ),
-            UpdateKeyErrorCodes.PARSE_ERROR: "MakeMKV settings file is corrupt",
-            UpdateKeyErrorCodes.INTERNAL_ERROR: "Key update script produced invalid output",
-            UpdateKeyErrorCodes.INVALID_MAKEMKV_SERIAL: (
-                "Invalid MakeMKV serial key format — should match M-XXXX-..."
-            ),
-        }
-        message = messages.get(code, f"Key update failed (error {code.name})")
+    .. deprecated::
+        Use ``GET /api/v1/metadata/test-key?provider=makemkv`` instead.
+        This endpoint is retained as an alias for one release window so
+        existing arm-ui versions keep working.
 
-    state = AppState.get()
+    Returns the legacy ``{key_valid, checked_at, message}`` shape; the
+    unified endpoint returns the cross-provider
+    ``{success, message, provider, checked_at}`` shape.
+    """
+    from arm.services.metadata import test_configured_key
+
+    result = await test_configured_key(override_provider="makemkv")
+    # Translate to the legacy shape so existing consumers don't break
+    # mid-deploy. The unified endpoint is the new path.
     return {
-        "key_valid": state.makemkv_key_valid,
-        "checked_at": (
-            state.makemkv_key_checked_at.isoformat()
-            if state.makemkv_key_checked_at else None
-        ),
-        "message": message,
+        "key_valid": result["success"],
+        "checked_at": result["checked_at"],
+        "message": result["message"],
     }
 
 

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -111,23 +111,101 @@ async def _test_omdb_key(key: str) -> dict[str, str]:
 
 
 async def test_configured_key(override_key: str | None = None, override_provider: str | None = None) -> dict[str, Any]:
-    """Test a metadata API key. Uses overrides if given, else the saved config."""
+    """Test a metadata / external-service API key.
+
+    Supports four providers via the unified
+    ``{success, message, provider, checked_at}`` shape:
+
+    - ``omdb`` / ``tmdb`` - hits the upstream search API once
+    - ``tvdb`` - delegates to ``arm.services.tvdb.validate_tvdb_key`` (login round-trip)
+    - ``makemkv`` - runs ``prep_mkv()`` synchronously via the executor
+
+    ``checked_at`` is ``None`` for the metadata providers (no caching);
+    for ``makemkv`` it carries the AppState timestamp, mirroring the
+    legacy ``/system/makemkv-key-check`` shape so the Settings panel can
+    surface "last validated at" without an extra round-trip.
+    """
     keys = _get_keys()
-    provider = override_provider or keys["provider"]
+    provider = (override_provider or keys["provider"]).lower()
+
+    if provider == "tvdb":
+        return await _test_tvdb_provider(override_key)
+    if provider == "makemkv":
+        return await _test_makemkv_provider()
+
+    # OMDB / TMDB path
     key = override_key or (keys["tmdb_key"] if provider == "tmdb" else keys["omdb_key"])
     if not key or not key.strip():
-        return {"success": False, "message": f"No API key configured for {provider.upper()}", "provider": provider}
+        return {
+            "success": False,
+            "message": f"No API key configured for {provider.upper()}",
+            "provider": provider,
+            "checked_at": None,
+        }
     try:
         result = await (_test_tmdb_key(key.strip()) if provider == "tmdb" else _test_omdb_key(key.strip()))
         result["provider"] = provider
+        result["checked_at"] = None
         return result
     except httpx.TimeoutException:
-        return {"success": False, "message": "Request timed out \u2014 check network connectivity", "provider": provider}
+        return {"success": False, "message": "Request timed out - check network connectivity", "provider": provider, "checked_at": None}
     except httpx.ConnectError:
-        return {"success": False, "message": "Cannot connect to API \u2014 check network/DNS", "provider": provider}
+        return {"success": False, "message": "Cannot connect to API - check network/DNS", "provider": provider, "checked_at": None}
     except Exception as exc:
         log.warning("Metadata key test failed: %s", exc)
-        return {"success": False, "message": f"Test failed: {type(exc).__name__}", "provider": provider}
+        return {"success": False, "message": f"Test failed: {type(exc).__name__}", "provider": provider, "checked_at": None}
+
+
+async def _test_tvdb_provider(override_key: str | None) -> dict[str, Any]:
+    """Validate TVDB key via login round-trip; reuses arm.services.tvdb."""
+    from arm.services.tvdb import validate_tvdb_key
+    key = override_key or cfg.arm_config.get("TVDB_API_KEY") or ""
+    result = await validate_tvdb_key(key)
+    result["provider"] = "tvdb"
+    result["checked_at"] = None
+    return result
+
+
+async def _test_makemkv_provider() -> dict[str, Any]:
+    """Run prep_mkv() in the default executor; mirrors /system/makemkv-key-check.
+
+    Same translation table for UpdateKeyErrorCodes as the legacy
+    /system/makemkv-key-check route, plus the AppState ``checked_at``
+    timestamp so the consolidated endpoint can replace the old one.
+    """
+    import asyncio
+    from arm.models.app_state import AppState
+    from arm.ripper.makemkv import UpdateKeyErrorCodes, UpdateKeyRunTimeError, prep_mkv
+
+    message = "MakeMKV key is valid"
+    try:
+        # prep_mkv() is sync + can fork; run via executor to avoid
+        # blocking the event loop (per feedback_preflight_event_loop_blocking).
+        await asyncio.get_running_loop().run_in_executor(None, prep_mkv)
+    except UpdateKeyRunTimeError as exc:
+        code = UpdateKeyErrorCodes(exc.returncode)
+        messages = {
+            UpdateKeyErrorCodes.URL_ERROR: (
+                "Could not reach forum.makemkv.com - set MAKEMKV_PERMA_KEY "
+                "in arm.yaml to use a purchased key"
+            ),
+            UpdateKeyErrorCodes.PARSE_ERROR: "MakeMKV settings file is corrupt",
+            UpdateKeyErrorCodes.INTERNAL_ERROR: "Key update script produced invalid output",
+            UpdateKeyErrorCodes.INVALID_MAKEMKV_SERIAL: (
+                "Invalid MakeMKV serial key format - should match M-XXXX-..."
+            ),
+        }
+        message = messages.get(code, f"Key update failed (error {code.name})")
+
+    # AppState.makemkv_key_valid is the canonical truth - prep_mkv()
+    # writes to it on success/failure regardless of whether it raised.
+    state = AppState.get()
+    return {
+        "success": bool(state.makemkv_key_valid),
+        "message": message,
+        "provider": "makemkv",
+        "checked_at": state.makemkv_key_checked_at.isoformat() if state.makemkv_key_checked_at else None,
+    }
 
 
 async def search(query: str, year: str | None = None, page: int = 1) -> list[dict[str, Any]]:

--- a/test/test_makemkv_key_api.py
+++ b/test/test_makemkv_key_api.py
@@ -50,7 +50,7 @@ class TestMakemkvKeyCheck:
     """POST /api/v1/system/makemkv-key-check endpoint."""
 
     def test_success_returns_valid(self, client, app_state):
-        with unittest.mock.patch("arm.api.v1.system.prep_mkv") as mock_prep:
+        with unittest.mock.patch("arm.ripper.makemkv.prep_mkv") as mock_prep:
             mock_prep.return_value = None
             # Simulate what prep_mkv does internally
             app_state.makemkv_key_valid = True
@@ -66,7 +66,7 @@ class TestMakemkvKeyCheck:
     def test_failure_returns_invalid(self, client, app_state):
         from arm.ripper.makemkv import UpdateKeyRunTimeError
 
-        with unittest.mock.patch("arm.api.v1.system.prep_mkv") as mock_prep:
+        with unittest.mock.patch("arm.ripper.makemkv.prep_mkv") as mock_prep:
             mock_prep.side_effect = UpdateKeyRunTimeError(
                 40, ["bash", "/opt/arm/scripts/update_key.sh"], output=""
             )

--- a/test/test_metadata_service.py
+++ b/test/test_metadata_service.py
@@ -1245,6 +1245,90 @@ class TestConfiguredKey:
         assert result["success"] is False
         assert "invalid response" in result["message"].lower()
 
+    # --- TVDB branch ---
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'TVDB_API_KEY': 'tvdb_secret',
+    })
+    def test_tvdb_provider_delegates_to_validate_tvdb_key(self):
+        """provider=tvdb override calls arm.services.tvdb.validate_tvdb_key."""
+        from arm.services.metadata import test_configured_key
+        with unittest.mock.patch(
+            'arm.services.tvdb.validate_tvdb_key',
+            new=unittest.mock.AsyncMock(return_value={"success": True, "message": "TVDB API key is valid"}),
+        ) as mock_validate:
+            result = _run(test_configured_key(override_provider='tvdb'))
+        mock_validate.assert_awaited_once_with('tvdb_secret')
+        assert result == {
+            "success": True,
+            "message": "TVDB API key is valid",
+            "provider": "tvdb",
+            "checked_at": None,
+        }
+
+    @unittest.mock.patch.dict('arm.config.config.arm_config', {
+        'METADATA_PROVIDER': 'omdb', 'TVDB_API_KEY': '',
+    })
+    def test_tvdb_uses_override_key(self):
+        """override_key wins over saved TVDB_API_KEY."""
+        from arm.services.metadata import test_configured_key
+        with unittest.mock.patch(
+            'arm.services.tvdb.validate_tvdb_key',
+            new=unittest.mock.AsyncMock(return_value={"success": False, "message": "Invalid TVDB API key"}),
+        ) as mock_validate:
+            result = _run(test_configured_key(override_key='user-supplied', override_provider='tvdb'))
+        mock_validate.assert_awaited_once_with('user-supplied')
+        assert result["provider"] == "tvdb"
+        assert result["success"] is False
+
+    # --- MakeMKV branch ---
+
+    def test_makemkv_provider_success(self):
+        """prep_mkv() returning normally + state.makemkv_key_valid=True is success."""
+        from arm.services.metadata import test_configured_key
+        from datetime import datetime, timezone
+
+        mock_state = unittest.mock.MagicMock()
+        mock_state.makemkv_key_valid = True
+        mock_state.makemkv_key_checked_at = datetime(2026, 5, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+        with (
+            unittest.mock.patch('arm.ripper.makemkv.prep_mkv') as mock_prep,
+            unittest.mock.patch('arm.models.app_state.AppState.get', return_value=mock_state),
+        ):
+            mock_prep.return_value = None
+            result = _run(test_configured_key(override_provider='makemkv'))
+
+        assert result["success"] is True
+        assert result["provider"] == "makemkv"
+        assert result["message"] == "MakeMKV key is valid"
+        assert result["checked_at"] is not None
+
+    def test_makemkv_provider_runtime_error(self):
+        """UpdateKeyRunTimeError translates to a friendly message and success=False."""
+        from arm.services.metadata import test_configured_key
+        from arm.ripper.makemkv import UpdateKeyRunTimeError, UpdateKeyErrorCodes
+
+        mock_state = unittest.mock.MagicMock()
+        mock_state.makemkv_key_valid = False
+        mock_state.makemkv_key_checked_at = None
+
+        with (
+            unittest.mock.patch('arm.ripper.makemkv.prep_mkv') as mock_prep,
+            unittest.mock.patch('arm.models.app_state.AppState.get', return_value=mock_state),
+        ):
+            mock_prep.side_effect = UpdateKeyRunTimeError(
+                UpdateKeyErrorCodes.URL_ERROR.value,
+                ["bash", "/opt/arm/scripts/update_key.sh"],
+                output="",
+            )
+            result = _run(test_configured_key(override_provider='makemkv'))
+
+        assert result["success"] is False
+        assert result["provider"] == "makemkv"
+        assert "forum.makemkv.com" in result["message"]
+        assert result["checked_at"] is None
+
 
 # ---------------------------------------------------------------------------
 # _omdb_search — fallback ?t= auth error


### PR DESCRIPTION
## Summary

Consolidates the three differently-shaped key-test endpoints into one. \`GET /api/v1/metadata/test-key?provider=X\` now covers OMDB, TMDB, TVDB, and MakeMKV with a unified \`{success, message, provider, checked_at}\` response shape.

## Why

Settings page key-test buttons hit:
- \`GET /metadata/test-key\` for OMDB/TMDB (returns \`{success, message, provider}\`)
- \`POST /system/makemkv-key-check\` for MakeMKV (returns \`{key_valid, checked_at, message}\` - different shape)
- nothing at all for TVDB (\`validate_tvdb_key\` was internal-only)

The mix forced the frontend to normalize three response shapes and left TVDB without a user-facing key validator.

## Implementation

- \`arm/services/metadata.py:test_configured_key()\`: extended to dispatch on \`provider in {omdb, tmdb, tvdb, makemkv}\`.
  - **TVDB:** new \`_test_tvdb_provider()\` delegates to \`arm.services.tvdb.validate_tvdb_key\` (login round-trip; doesn't pollute the \`_ensure_token\` cache).
  - **MakeMKV:** new \`_test_makemkv_provider()\` runs \`prep_mkv()\` via \`run_in_executor\` (avoids blocking the event loop per \`feedback_preflight_event_loop_blocking\`) and returns AppState.makemkv_key_valid + makemkv_key_checked_at.
  - OMDB/TMDB now also include \`checked_at: None\` for shape parity.
- \`arm/api/v1/metadata.py\`: \`/test-key\` endpoint docstring + Query description updated to advertise all four providers.
- \`arm/api/v1/system.py:check_makemkv_key\`: marked \`deprecated=True\`. Now delegates to the unified endpoint and translates back to the legacy \`{key_valid, checked_at, message}\` shape so existing arm-ui versions keep working through one release window.
- Removed unused \`from arm.ripper.makemkv import prep_mkv\` from system.py.

## Wire compatibility

- arm-ui versions that hit \`POST /system/makemkv-key-check\`: continue to work via the deprecated alias.
- arm-ui versions that hit \`GET /metadata/test-key?provider=omdb|tmdb\`: continue to work; response gains a \`checked_at: null\` field.
- TVDB testing: now possible from the API; companion arm-ui PR will surface a button.

## Test plan

- [x] 4 new \`TestConfiguredKey\` cases for tvdb (provider-resolved + override-key) and makemkv (success path + \`UpdateKeyRunTimeError\` -> friendly message).
- [x] \`test_makemkv_key_api.py\` patches updated to target \`arm.ripper.makemkv.prep_mkv\` (the actual definition site, since the alias delegates rather than importing prep_mkv at module level).
- [x] Full suite: 2232/2232 passed.
- [ ] Visual: existing arm-ui Settings panel buttons still work (OMDB/TMDB/MakeMKV); curl \`GET /api/v1/metadata/test-key?provider=tvdb\` returns the expected shape on hifi.

## Companion arm-ui work

Collapsing the per-provider Settings buttons to a single iteration is a follow-up arm-ui PR. Until that lands the existing buttons keep working since the OMDB/TMDB/MakeMKV endpoints all still respond.