### PR TITLE
test: silence Sonar python:S1244 float-equality warnings

### DIFF
--- a/test/_rsync_conformance.py
+++ b/test/_rsync_conformance.py
@@ -19,6 +19,7 @@ a sync return. Conformance tests are execution-model-agnostic.
 """
 from __future__ import annotations
 
+import math
 import os
 from pathlib import Path
 from typing import Protocol
@@ -75,7 +76,7 @@ def assert_streams_progress(adapter: HelperAdapter, tmp_path: Path) -> None:
         f"Never saw a mid-transfer event. All events: "
         f"{[e.progress_pct for e in events]}"
     )
-    assert events[-1].progress_pct == 100.0, (
+    assert math.isclose(events[-1].progress_pct, 100.0), (
         f"Final event was {events[-1].progress_pct}, expected 100.0. "
         f"This indicates a partial-line-at-EOF drop."
     )

--- a/test/test_jobs_progress_state_copy.py
+++ b/test/test_jobs_progress_state_copy.py
@@ -71,5 +71,5 @@ def test_progress_state_returns_copy_progress_from_side_file(
     resp = client.get(f"/api/v1/jobs/{job.job_id}/progress-state")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["copy_progress"] == 73.5
+    assert data["copy_progress"] == pytest.approx(73.5)
     assert data["copy_stage"] == "scratch-to-media"


### PR DESCRIPTION
## Summary
SonarCloud quality gate on arm-neu main was failing on `new_reliability_rating=3 (D)` because of two BUG/MAJOR `python:S1244` (no `==` on float) issues introduced by the rsync helper + copy-progress work:

- `test/_rsync_conformance.py:78` - rsync's literal \"100%\" sentinel
- `test/test_jobs_progress_state_copy.py:74` - 73.5 round-tripping through json

Both compare values that are bit-stable, but Sonar's rule has no semantic context. Use `math.isclose()` and `pytest.approx()` to silence the warnings without changing test intent.

## Test plan
- [x] `pytest test/test_jobs_progress_state_copy.py` -> 2/2 pass
- [ ] _rsync_conformance.py only runs in cross-repo integration suite; refactor preserves assertion semantics
- [ ] SonarCloud reliability rating returns to A on merge