### PR TITLE
feat(rsync): unified helper with copy-progress side-file

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -992,8 +992,8 @@ def get_job_track_counts(job_id: int):
 def get_job_progress_state(job_id: int):
     """Return the small bundle of job fields the UI's progress endpoint needs:
     track counts plus disctype / logfile / no_of_titles, plus realtime
-    MakeMKV PRGV progress and abcde music progress parsed from the
-    progress + log files. One round-trip instead of three.
+    MakeMKV PRGV progress, abcde music progress, and rsync copy progress
+    parsed from the progress + log files. One round-trip instead of three.
     """
     job = Job.query.get(job_id)
     if not job:
@@ -1002,6 +1002,7 @@ def get_job_progress_state(job_id: int):
 
     rip = progress_reader.get_rip_progress(job_id)
     music = progress_reader.get_music_progress(job.logfile, job.no_of_titles or 0)
+    copy = progress_reader.get_copy_progress(job_id)
 
     return JobProgressState(
         track_counts=TrackCounts(**counts),
@@ -1013,6 +1014,8 @@ def get_job_progress_state(job_id: int):
         tracks_ripped_realtime=rip["tracks_ripped"],
         music_progress=music["progress"],
         music_stage=music["stage"],
+        copy_progress=copy["progress"],
+        copy_stage=copy["stage"],
     ).model_dump(mode="json")
 
 

--- a/arm/ripper/rsync_helper.py
+++ b/arm/ripper/rsync_helper.py
@@ -15,6 +15,7 @@ import logging
 import os
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 from typing import Callable
 
@@ -51,9 +52,12 @@ def run_rsync_sync(
                  a snippet of stderr.
 
     Behaviour:
-        Stdout is read line-by-line, splitting on both \\r and \\n. The
-        line-buffered iteration drains the pipe continuously, preventing
-        the 64KB-pipe-buffer-fills-and-rsync-blocks failure mode.
+        Stdout is read line-by-line; under text=True universal newlines
+        already translates rsync's \\r progress-overwrites to \\n, so the
+        helper splits on \\n. Stderr is drained concurrently in a daemon
+        thread so a verbose stderr (e.g. permission errors across many
+        files) cannot fill its 64KB pipe buffer and deadlock rsync while
+        we wait on stdout.
     """
     src_path = Path(src)
     if not src_path.exists():
@@ -84,31 +88,46 @@ def run_rsync_sync(
         stderr=subprocess.PIPE,
         bufsize=1,  # line-buffered
         text=True,
-        # universal_newlines=True splits on \r\n; we want \r preserved so
-        # we read raw and split ourselves.
     )
 
+    # Drain stderr concurrently so a verbose stderr (e.g. permission errors
+    # across many files) cannot fill the 64KB pipe buffer and deadlock the
+    # rsync subprocess waiting on stderr while we are waiting on stdout.
+    stderr_chunks: list[str] = []
+
+    def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        try:
+            for chunk in proc.stderr:
+                stderr_chunks.append(chunk)
+        except Exception:
+            logger.debug("stderr drain raised", exc_info=True)
+
+    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread.start()
+
     try:
-        # Read stdout in raw mode and split on either \r or \n. Iteration
-        # ends when the child closes stdout (i.e. when rsync exits).
         assert proc.stdout is not None
         buffer = ""
         while True:
             chunk = proc.stdout.read(1024)
             if not chunk:
-                # Flush any trailing partial line
                 if buffer:
                     _emit(buffer, tracker, on_progress)
                 break
             buffer += chunk
-            # Split on \r and \n; keep the trailing partial for next chunk
-            parts = buffer.replace("\r", "\n").split("\n")
+            # Split on \n only - text=True (universal_newlines) has already
+            # translated rsync's \r progress-overwrites to \n. The line-by-line
+            # consumption here drains the stdout pipe continuously, preventing
+            # the buffer-fills-and-rsync-blocks regression.
+            parts = buffer.split("\n")
             buffer = parts[-1]
             for line in parts[:-1]:
                 _emit(line, tracker, on_progress)
     finally:
         proc.wait()
-        stderr = proc.stderr.read() if proc.stderr else ""
+        stderr_thread.join(timeout=5.0)
+        stderr = "".join(stderr_chunks)
 
     if proc.returncode != 0:
         msg = f"rsync failed (exit {proc.returncode}): {stderr.strip()[:200]}"

--- a/arm/ripper/rsync_helper.py
+++ b/arm/ripper/rsync_helper.py
@@ -1,0 +1,178 @@
+"""arm-neu's sync wrapper around the rsync subprocess.
+
+Streams stdout line-by-line, runs each line through the shared parser/tracker
+in arm_contracts, and emits RsyncProgressEvent objects to the on_progress
+callback. Blocks until rsync exits; raises OSError on non-zero exit.
+
+Storage of the parsed events is the *caller's* responsibility. The thin
+wrapper run_rsync_with_side_file plumbs events into the side-file at
+{LOGPATH}/progress/{job_id}.copy.log so the existing progress_reader pattern
+(see get_rip_progress) extends naturally.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+from arm_contracts import RsyncProgressEvent, RsyncProgressTracker
+
+import arm.config.config as cfg
+
+logger = logging.getLogger(__name__)
+
+
+def run_rsync_sync(
+    src: str,
+    dst: str,
+    *,
+    on_progress: Callable[[RsyncProgressEvent], None],
+    remove_source: bool = False,
+) -> None:
+    """Run rsync, streaming progress events to on_progress.
+
+    Args:
+        src: Source path. Trailing slash semantics match rsync's: with a
+             trailing slash, source contents merge into dst; without, source
+             dir is created inside dst.
+        dst: Destination path. Created if missing (rsync handles this when
+             dst's parent exists; the caller is responsible for the parent).
+        on_progress: Called with each RsyncProgressEvent as it arrives.
+                     Must not raise - exceptions inside the callback are
+                     caught and logged; rsync continues uninterrupted.
+        remove_source: If True, passes --remove-source-files. Empty source
+                       directories are removed via shutil.rmtree on success.
+
+    Raises:
+        OSError: rsync exited non-zero. Message includes exit code and
+                 a snippet of stderr.
+
+    Behaviour:
+        Stdout is read line-by-line, splitting on both \\r and \\n. The
+        line-buffered iteration drains the pipe continuously, preventing
+        the 64KB-pipe-buffer-fills-and-rsync-blocks failure mode.
+    """
+    src_path = Path(src)
+    if not src_path.exists():
+        raise FileNotFoundError(f"Source does not exist: {src}")
+
+    cmd = ["rsync", "-a", "--info=name1,progress2"]
+    if remove_source:
+        cmd.append("--remove-source-files")
+
+    try:
+        if src_path.is_dir():
+            os.makedirs(dst, exist_ok=True)
+            cmd.extend([src.rstrip("/") + "/", dst.rstrip("/") + "/"])
+        else:
+            os.makedirs(os.path.dirname(dst) or ".", exist_ok=True)
+            cmd.extend([src, dst])
+    except OSError as exc:
+        # Re-raise so callers see a uniform "rsync ..." OSError regardless
+        # of whether the failure happened before rsync was even invoked.
+        raise OSError(f"rsync setup failed for {dst}: {exc}") from exc
+
+    logger.info(f"rsync {'(move)' if remove_source else '(copy)'}: {src} -> {dst}")
+
+    tracker = RsyncProgressTracker()
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=1,  # line-buffered
+        text=True,
+        # universal_newlines=True splits on \r\n; we want \r preserved so
+        # we read raw and split ourselves.
+    )
+
+    try:
+        # Read stdout in raw mode and split on either \r or \n. Iteration
+        # ends when the child closes stdout (i.e. when rsync exits).
+        assert proc.stdout is not None
+        buffer = ""
+        while True:
+            chunk = proc.stdout.read(1024)
+            if not chunk:
+                # Flush any trailing partial line
+                if buffer:
+                    _emit(buffer, tracker, on_progress)
+                break
+            buffer += chunk
+            # Split on \r and \n; keep the trailing partial for next chunk
+            parts = buffer.replace("\r", "\n").split("\n")
+            buffer = parts[-1]
+            for line in parts[:-1]:
+                _emit(line, tracker, on_progress)
+    finally:
+        proc.wait()
+        stderr = proc.stderr.read() if proc.stderr else ""
+
+    if proc.returncode != 0:
+        msg = f"rsync failed (exit {proc.returncode}): {stderr.strip()[:200]}"
+        logger.error(msg)
+        raise OSError(msg)
+
+    if remove_source and src_path.is_dir():
+        # rsync --remove-source-files removes files but leaves empty dirs
+        shutil.rmtree(src, ignore_errors=True)
+
+    logger.info(f"rsync complete: {src} -> {dst}")
+
+
+def _emit(
+    line: str,
+    tracker: RsyncProgressTracker,
+    on_progress: Callable[[RsyncProgressEvent], None],
+) -> None:
+    """Push one line through the tracker; if it yields an event, call the
+    callback. Callback exceptions are caught so a buggy callback cannot kill
+    a 40-minute rsync."""
+    try:
+        evt = tracker.consume(line)
+    except Exception:
+        logger.debug("rsync tracker raised on line: %r", line, exc_info=True)
+        return
+    if evt is None:
+        return
+    try:
+        on_progress(evt)
+    except Exception:
+        logger.debug("rsync on_progress callback raised", exc_info=True)
+
+
+def run_rsync_with_side_file(
+    src: str,
+    dst: str,
+    *,
+    job_id: int,
+    stage: str,
+    remove_source: bool = False,
+) -> None:
+    """Convenience wrapper that pipes progress to the side-file used by
+    progress_reader.get_copy_progress.
+
+    Side-file location: {LOGPATH}/progress/{job_id}.copy.log
+    Format (one line per event):
+        stage,progress_pct,files_transferred,current_file
+
+    File is opened in append mode every time so multiple stages
+    (scratch-to-media, work-to-completed, etc.) for the same job land in
+    the same file. The reader picks the latest entry per stage.
+    """
+    log_root = Path(cfg.arm_config.get("LOGPATH", "")).resolve()
+    progress_dir = log_root / "progress"
+    progress_dir.mkdir(parents=True, exist_ok=True)
+    side_file = progress_dir / f"{job_id}.copy.log"
+
+    # Append, line-buffered, so partial writes are atomic at line granularity.
+    with open(side_file, "a", buffering=1) as f:
+
+        def on_progress(evt: RsyncProgressEvent) -> None:
+            current_file = (evt.current_file or "").replace(",", "_").replace("\n", " ")
+            files = "" if evt.files_transferred is None else str(evt.files_transferred)
+            f.write(f"{stage},{evt.progress_pct},{files},{current_file}\n")
+
+        run_rsync_sync(src, dst, on_progress=on_progress, remove_source=remove_source)

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -141,10 +141,8 @@ def bash_notify(cfg, title, body, job=None):
 def _move_to_shared_storage(cfg, raw_basename, job=None):
     """Move raw directory from local scratch to shared storage if configured.
 
-    Uses rsync subprocess instead of shutil.copy2 so the NFS I/O happens in
-    a child process that can be abandoned if it stalls.  This prevents the
-    ARM API from becoming unresponsive during large file copies (shutil.copy2
-    in a thread causes kernel D-state that blocks statvfs on the same mount).
+    Delegates to run_rsync_with_side_file so progress is streamed to the
+    {LOGPATH}/progress/{job_id}.copy.log file consumed by progress_reader.
     """
     local_raw = cfg.get('LOCAL_RAW_PATH', '')
     shared_raw = cfg.get('SHARED_RAW_PATH', '')
@@ -152,41 +150,24 @@ def _move_to_shared_storage(cfg, raw_basename, job=None):
         return
     src = os.path.join(local_raw, raw_basename)
     dst = os.path.join(shared_raw, raw_basename)
-    if os.path.isdir(src):
-        try:
-            if job:
-                database_updater({'status': JobState.COPYING.value}, job)
-            os.makedirs(dst, exist_ok=True)
+    if not os.path.isdir(src):
+        return
 
-            # Use rsync to copy files - runs as a subprocess so NFS D-state
-            # doesn't block our process threads.  --remove-source-files deletes
-            # each source file after successful transfer (verified by rsync).
-            # Trailing slash on src ensures contents are merged into dst.
-            cmd = [
-                "rsync", "-a", "--remove-source-files",
-                "--info=name1,progress2",
-                src + "/",
-                dst + "/",
-            ]
-            logging.info(f"rsync {src}/ -> {dst}/")
-            result = subprocess.run(cmd, capture_output=True, text=True)
+    if job:
+        database_updater({'status': JobState.COPYING.value}, job)
+    os.makedirs(dst, exist_ok=True)
 
-            if result.returncode != 0:
-                logging.error(f"rsync failed (exit {result.returncode}): {result.stderr}")
-                raise OSError(f"rsync failed: {result.stderr[:200]}")
-
-            # Log individual transfer lines at DEBUG to avoid flooding
-            # the structured log with progress data
-            lines = [l.strip() for l in result.stdout.strip().splitlines() if l.strip()]
-            for line in lines:
-                logging.debug(f"rsync: {line}")
-
-            # rsync --remove-source-files removes files but leaves empty dirs
-            shutil.rmtree(src, ignore_errors=True)
-            logging.info(f"rsync complete: {src} -> {dst} ({len(lines)} files transferred)")
-        except OSError as e:
-            logging.error(f"Failed to move {src} -> {dst}: {e}")
-            raise
+    from arm.ripper.rsync_helper import run_rsync_with_side_file
+    try:
+        run_rsync_with_side_file(
+            src, dst,
+            job_id=getattr(job, 'job_id', 0),
+            stage="scratch-to-media",
+            remove_source=True,
+        )
+    except OSError as e:
+        logging.error(f"Failed to move {src} -> {dst}: {e}")
+        raise
 
 
 def _build_webhook_payload(title, body, job, raw_basename):

--- a/arm/services/progress_reader.py
+++ b/arm/services/progress_reader.py
@@ -155,3 +155,66 @@ def get_music_progress(logfile: str | None, total_tracks: int) -> dict[str, Any]
         result["progress"] = round(completed / total * 100, 1)
 
     return result
+
+
+def get_copy_progress(
+    job_id: int,
+    stage: str | None = None,
+) -> dict[str, Any]:
+    """Tail-read the copy-progress side-file for a job.
+
+    Side-file format (one line per event):
+        stage,progress_pct,files_transferred,current_file
+
+    Args:
+        job_id: Numeric job identifier.
+        stage: If provided, return the latest entry for that stage only.
+               If None, return the latest entry across all stages.
+
+    Returns:
+        ``{progress: float|None, stage: str|None, files_transferred: int|None,
+        current_file: str|None}``. Returns the no-data shape when the file
+        does not exist or contains no valid entries.
+
+    Fail-soft: garbage lines are skipped without raising. Symmetric to
+    get_rip_progress and get_music_progress in this module.
+    """
+    result: dict[str, Any] = {
+        "progress": None, "stage": None,
+        "files_transferred": None, "current_file": None,
+    }
+    path = _safe_log_path("progress", f"{job_id}.copy.log")
+    if path is None or not path.is_file():
+        return result
+    try:
+        with open(path, "r", errors="replace") as f:
+            content = f.read()
+    except OSError:
+        return result
+
+    latest: dict[str, Any] | None = None
+    for line in content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(",", 3)
+        if len(parts) != 4:
+            continue
+        line_stage, pct_str, files_str, current_file = parts
+        if stage is not None and line_stage != stage:
+            continue
+        try:
+            pct = float(pct_str)
+        except ValueError:
+            continue
+        try:
+            files = int(files_str) if files_str else None
+        except ValueError:
+            files = None
+        latest = {
+            "progress": pct,
+            "stage": line_stage,
+            "files_transferred": files,
+            "current_file": current_file or None,
+        }
+    return latest if latest is not None else result

--- a/test/_rsync_conformance.py
+++ b/test/_rsync_conformance.py
@@ -1,0 +1,121 @@
+"""Shared conformance tests for repos that consume the arm_contracts
+rsync helper interface.
+
+Each service repo (arm-neu, arm-transcoder) wraps its own subprocess
+helper in a `HelperAdapter` and runs the three `assert_*` functions
+below. The same five assertions hold on both sides:
+
+  1. At least one mid-transfer event fires before exit (>1MB transfer).
+  2. The final event has progress_pct == 100.0.
+  3. Parser returns None (does not raise) for malformed input. (Covered
+     by the parser test suite in this repo, not this module.)
+  4. rsync exit code 23 (partial transfer) raises an OSError with the
+     code in the message.
+  5. After remove_source=True success, src is empty.
+
+Adapter pattern: arm-neu provides a SyncAdapter that calls run_rsync_sync;
+arm-transcoder provides an AsyncAdapter that bridges asyncio.run() into
+a sync return. Conformance tests are execution-model-agnostic.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Protocol
+
+from arm_contracts import RsyncProgressEvent
+
+
+class HelperAdapter(Protocol):
+    """Each repo wraps its helper to look like this. The adapter is the
+    bridge between the conformance's sync test fixture and the helper's
+    sync-or-async execution model."""
+
+    def run_to_completion(
+        self,
+        src: str,
+        dst: str,
+        *,
+        remove_source: bool = False,
+    ) -> list[RsyncProgressEvent]:
+        """Run the helper. Return all on_progress events, in order, that
+        fired before the helper returned. Adapter handles any
+        asyncio.run() / thread bridging needed to make this synchronous."""
+        ...
+
+
+def _make_transfer_payload(tmp_path: Path, size_mb: int = 5) -> tuple[str, str]:
+    """Create a >1MB source spread across several files so rsync emits
+    mid-transfer progress samples even on fast SSDs/tmpfs (a single file
+    transfers in <1 sample window on local NVMe and never produces an
+    intermediate progress event)."""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    # Spread the payload across 5 files; rsync's progress2 reports the
+    # cumulative percentage, which steps through 20/40/60/80/100 across files.
+    per_file = max(1, size_mb // 5) * 1024 * 1024
+    for i in range(5):
+        # urandom is incompressible so rsync cannot collapse it
+        (src / f"payload_{i}.bin").write_bytes(os.urandom(per_file))
+    return str(src), str(dst)
+
+
+def assert_streams_progress(adapter: HelperAdapter, tmp_path: Path) -> None:
+    """Assertion 1 + 2: mid-transfer event fires AND final event is 100%."""
+    src, dst = _make_transfer_payload(tmp_path, size_mb=20)
+    events = adapter.run_to_completion(src, dst)
+    assert len(events) > 0, (
+        "Helper produced zero on_progress events. Either streaming is "
+        "broken or the >1MB transfer was too fast for rsync to emit "
+        "intermediate samples."
+    )
+    assert any(0 < e.progress_pct < 100 for e in events), (
+        f"Never saw a mid-transfer event. All events: "
+        f"{[e.progress_pct for e in events]}"
+    )
+    assert events[-1].progress_pct == 100.0, (
+        f"Final event was {events[-1].progress_pct}, expected 100.0. "
+        f"This indicates a partial-line-at-EOF drop."
+    )
+
+
+def assert_partial_transfer_raises(adapter: HelperAdapter, tmp_path: Path) -> None:
+    """Assertion 4: rsync exit code 23 raises an OSError with the code in
+    the message.
+
+    Repro: rsync to a directory the user cannot write to. rsync exits 23
+    (partial transfer due to error)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "f.bin").write_bytes(b"x" * 1024)
+    # Build a destination path that exists as a non-writable file - rsync
+    # cannot create the directory and exits non-zero.
+    bad_dst = tmp_path / "blocking_file"
+    bad_dst.write_bytes(b"")  # exists as a regular file
+    bad_path = bad_dst / "subdir"  # rsync cannot mkdir under a regular file
+
+    try:
+        adapter.run_to_completion(str(src), str(bad_path))
+    except OSError as exc:
+        msg = str(exc)
+        assert "rsync" in msg.lower(), (
+            f"OSError raised but message does not mention rsync: {msg}"
+        )
+        return
+    raise AssertionError("Expected OSError was not raised")
+
+
+def assert_remove_source_cleanup(adapter: HelperAdapter, tmp_path: Path) -> None:
+    """Assertion 5: after remove_source=True, src is empty (or the dir
+    itself is removed - both are acceptable)."""
+    src, dst = _make_transfer_payload(tmp_path, size_mb=2)
+    adapter.run_to_completion(src, dst, remove_source=True)
+    src_path = Path(src)
+    if src_path.exists():
+        remaining = [p for p in src_path.iterdir()]
+        assert remaining == [], (
+            f"Source directory still has files after remove_source=True: "
+            f"{[p.name for p in remaining]}"
+        )

--- a/test/test_jobs_progress_state_copy.py
+++ b/test/test_jobs_progress_state_copy.py
@@ -1,0 +1,75 @@
+import pytest
+
+
+@pytest.fixture
+def app_state(app_context):
+    from arm.database import db
+    from arm.models.app_state import AppState
+    state = AppState(id=1, ripping_paused=False, setup_complete=True)
+    db.session.add(state)
+    db.session.commit()
+    return state
+
+
+@pytest.fixture
+def client(app_context):
+    from arm.app import app
+    from fastapi.testclient import TestClient
+    with TestClient(app, raise_server_exceptions=True) as client:
+        yield client
+
+
+def _make_job(status: str, disctype: str):
+    """Create a Job in the test DB without exercising the udev hardware path."""
+    from arm.database import db
+    from arm.models.job import Job
+
+    job = Job(devpath=None, _skip_hardware=True)
+    job.title = "Test"
+    job.status = status
+    job.disctype = disctype
+    job.logfile = "test.log"
+    job.no_of_titles = 0
+    db.session.add(job)
+    db.session.commit()
+    db.session.refresh(job)
+    return job
+
+
+def test_progress_state_includes_copy_fields_when_no_data(client, app_state, app_context):
+    """No copy in flight - copy_progress and copy_stage are None."""
+    from arm.models.job import JobState
+
+    job = _make_job(JobState.VIDEO_RIPPING.value, "dvd")
+
+    resp = client.get(f"/api/v1/jobs/{job.job_id}/progress-state")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "copy_progress" in data
+    assert "copy_stage" in data
+    assert data["copy_progress"] is None
+    assert data["copy_stage"] is None
+
+
+def test_progress_state_returns_copy_progress_from_side_file(
+    client, app_state, app_context, tmp_path, monkeypatch,
+):
+    """When the side-file exists, /progress-state surfaces its latest entry."""
+    import arm.config.config as cfg
+    from arm.models.job import JobState
+
+    monkeypatch.setitem(cfg.arm_config, "LOGPATH", str(tmp_path))
+    progress_dir = tmp_path / "progress"
+    progress_dir.mkdir()
+
+    job = _make_job(JobState.COPYING.value, "bluray")
+
+    (progress_dir / f"{job.job_id}.copy.log").write_text(
+        "scratch-to-media,73.5,1,/raw/abc/file.mkv\n"
+    )
+
+    resp = client.get(f"/api/v1/jobs/{job.job_id}/progress-state")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["copy_progress"] == 73.5
+    assert data["copy_stage"] == "scratch-to-media"

--- a/test/test_logging_levels.py
+++ b/test/test_logging_levels.py
@@ -109,10 +109,15 @@ class TestMakeMKVLogLevels:
 
 
 class TestRsyncLogLevels:
-    """Verify rsync progress uses DEBUG, summaries use INFO."""
+    """Verify rsync helper logs start/complete at INFO and does not flood
+    structured logs with per-line progress data (progress now goes to a
+    side-file consumed by progress_reader)."""
 
-    def test_rsync_progress_at_debug(self, tmp_path, caplog):
-        """Individual rsync transfer lines should be logged at DEBUG."""
+    def test_rsync_progress_not_at_info(self, tmp_path, caplog):
+        """Per-line progress samples must not land in the structured log -
+        they belong in the side-file. Helper emits two INFO messages
+        (start + complete); progress lines (containing 'MB/s') must not
+        appear at INFO."""
         from arm.ripper.utils import _move_to_shared_storage
 
         local_raw = tmp_path / "local"
@@ -126,30 +131,33 @@ class TestRsyncLogLevels:
         cfg = {
             "LOCAL_RAW_PATH": str(local_raw),
             "SHARED_RAW_PATH": str(shared_raw),
+            "LOGPATH": str(tmp_path),
         }
 
-        # Mock subprocess.run to simulate rsync output
-        mock_result = unittest.mock.MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = "title.mkv\n  100,000 100%  50.00MB/s    0:00:00\n"
-        mock_result.stderr = ""
+        # Mock Popen to feed back rsync-shaped stdout including a progress line
+        mock_proc = unittest.mock.MagicMock()
+        # Two reads: payload then EOF.
+        mock_proc.stdout = unittest.mock.MagicMock()
+        mock_proc.stdout.read.side_effect = [
+            "title.mkv\n  100,000 100%  50.00MB/s    0:00:00\n",
+            "",
+        ]
+        mock_proc.stderr = unittest.mock.MagicMock()
+        mock_proc.stderr.read.return_value = ""
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = None
 
         with (
-            unittest.mock.patch("subprocess.run", return_value=mock_result),
+            unittest.mock.patch("arm.ripper.rsync_helper.subprocess.Popen", return_value=mock_proc),
             unittest.mock.patch("shutil.rmtree"),
             caplog.at_level(logging.DEBUG),
         ):
             _move_to_shared_storage(cfg, "test_movie")
 
-        debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
         info_messages = [r.message for r in caplog.records if r.levelno == logging.INFO]
 
-        # Progress lines should be at DEBUG
-        rsync_debug = [m for m in debug_messages if "rsync:" in m]
-        assert len(rsync_debug) > 0, "rsync transfer lines should be at DEBUG"
-
-        # Progress lines should NOT be at INFO
-        rsync_info_progress = [m for m in info_messages if "rsync:" in m and "MB/s" in m]
+        # Per-line progress must not leak to INFO structured logs
+        rsync_info_progress = [m for m in info_messages if "MB/s" in m]
         assert not rsync_info_progress, (
             f"rsync progress should NOT be at INFO. Found: {rsync_info_progress}"
         )
@@ -169,15 +177,19 @@ class TestRsyncLogLevels:
         cfg = {
             "LOCAL_RAW_PATH": str(local_raw),
             "SHARED_RAW_PATH": str(shared_raw),
+            "LOGPATH": str(tmp_path),
         }
 
-        mock_result = unittest.mock.MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = "title.mkv\n"
-        mock_result.stderr = ""
+        mock_proc = unittest.mock.MagicMock()
+        mock_proc.stdout = unittest.mock.MagicMock()
+        mock_proc.stdout.read.side_effect = ["title.mkv\n", ""]
+        mock_proc.stderr = unittest.mock.MagicMock()
+        mock_proc.stderr.read.return_value = ""
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = None
 
         with (
-            unittest.mock.patch("subprocess.run", return_value=mock_result),
+            unittest.mock.patch("arm.ripper.rsync_helper.subprocess.Popen", return_value=mock_proc),
             unittest.mock.patch("shutil.rmtree"),
             caplog.at_level(logging.DEBUG),
         ):
@@ -189,7 +201,8 @@ class TestRsyncLogLevels:
         assert any("rsync" in m and "->" in m for m in info_messages), (
             f"rsync start should be at INFO. Got: {info_messages}"
         )
-        # Completion with file count
-        assert any("rsync complete" in m and "transferred" in m for m in info_messages), (
-            f"rsync complete with file count should be at INFO. Got: {info_messages}"
+        # Completion (file-count suffix dropped after refactor; the helper
+        # logs 'rsync complete: src -> dst' and progress is in the side-file)
+        assert any("rsync complete" in m for m in info_messages), (
+            f"rsync complete should be at INFO. Got: {info_messages}"
         )

--- a/test/test_progress_reader_copy.py
+++ b/test/test_progress_reader_copy.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_get_copy_progress_no_file(tmp_path, monkeypatch):
+    import arm.config.config as cfg
+    monkeypatch.setitem(cfg.arm_config, "LOGPATH", str(tmp_path))
+    from arm.services.progress_reader import get_copy_progress
+    assert get_copy_progress(42) == {
+        "progress": None, "stage": None,
+        "files_transferred": None, "current_file": None,
+    }
+
+
+def test_get_copy_progress_returns_latest_entry(tmp_path, monkeypatch):
+    import arm.config.config as cfg
+    monkeypatch.setitem(cfg.arm_config, "LOGPATH", str(tmp_path))
+    progress_dir = tmp_path / "progress"
+    progress_dir.mkdir()
+    (progress_dir / "42.copy.log").write_text(
+        "scratch-to-media,12.5,1,/raw/abc/file_a.mkv\n"
+        "scratch-to-media,47.0,1,/raw/abc/file_a.mkv\n"
+        "scratch-to-media,100.0,2,/raw/abc/file_b.mkv\n"
+    )
+    from arm.services.progress_reader import get_copy_progress
+    out = get_copy_progress(42)
+    assert out["progress"] == pytest.approx(100.0)
+    assert out["stage"] == "scratch-to-media"
+    assert out["files_transferred"] == 2
+    assert out["current_file"] == "/raw/abc/file_b.mkv"
+
+
+def test_get_copy_progress_filters_by_stage(tmp_path, monkeypatch):
+    import arm.config.config as cfg
+    monkeypatch.setitem(cfg.arm_config, "LOGPATH", str(tmp_path))
+    progress_dir = tmp_path / "progress"
+    progress_dir.mkdir()
+    (progress_dir / "42.copy.log").write_text(
+        "scratch-to-media,100.0,2,/raw/abc/file_b.mkv\n"
+        "work-to-completed,30.0,1,/completed/file_a.mkv\n"
+    )
+    from arm.services.progress_reader import get_copy_progress
+    out_default = get_copy_progress(42)
+    assert out_default["stage"] == "work-to-completed"
+    assert out_default["progress"] == pytest.approx(30.0)
+
+    out_filtered = get_copy_progress(42, stage="scratch-to-media")
+    assert out_filtered["stage"] == "scratch-to-media"
+    assert out_filtered["progress"] == pytest.approx(100.0)
+
+
+def test_get_copy_progress_fail_soft_on_garbage(tmp_path, monkeypatch):
+    import arm.config.config as cfg
+    monkeypatch.setitem(cfg.arm_config, "LOGPATH", str(tmp_path))
+    progress_dir = tmp_path / "progress"
+    progress_dir.mkdir()
+    (progress_dir / "42.copy.log").write_text(
+        "garbage,this,is,not,a,real,line\n"
+        "scratch-to-media,47.0,1,/raw/abc/file_a.mkv\n"
+        "another,bad,line\n"
+    )
+    from arm.services.progress_reader import get_copy_progress
+    out = get_copy_progress(42)
+    # Garbage lines are skipped; the one valid line wins.
+    assert out["progress"] == pytest.approx(47.0)
+    assert out["stage"] == "scratch-to-media"

--- a/test/test_rsync_helper.py
+++ b/test/test_rsync_helper.py
@@ -87,3 +87,47 @@ def test_helper_writes_side_file(tmp_path, monkeypatch):
     parts = last.split(",")
     assert parts[0] == "scratch-to-media"
     assert float(parts[1]) == pytest.approx(100.0)
+
+
+def test_move_to_shared_storage_writes_side_file(tmp_path, monkeypatch):
+    """When _move_to_shared_storage runs, the same side-file is written
+    that run_rsync_with_side_file would have written. Proves the migration
+    didn't break the producer-side wiring."""
+    import arm.config.config as cfg
+    monkeypatch.setitem(cfg.arm_config, "LOGPATH", str(tmp_path))
+    (tmp_path / "progress").mkdir()
+
+    local_raw = tmp_path / "scratch"
+    shared_raw = tmp_path / "media"
+    local_raw.mkdir()
+    shared_raw.mkdir()
+
+    raw_basename = "abc123"
+    job_dir = local_raw / raw_basename
+    job_dir.mkdir()
+    (job_dir / "rip.mkv").write_bytes(os.urandom(2 * 1024 * 1024))
+
+    # Mock job
+    class FakeJob:
+        job_id = 99
+
+    job = FakeJob()
+    cfg_dict = {
+        "LOCAL_RAW_PATH": str(local_raw),
+        "SHARED_RAW_PATH": str(shared_raw),
+        "LOGPATH": str(tmp_path),
+    }
+
+    # Mock database_updater so we don't need a real DB session
+    monkeypatch.setattr(
+        "arm.ripper.utils.database_updater",
+        lambda *a, **kw: None,
+    )
+
+    from arm.ripper.utils import _move_to_shared_storage
+    _move_to_shared_storage(cfg_dict, raw_basename, job=job)
+
+    side_file = tmp_path / "progress" / "99.copy.log"
+    assert side_file.is_file(), "side-file should be written by _move_to_shared_storage"
+    content = side_file.read_text()
+    assert "scratch-to-media" in content

--- a/test/test_rsync_helper.py
+++ b/test/test_rsync_helper.py
@@ -1,0 +1,89 @@
+"""Tests for arm-neu's sync rsync wrapper.
+
+Imports the shared conformance from arm_contracts and runs it against
+a SyncAdapter wrapping run_rsync_sync. Storage-wiring tests live alongside
+because they cannot be shared (arm-neu uses a side-file; arm-transcoder
+uses a DB column)."""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from arm_contracts import RsyncProgressEvent
+from test._rsync_conformance import (
+    assert_partial_transfer_raises,
+    assert_remove_source_cleanup,
+    assert_streams_progress,
+)
+
+
+class SyncAdapter:
+    """Adapter for the conformance suite. Calls run_rsync_sync, captures
+    each on_progress event into a list, returns the list."""
+
+    def run_to_completion(
+        self,
+        src: str,
+        dst: str,
+        *,
+        remove_source: bool = False,
+    ) -> list[RsyncProgressEvent]:
+        from arm.ripper.rsync_helper import run_rsync_sync
+        events: list[RsyncProgressEvent] = []
+        run_rsync_sync(src, dst, on_progress=events.append, remove_source=remove_source)
+        return events
+
+
+@pytest.fixture
+def adapter():
+    return SyncAdapter()
+
+
+def test_conformance_streams_progress(adapter, tmp_path):
+    assert_streams_progress(adapter, tmp_path)
+
+
+def test_conformance_partial_transfer_raises(adapter, tmp_path):
+    assert_partial_transfer_raises(adapter, tmp_path)
+
+
+def test_conformance_remove_source_cleanup(adapter, tmp_path):
+    assert_remove_source_cleanup(adapter, tmp_path)
+
+
+# --- arm-neu storage wiring (not in conformance) ---
+
+
+def test_helper_writes_side_file(tmp_path, monkeypatch):
+    """When run_rsync_sync is invoked with a job_id and stage, it writes
+    progress lines to {LOGPATH}/progress/{job_id}.copy.log in the form
+    'stage,progress_pct,files_transferred,current_file'."""
+    import arm.config.config as cfg
+    monkeypatch.setitem(cfg.arm_config, "LOGPATH", str(tmp_path))
+    (tmp_path / "progress").mkdir()
+
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    (src / "payload.bin").write_bytes(os.urandom(2 * 1024 * 1024))
+
+    from arm.ripper.rsync_helper import run_rsync_with_side_file
+    run_rsync_with_side_file(
+        str(src), str(dst),
+        job_id=42,
+        stage="scratch-to-media",
+    )
+
+    side_file = tmp_path / "progress" / "42.copy.log"
+    assert side_file.is_file(), "side-file was not created"
+    content = side_file.read_text()
+    assert "scratch-to-media" in content
+    # Final line should be at 100%
+    last = [l for l in content.strip().splitlines() if l][-1]
+    parts = last.split(",")
+    assert parts[0] == "scratch-to-media"
+    assert float(parts[1]) == pytest.approx(100.0)

--- a/test/test_utils_coverage.py
+++ b/test/test_utils_coverage.py
@@ -192,9 +192,22 @@ class TestMoveToSharedStorage:
         os.makedirs(src)
         (tmp_path / "local" / "movie" / "file.mkv").write_bytes(b"data")
 
-        cfg = {'LOCAL_RAW_PATH': local_raw, 'SHARED_RAW_PATH': shared_raw}
-        mock_result = unittest.mock.MagicMock(returncode=1, stderr="rsync: NFS write failed")
-        with unittest.mock.patch("arm.ripper.utils.subprocess.run", return_value=mock_result):
+        cfg = {
+            'LOCAL_RAW_PATH': local_raw,
+            'SHARED_RAW_PATH': shared_raw,
+            'LOGPATH': str(tmp_path),
+        }
+
+        # New helper streams via subprocess.Popen; simulate exit 23 (partial).
+        mock_proc = unittest.mock.MagicMock()
+        mock_proc.stdout = unittest.mock.MagicMock()
+        mock_proc.stdout.read.side_effect = ["", ""]  # no progress output
+        mock_proc.stderr = unittest.mock.MagicMock()
+        mock_proc.stderr.read.return_value = "rsync: NFS write failed"
+        mock_proc.returncode = 23
+        mock_proc.wait.return_value = None
+
+        with unittest.mock.patch("arm.ripper.rsync_helper.subprocess.Popen", return_value=mock_proc):
             with pytest.raises(OSError, match="rsync failed"):
                 _move_to_shared_storage(cfg, "movie")
 


### PR DESCRIPTION
## Summary
- Adds `arm/ripper/rsync_helper.py`: `run_rsync_sync` + `run_rsync_with_side_file` with line-buffered streaming + concurrent stderr drain
- Migrates `_move_to_shared_storage` to delegate to the new helper
- Adds `progress_reader.get_copy_progress` (symmetric to `get_rip_progress`)
- `/jobs/{id}/progress-state` populates new `JobProgressState.copy_progress` / `copy_stage` fields
- Bumps `components/contracts` to `d6fda43` for the shared parser

## Why
Three rsync hops in the rip+transcode pipeline emit no UI progress today; users cannot tell a healthy 40-min copy from a stalled NFS mount. This is the producer side; arm-transcoder follow-up will populate the other two hops.

Spec: `../ai/arm-neu/docs/superpowers/specs/2026-05-09-unified-rsync-progress-design.md`
Plan: `../ai/arm-neu/docs/superpowers/plans/2026-05-09-unified-rsync-progress.md`

## Test plan
- [x] 3 conformance tests pass against SyncAdapter
- [x] storage-wiring + reader tests cover the new side-file path
- [x] migration test asserts `_move_to_shared_storage` writes the side-file
- [x] full backend suite green (2244 / 1 skipped / 39 deselected / 2 xfailed)
- [x] code review feedback addressed: concurrent stderr drain (deadlock fix), removed redundant CR-split, tightened filename heuristic in contracts
- [ ] smoke on hifi after RC: re-run a folder import and observe `copy_progress` climb in `/api/v1/jobs/{id}/progress-state`