### PR TITLE
fix(import): deselect-delete must skip filenames a kept track now claims

### DIFF
--- a/arm/ripper/folder_ripper.py
+++ b/arm/ripper/folder_ripper.py
@@ -149,11 +149,30 @@ def _remove_deselected_track_files(job, rawpath):
     the user's per-track process=False choice in review must still win.
     Reconciliation runs first so each output file is matched to a track
     row, making process==False the authoritative discard signal.
+
+    Filename collision guard: prescan seeds every track row with a
+    sequentially-numbered filename ('Annihilation_t00.mkv' .. '_t69.mkv').
+    After MakeMKV's 'all' rip and _reconcile_filenames, the kept tracks'
+    filenames are renumbered to match disk ('_t03.mkv' -> '_t00.mkv'),
+    but deselected tracks retain their stale prescan filenames. Without
+    the kept-filename guard those stale strings collide with the kept
+    files on disk and the rip output gets deleted out from under us.
     """
     if not os.path.isdir(rawpath):
         return
+    kept_filenames = {
+        t.filename for t in job.tracks
+        if t.process is not False and t.filename
+    }
     for track in job.tracks:
         if track.process is not False or not track.filename:
+            continue
+        if track.filename in kept_filenames:
+            log.debug(
+                "Skipping deselected track #%s filename %s: claimed by a "
+                "kept track after reconciliation",
+                track.track_number, track.filename,
+            )
             continue
         fpath = os.path.join(rawpath, track.filename)
         if not os.path.isfile(fpath):

--- a/test/test_folder_ripper.py
+++ b/test/test_folder_ripper.py
@@ -338,3 +338,61 @@ class TestRipFolder:
 
         assert kept.exists(), "kept track file should not be deleted"
         assert not dropped.exists(), "deselected track file should be removed"
+
+    @patch("arm.ripper.folder_ripper.db")
+    @patch("arm.ripper.folder_ripper._reconcile_filenames")
+    @patch("arm.ripper.makemkv.run")
+    @patch("arm.ripper.folder_ripper.prescan_track_info")
+    @patch("arm.ripper.folder_ripper.prep_mkv")
+    def test_deselected_filename_collision_with_kept_track(
+        self, mock_prep, mock_prescan, mock_run,
+        mock_reconcile, mock_db, tmp_path
+    ):
+        """Deselect-delete must skip filenames that a kept track now claims.
+
+        Repro on hifi 18.1.0-rc job 220 ("Annihilation" 4K BD import):
+        prescan seeded 70 tracks with sequential filenames _t00..._t69.
+        Auto-disable flipped 68 short tracks to process=False (including
+        track #0 with stale filename 'Annihilation_t00.mkv'). MakeMKV's
+        'all' rip produced 2 output files which got renamed by
+        reconciliation (kept track #3 -> '_t00.mkv'). The deselect-delete
+        loop then deleted '_t00.mkv' off disk because deselected track #0
+        still pointed at that filename - destroying the kept rip output
+        and 413-ing the transcoder handoff.
+        """
+        from arm.ripper.folder_ripper import rip_folder
+
+        rawpath = tmp_path / "raw" / "Test Movie"
+        rawpath.mkdir(parents=True)
+        # Only the renamed kept-track file exists on disk after MakeMKV +
+        # reconciliation. The deselected track row's stale filename
+        # collides with this exact path.
+        kept_after_rename = rawpath / "Annihilation_t00.mkv"
+        kept_after_rename.write_bytes(b"the actual rip output")
+
+        job = self._make_job(tmp_path)
+        # Kept track was renamed by reconciliation: '_t03.mkv' -> '_t00.mkv'.
+        kept_track = MagicMock(
+            track_number="3", filename="Annihilation_t00.mkv",
+            process=True, length=8000,
+        )
+        # Deselected track still has its prescan filename, which now
+        # collides with the kept track's renamed filename.
+        deselected_with_collision = MagicMock(
+            track_number="0", filename="Annihilation_t00.mkv",
+            process=False, length=7,
+        )
+        job.tracks = [kept_track, deselected_with_collision]
+        mock_run.return_value = iter([])
+
+        with patch("arm.ripper.folder_ripper.setup_rawpath", return_value=str(rawpath)), \
+             patch("arm.ripper.folder_ripper.cfg") as mock_cfg, \
+             patch("arm.ripper.arm_ripper._post_rip_handoff"):
+            mock_cfg.arm_config = {"TRANSCODER_URL": ""}
+            rip_folder(job)
+
+        assert kept_after_rename.exists(), (
+            "kept track's renamed output must NOT be deleted by the "
+            "deselect-delete loop just because a deselected track row "
+            "still points at the same filename"
+        )


### PR DESCRIPTION
## Summary
- Fixes a data-loss regression in folder + ISO imports where a deselected track row's stale filename collides with a kept track's reconciled filename, causing _remove_deselected_track_files to delete the kept rip output
- Adds a regression test that reproduces the exact 18.1.0-rc hifi failure on job 220

## Reproduction
hifi 18.1.0-rc job 220 ('Annihilation' 4K BD import, 70 disc titles):

1. Prescan seeds 70 tracks with sequential filenames \`Annihilation_t00.mkv .. _t69.mkv\` and length values from MakeMKV info.
2. \`auto_disable_short_tracks\` flips 68 tracks to \`process=False\` (length < 600s minlength). One of them is track_number=0 with stale filename \`Annihilation_t00.mkv\`.
3. MakeMKV 'all' rip produces 2 output files: titles #3 and #61, renumbered on disk to \`_t00.mkv\` and \`_t01.mkv\`.
4. \`_reconcile_filenames\` updates the **kept** tracks via title_map: track #3 -> \`_t00.mkv\`, track #61 -> \`_t01.mkv\`. The deselected rows keep their prescan filenames.
5. \`_remove_deselected_track_files\` walks \`job.tracks\`, finds deselected track #0 with filename \`Annihilation_t00.mkv\` and deselected track #1 with filename \`Annihilation_t01.mkv\`, sees both files on disk, **deletes them** - destroying the kept rip output.
6. rsync transfers the residual sub-second ghost files; transcoder webhook fires with empty input dir; transcoder logs 'No video or audio files found'.

Log evidence:
\`\`\`
Reconciled track #3 by title_map (output 0 -> title 3): 'Annihilation_t03.mkv' -> 'Annihilation_t00.mkv'
Reconciled track #61 by title_map (output 1 -> title 61): 'Annihilation_t61.mkv' -> 'Annihilation_t01.mkv'
Removed deselected track #0 output: Annihilation_t00.mkv  <-- BUG: kept track #3's output
Removed deselected track #1 output: Annihilation_t01.mkv  <-- BUG: kept track #61's output
Ripped 0 of 70 tracks to /home/arm/scratch/raw/de11c018-...
\`\`\`

## Fix
Build the set of filenames any kept track claims after reconciliation; skip those names in the deselect-delete loop. A deselected row whose stale filename collides with a renamed kept file means reconciliation handed that disk file to the kept track, not to us; deleting it would destroy real rip output.

## Test plan
- [x] New regression test reproduces the prod failure (asserts kept \`_t00.mkv\` survives even when a deselected row also points at \`_t00.mkv\`); fails on main, passes with fix
- [x] All existing folder_ripper tests still pass (12/12)
- [x] Full backend suite green (2233 / 1 skipped / 2 xfail / 39 deselected)
- [ ] Re-run a multi-title 4K BD import on hifi after deploy and verify the rip files reach \`/home/arm/media/raw/<guid>/\` non-empty