### PR TITLE
chore(compose): cleanup pass after compose-file audit

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,12 @@
 #
 # Override paths: UI_SRC_PATH=../my-ui  TRANSCODER_SRC_PATH=../my-transcoder
 #
+# Compatible base files: docker-compose.yml only.
+# This overlay patches `arm-rippers`, `arm-ui`, AND `arm-transcoder`.
+# It is NOT compatible with docker-compose.ripper-only.yml (no
+# arm-transcoder service to override) or docker-compose.remote-transcoder.yml
+# (the transcoder runs on a remote host - dev-build it from its own repo).
+#
 # Usage: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
 
 services:

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,4 +1,11 @@
 # NVIDIA GPU overlay for the transcoder.
+#
+# Compatible base files: docker-compose.yml only.
+# This overlay patches the `arm-transcoder` service. It is NOT compatible
+# with docker-compose.ripper-only.yml (no arm-transcoder service) or
+# docker-compose.remote-transcoder.yml (the transcoder runs on a remote
+# host - configure NVIDIA on that host's transcoder compose file).
+#
 # Usage: docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build
 
 services:

--- a/docker-compose.remote-transcoder.yml
+++ b/docker-compose.remote-transcoder.yml
@@ -44,7 +44,6 @@ services:
       - ARM_LOGS_PATH=${ARM_LOGS_PATH}
       - ARM_MUSIC_PATH=${ARM_MUSIC_PATH}
     volumes:
-      - /dev:/dev
       - ${ARM_MUSIC_PATH}:/home/arm/music
       - ${ARM_LOGS_PATH}:/home/arm/logs
       - ${ARM_MEDIA_PATH}:/home/arm/media
@@ -54,6 +53,9 @@ services:
       - ${ARM_CONFIG_PATH}:/etc/arm/config
       - arm-db:/home/arm/db
       - ${ARM_MAKEMKV_PATH:-makemkv-settings}:/home/arm/.MakeMKV
+      # Live /dev mount ensures USB optical drives remain visible after
+      # hot-plug, disconnect/reconnect, or device re-enumeration.
+      - /dev:/dev
     cpuset: ${ARM_CPUSET:-2,3,4,5,6,7}
     depends_on:
       arm-db-init:

--- a/docker-compose.ripper-only.yml
+++ b/docker-compose.ripper-only.yml
@@ -1,8 +1,13 @@
 # Ripper-only: ARM + UI on a single machine, no transcoder.
-# ARM writes final named files directly via the v15.0.0 finalize_output path.
+# ARM writes final named files directly via finalize_output (the
+# ripper-only completion path triggered by ARM_TRANSCODER_ENABLED=false).
 # Copy .env.ripper-only.example to .env and adjust values before starting.
 #
 # Start: docker compose -f docker-compose.ripper-only.yml up -d --build
+#
+# Compatible overlays: docker-compose.nfs.yml only.
+# docker-compose.dev.yml and docker-compose.gpu.yml both patch the
+# arm-transcoder service which this file does not declare.
 
 services:
   # Fix ownership on the shared DB volume before ARM starts


### PR DESCRIPTION
## Summary
Four small consistency fixes from a cross-file diff of the five compose variants (docker-compose.yml, remote-transcoder.yml, ripper-only.yml, dev.yml, gpu.yml, nfs.yml).

**No service or env-var changes; comments-only across all four files.**

1. **remote-transcoder.yml**: move /dev:/dev to the end of arm-rippers volumes (matches docker-compose.yml and ripper-only.yml ordering). Adds the same explanatory comment used elsewhere.

2. **dev.yml header**: document that this overlay only composes with docker-compose.yml. It patches arm-transcoder, which neither ripper-only.yml (no transcoder service) nor remote-transcoder.yml (transcoder runs on a remote host) declares. A user combining \`-f docker-compose.ripper-only.yml -f docker-compose.dev.yml\` would silently get a confusing 'service arm-transcoder not found' error.

3. **gpu.yml header**: same compatibility note - it also patches arm-transcoder only.

4. **ripper-only.yml header**: drop the v15.0.0 version reference (finalize_output is the current production path, independent of the version that introduced it). Add a positive list of compatible overlays (only nfs.yml).

## Test plan
- [ ] \`docker compose -f docker-compose.yml config\` validates
- [ ] \`docker compose -f docker-compose.remote-transcoder.yml config\` validates
- [ ] \`docker compose -f docker-compose.ripper-only.yml config\` validates
- [ ] \`docker compose -f docker-compose.yml -f docker-compose.dev.yml config\` validates
- [ ] \`docker compose -f docker-compose.yml -f docker-compose.gpu.yml config\` validates