### PR TITLE
chore(compose): drop dead transcoder SUBDIR env vars (ARM-side since v18.0.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,19 +104,17 @@ DELETE_SOURCE=true
 OUTPUT_EXTENSION=mkv
 
 # Output organization subdirs under the completed-path root.
-# Honored by BOTH the ripper (writes via finalize_output when transcoder
-# disabled, and reads for file browser / maintenance) AND the transcoder.
+# ARM-side only since v18.0.0: the ripper folds these into the webhook's
+# output_path field, which the transcoder uses verbatim. Setting these
+# on a transcoder host has no effect.
 # Each value may contain '/' for nested dirs, e.g.:
 #   MOVIES_SUBDIR=Movies/0.Rips     -> ${ARM_COMPLETED_PATH}/Movies/0.Rips/<title>/
 #   TV_SUBDIR=TV/0.Rips             -> ${ARM_COMPLETED_PATH}/TV/0.Rips/<show>/...
-# Note: ARM defaults AUDIO_SUBDIR to "music" (not "audio") for backward
-# compat with existing deployments; transcoder default remains "audio".
-# Set both consistently if you customize.
 MOVIES_SUBDIR=movies
 TV_SUBDIR=tv
 AUDIO_SUBDIR=music
 # Fallback subdir for jobs whose video_type was never identified.
-# Operator triage bucket - ripper-only.
+# Operator triage bucket.
 UNIDENTIFIED_SUBDIR=unidentified
 
 MAX_CONCURRENT=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,10 +133,10 @@ services:
       # File handling
       - DELETE_SOURCE=${DELETE_SOURCE:-true}
       - OUTPUT_EXTENSION=${OUTPUT_EXTENSION:-mkv}
-      # Organization
-      - MOVIES_SUBDIR=${MOVIES_SUBDIR:-movies}
-      - TV_SUBDIR=${TV_SUBDIR:-tv}
-      - AUDIO_SUBDIR=${AUDIO_SUBDIR:-audio}
+      # Output organization (MOVIES_SUBDIR / TV_SUBDIR / AUDIO_SUBDIR /
+      # UNIDENTIFIED_SUBDIR) is ARM-side only since v18.0.0 - the
+      # transcoder reads payload.output_path from the webhook and writes
+      # under ${COMPLETED_PATH}/<output_path> with no per-type routing.
       # Performance
       - MAX_CONCURRENT=${MAX_CONCURRENT:-1}
       - STABILIZE_SECONDS=${STABILIZE_SECONDS:-60}


### PR DESCRIPTION
## Summary
The transcoder service in docker-compose.yml was still passing MOVIES_SUBDIR / TV_SUBDIR / AUDIO_SUBDIR env vars that the transcoder stopped reading when v18.0.0 GA moved output-path resolution into ARM. Verified: zero matches for these keys under transcoder/src/.

Two issues this fix:
1. **Dead vars on the transcoder block** - confusing and a setup-time footgun for operators. Replace with a comment pointing at where the routing actually lives now (payload.output_path).
2. **AUDIO_SUBDIR default mismatch** - the transcoder block defaulted to ${AUDIO_SUBDIR:-audio} while the arm-rippers block four screens up defaults to ${AUDIO_SUBDIR:-music}. If anyone ever re-wired the transcoder to read this var, audio rips would silently misroute. Removing the dead var resolves the inconsistency.

The arm-rippers env block (lines 39-42) keeps all four SUBDIR vars - those still drive ARM's path rendering and flow into the webhook output_path field.

.env.example commentary on the same vars said \"Honored by BOTH the ripper AND the transcoder ... transcoder default remains 'audio'.\" Both clauses are stale. Reword to ARM-side-only.

## Test plan
- [ ] Compose validates (visual diff is small enough)
- [ ] Smoke deploy on hifi: arm-transcoder still finds files at the same output paths because routing is webhook-driven, not env-driven
- [ ] Doc review PR #355 already documents this design (v18.0.0 input_path/output_path); compose now matches