### PR TITLE
feat: MediaMetadata contract integration (storage, adapters, naming engine)

### DIFF
--- a/arm/api/v1/_import_helpers.py
+++ b/arm/api/v1/_import_helpers.py
@@ -31,7 +31,8 @@ def apply_request_metadata_to_job(job: Any, req: Any) -> None:
     if req.imdb_id:
         job.imdb_id = req.imdb_id
     if req.poster_url:
-        job.poster_url = req.poster_url
+        from arm_contracts import MediaMetadata
+        job.set_metadata_auto(MediaMetadata(poster_url=req.poster_url))
     job.multi_title = req.multi_title
     if req.season is not None:
         job.season = str(req.season)

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -1095,7 +1095,7 @@ def get_retranscode_info(job_id: int):
         "video_type": job.video_type or job.video_type_auto or "movie",
         "year": year,
         "disctype": job.disctype,
-        "poster_url": job.poster_url or job.poster_url_auto or "",
+        "poster_url": job.media_metadata.poster_url or "",
         "config_overrides": _parse_transcode_overrides(job.transcode_overrides),
     }
 

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -315,6 +315,15 @@ def delete_job(job_id: int):
     return svc_jobs.delete_job(str(job_id), 'delete')
 
 
+@router.get('/jobs/{job_id}/metadata')
+def get_job_metadata(job_id: int):
+    """Return the merged MediaMetadata for a job (auto + manual overrides)."""
+    job = Job.query.get(job_id)
+    if not job:
+        return JSONResponse({"detail": _JOB_NOT_FOUND}, status_code=404)
+    return JSONResponse(job.media_metadata.model_dump(mode='json'), status_code=200)
+
+
 @router.post('/jobs/{job_id}/abandon')
 def abandon_job(job_id: int):
     """Abandon a running job."""

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -563,20 +563,26 @@ _FIELD_MAP = {
     'year': ('year', 'year_manual'),
     'video_type': ('video_type', 'video_type_manual'),
     'imdb_id': ('imdb_id', 'imdb_id_manual'),
-    'poster_url': ('poster_url', 'poster_url_manual'),
-    'artist': ('artist', 'artist_manual'),
-    'album': ('album', 'album_manual'),
     'season': ('season', 'season_manual'),
     'episode': ('episode', 'episode_manual'),
 }
+# Fields that don't map to Job columns - they route into the
+# media_metadata_manual MediaMetadata blob via set_metadata_manual().
+_METADATA_FIELDS = frozenset(('artist', 'album', 'poster_url'))
 _DIRECT_FIELDS = ('path', 'label', 'disctype', 'disc_number', 'disc_total')
 _STRUCTURED_KEYS = frozenset(('artist', 'album', 'season', 'episode'))
 _VALID_DISCTYPES = ('dvd', 'bluray', 'bluray4k', 'music', 'data')
 
 
 def _process_mapped_fields(body):
-    """Extract mapped fields from request body. Returns (args, updated, structured_changed)."""
-    args, updated = {}, {}
+    """Extract mapped fields from request body. Returns (args, updated, metadata_overrides, structured_changed).
+
+    `args` are the Job-column writes (bundle for database_updater).
+    `metadata_overrides` is a dict of {MediaMetadata field: value} that
+    must be written via set_metadata_manual().
+    `structured_changed` triggers a title re-render after the update.
+    """
+    args, updated, metadata_overrides = {}, {}, {}
     structured_changed = False
     for key, (eff, manual) in _FIELD_MAP.items():
         if key not in body or body[key] is None:
@@ -587,7 +593,15 @@ def _process_mapped_fields(body):
         updated[key] = value
         if key in _STRUCTURED_KEYS:
             structured_changed = True
-    return args, updated, structured_changed
+    for key in _METADATA_FIELDS:
+        if key not in body or body[key] is None:
+            continue
+        value = str(body[key]).strip()
+        metadata_overrides[key] = value
+        updated[key] = value
+        if key in _STRUCTURED_KEYS:
+            structured_changed = True
+    return args, updated, metadata_overrides, structured_changed
 
 
 def _process_direct_fields(body, args, updated):
@@ -629,7 +643,7 @@ def update_job_title(job_id: int, body: dict):
         return JSONResponse({"success": False, "error": _JOB_NOT_FOUND}, status_code=404)
     old_title, old_year = job.title, job.year
 
-    args, updated, structured_changed = _process_mapped_fields(body)
+    args, updated, metadata_overrides, structured_changed = _process_mapped_fields(body)
     error = _process_direct_fields(body, args, updated)
     if error:
         return error
@@ -638,6 +652,21 @@ def update_job_title(job_id: int, body: dict):
         return JSONResponse({"success": False, "error": "No fields to update"}, status_code=400)
 
     args['hasnicetitle'] = True
+    # If the body included MediaMetadata fields (artist/album/poster_url),
+    # merge them into the existing media_metadata_manual blob and bundle
+    # the write into the same database_updater call as the column writes.
+    if metadata_overrides:
+        from arm_contracts import MediaMetadata
+        existing_blob = job.media_metadata_manual
+        if existing_blob:
+            try:
+                existing = MediaMetadata.model_validate_json(existing_blob)
+                merged = existing.model_copy(update=metadata_overrides)
+            except Exception:
+                merged = MediaMetadata(**metadata_overrides)
+        else:
+            merged = MediaMetadata(**metadata_overrides)
+        args['media_metadata_manual'] = merged.model_dump_json()
     svc_files.database_updater(args, job)
 
     if structured_changed and 'title' not in updated:

--- a/arm/migrations/versions/u6v7w8x9y0_media_metadata_columns.py
+++ b/arm/migrations/versions/u6v7w8x9y0_media_metadata_columns.py
@@ -1,0 +1,132 @@
+"""Add media_metadata_auto/manual JSON columns; backfill from legacy
+poster_url/artist/album triple-columns; drop the retired triples.
+
+Revision ID: u6v7w8x9y0
+Revises: 335d2d235fe0
+Create Date: 2026-05-10
+"""
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = 'u6v7w8x9y0'
+down_revision = '335d2d235fe0'
+branch_labels = None
+depends_on = None
+
+
+def _build_metadata_json(row, source):
+    """Build a MediaMetadata-shaped dict from legacy column values.
+
+    `source` is "auto" or "manual" - selects the *_auto or *_manual
+    columns respectively. Returns a JSON string or None if all fields
+    were null/empty.
+    """
+    suffix = f"_{source}" if source != "auto" else "_auto"
+
+    def col(base):
+        return row._mapping.get(f"{base}{suffix}")
+
+    payload = {}
+    if col("poster_url"):
+        payload["poster_url"] = col("poster_url")
+    if col("artist"):
+        payload["artist"] = col("artist")
+    if col("album"):
+        payload["album"] = col("album")
+    if not payload:
+        return None
+    return json.dumps(payload)
+
+
+def upgrade():
+    # 1. Add new columns
+    op.add_column('job', sa.Column('media_metadata_auto', sa.Text(), nullable=True))
+    op.add_column('job', sa.Column('media_metadata_manual', sa.Text(), nullable=True))
+
+    # 2. Backfill from legacy triples
+    bind = op.get_bind()
+    rows = bind.execute(sa.text(
+        "SELECT job_id, "
+        "poster_url_auto, poster_url_manual, "
+        "artist_auto, artist_manual, "
+        "album_auto, album_manual "
+        "FROM job"
+    )).fetchall()
+
+    for row in rows:
+        auto_json = _build_metadata_json(row, "auto")
+        manual_json = _build_metadata_json(row, "manual")
+        if auto_json or manual_json:
+            bind.execute(
+                sa.text(
+                    "UPDATE job SET "
+                    "media_metadata_auto = :auto, "
+                    "media_metadata_manual = :manual "
+                    "WHERE job_id = :job_id"
+                ),
+                {"auto": auto_json, "manual": manual_json, "job_id": row._mapping["job_id"]},
+            )
+
+    # 3. Drop the legacy triple-columns. Use batch_alter_table for SQLite
+    # which can't drop columns directly.
+    with op.batch_alter_table('job', schema=None) as batch_op:
+        batch_op.drop_column('poster_url')
+        batch_op.drop_column('poster_url_auto')
+        batch_op.drop_column('poster_url_manual')
+        batch_op.drop_column('artist')
+        batch_op.drop_column('artist_auto')
+        batch_op.drop_column('artist_manual')
+        batch_op.drop_column('album')
+        batch_op.drop_column('album_auto')
+        batch_op.drop_column('album_manual')
+
+
+def downgrade():
+    # Restore legacy triple-columns; data loss for any field not in those
+    # triples (e.g. genres, directors) - downgrade is best-effort.
+    with op.batch_alter_table('job', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('poster_url', sa.String(256), nullable=True))
+        batch_op.add_column(sa.Column('poster_url_auto', sa.String(256), nullable=True))
+        batch_op.add_column(sa.Column('poster_url_manual', sa.String(256), nullable=True))
+        batch_op.add_column(sa.Column('artist', sa.String(256), nullable=True))
+        batch_op.add_column(sa.Column('artist_auto', sa.String(256), nullable=True))
+        batch_op.add_column(sa.Column('artist_manual', sa.String(256), nullable=True))
+        batch_op.add_column(sa.Column('album', sa.String(256), nullable=True))
+        batch_op.add_column(sa.Column('album_auto', sa.String(256), nullable=True))
+        batch_op.add_column(sa.Column('album_manual', sa.String(256), nullable=True))
+
+    bind = op.get_bind()
+    rows = bind.execute(sa.text(
+        "SELECT job_id, media_metadata_auto, media_metadata_manual FROM job"
+    )).fetchall()
+
+    for row in rows:
+        for source_col, target_suffix in (
+            ("media_metadata_auto", "_auto"),
+            ("media_metadata_manual", "_manual"),
+        ):
+            blob = row._mapping[source_col]
+            if not blob:
+                continue
+            try:
+                payload = json.loads(blob)
+            except (ValueError, TypeError):
+                continue
+            updates = {}
+            for legacy_field in ("poster_url", "artist", "album"):
+                if legacy_field in payload and payload[legacy_field]:
+                    updates[f"{legacy_field}{target_suffix}"] = payload[legacy_field]
+            if updates:
+                set_clause = ", ".join(f"{k} = :{k}" for k in updates)
+                params = {**updates, "job_id": row._mapping["job_id"]}
+                bind.execute(
+                    sa.text(f"UPDATE job SET {set_clause} WHERE job_id = :job_id"),
+                    params,
+                )
+
+    with op.batch_alter_table('job', schema=None) as batch_op:
+        batch_op.drop_column('media_metadata_manual')
+        batch_op.drop_column('media_metadata_auto')

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -141,9 +141,6 @@ class Job(db.Model):
     imdb_id = db.Column(db.String(15))
     imdb_id_auto = db.Column(db.String(15))
     imdb_id_manual = db.Column(db.String(15))
-    poster_url = db.Column(db.String(256))
-    poster_url_auto = db.Column(db.String(256))
-    poster_url_manual = db.Column(db.String(256))
     devpath = db.Column(db.String(15))
     mountpoint = db.Column(db.String(20))
     hasnicetitle = db.Column(db.Boolean)
@@ -153,13 +150,6 @@ class Job(db.Model):
     path = db.Column(db.String(256))
     raw_path = db.Column(db.String(256))
     transcode_path = db.Column(db.String(256))
-    # Music structured fields
-    artist = db.Column(db.String(256))
-    artist_auto = db.Column(db.String(256))
-    artist_manual = db.Column(db.String(256))
-    album = db.Column(db.String(256))
-    album_auto = db.Column(db.String(256))
-    album_manual = db.Column(db.String(256))
     # TV structured fields
     season = db.Column(db.String(10))
     season_auto = db.Column(db.String(10))

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -527,14 +527,12 @@ class Job(db.Model):
     def _pattern_fields_available(self):
         """Check if the structured fields needed for pattern rendering are populated.
         Movies: always available (just need title).
-        Music: need artist or album.
+        Music: need artist or album (read from media_metadata).
         Series: need season or episode.
         """
         if self.video_type == 'music':
-            return bool(
-                getattr(self, 'artist', None) or getattr(self, 'artist_manual', None)
-                or getattr(self, 'album', None) or getattr(self, 'album_manual', None)
-            )
+            meta = self.media_metadata
+            return bool(meta.artist or meta.album)
         elif self.video_type == 'series':
             return bool(
                 getattr(self, 'season', None) or getattr(self, 'season_manual', None)

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -193,6 +193,12 @@ class Job(db.Model):
     wait_start_time = db.Column(db.DateTime, nullable=True)
     title_pattern_override = db.Column(db.String(512), nullable=True)
     folder_pattern_override = db.Column(db.String(512), nullable=True)
+    # MediaMetadata storage. media_metadata_auto is written by provider
+    # adapters in arm/services/metadata.py. media_metadata_manual is
+    # written by the UI when an operator overrides any field. The
+    # `media_metadata` read property merges manual-over-auto field-by-field.
+    media_metadata_auto = db.Column(db.Text, nullable=True)
+    media_metadata_manual = db.Column(db.Text, nullable=True)
     tracks = db.relationship('Track', backref='job', lazy='dynamic')
     config = db.relationship('Config', uselist=False, backref="job")
     expected_titles = db.relationship(
@@ -228,6 +234,49 @@ class Job(db.Model):
         self.manual_pause = False
         self.manual_mode = False
         self.has_track_99 = False
+
+    @property
+    def media_metadata(self):
+        """Merged MediaMetadata: manual overrides auto field-by-field.
+
+        Empty / None / [] manual values fall through to auto. The merge
+        runs on every access; if profile shows it as hot, cache on the
+        instance.
+        """
+        from arm_contracts import MediaMetadata
+        auto_blob = self.media_metadata_auto
+        manual_blob = self.media_metadata_manual
+        auto = (
+            MediaMetadata.model_validate_json(auto_blob)
+            if auto_blob else MediaMetadata()
+        )
+        manual = (
+            MediaMetadata.model_validate_json(manual_blob)
+            if manual_blob else MediaMetadata()
+        )
+
+        merged_data = {}
+        for field_name in MediaMetadata.model_fields:
+            manual_value = getattr(manual, field_name)
+            auto_value = getattr(auto, field_name)
+            if manual_value is not None and manual_value != "" and manual_value != []:
+                merged_data[field_name] = manual_value
+            else:
+                merged_data[field_name] = auto_value
+        return MediaMetadata(**merged_data)
+
+    def set_metadata_auto(self, metadata):
+        """Persist a MediaMetadata instance to media_metadata_auto."""
+        self.media_metadata_auto = metadata.model_dump_json()
+
+    def set_metadata_manual(self, metadata):
+        """Persist a MediaMetadata instance to media_metadata_manual.
+
+        Pass a partial MediaMetadata - only fields the operator actually
+        overrode should be set; the merge logic in `media_metadata`
+        treats unset (None / empty) fields as fall-through.
+        """
+        self.media_metadata_manual = metadata.model_dump_json()
 
     @classmethod
     def from_folder(cls, source_path: str, disctype: str):

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -660,8 +660,6 @@ def update_job(job, search_results):
         'video_type': best.type,
         'imdb_id_auto': best.imdb_id,
         'imdb_id': best.imdb_id,
-        'poster_url_auto': best.poster_url or '',
-        'poster_url': best.poster_url or '',
         'hasnicetitle': True,
     }
     # Persist disc number/season from label parsing (e.g. "Disc 2", "S01D03")
@@ -672,6 +670,14 @@ def update_job(job, search_results):
             args['season_auto'] = str(selection.label_info.season_number)
             args['season'] = str(selection.label_info.season_number)
     result = utils.database_updater(args, job)
+
+    # Persist editorial metadata (poster_url, plus future MediaMetadata
+    # fields) to the auto-blob. The legacy poster_url column was retired
+    # by the media_metadata_columns migration.
+    if best.poster_url:
+        from arm_contracts import MediaMetadata
+        job.set_metadata_auto(MediaMetadata(poster_url=best.poster_url))
+        db.session.commit()
 
     # Only write ExpectedTitle for movies. TV series matches are handled by the
     # TVDB-based path in A6, which writes one row per episode.

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -517,18 +517,36 @@ def identify_dvd(job):
             logging.info("Found crc64 id from online API")
             logging.info(f"title is {hit['title']}")
             poster = _resolve_poster(hit)
+            cleaned_year = utils.extract_year(hit['year'])
+            # poster_url + the rest of the editorial metadata live in the
+            # media_metadata_auto JSON blob now. Bundle the column writes
+            # and the blob write into a single database_updater call so
+            # everything commits atomically.
+            from arm_contracts import MediaMetadata
+            from arm_contracts.enums import VideoType
+            video_type_enum = (
+                VideoType.movie if hit['video_type'] == "movie"
+                else VideoType.series if hit['video_type'] == "series"
+                else None
+            )
+            metadata_blob = MediaMetadata(
+                title=hit['title'] or None,
+                year=cleaned_year or None,
+                video_type=video_type_enum,
+                imdb_id=hit['imdb_id'] or None,
+                poster_url=poster or None,
+            ).model_dump_json()
             args = {
                 'title': hit['title'],
                 'title_auto': hit['title'],
-                'year': utils.extract_year(hit['year']),
-                'year_auto': utils.extract_year(hit['year']),
+                'year': cleaned_year,
+                'year_auto': cleaned_year,
                 'imdb_id': hit['imdb_id'],
                 'imdb_id_auto': hit['imdb_id'],
                 'video_type': hit['video_type'],
                 'video_type_auto': hit['video_type'],
-                'poster_url': poster,
-                'poster_url_auto': poster,
-                'hasnicetitle': True
+                'media_metadata_auto': metadata_blob,
+                'hasnicetitle': True,
             }
             utils.database_updater(args, job)
             _write_movie_expected_title(
@@ -651,6 +669,27 @@ def update_job(job, search_results):
         best.title_score, best.year_score, best.type_score,
     )
 
+    # Build the editorial metadata blob from the matcher hit + the
+    # original search-result raw_result. Title/year/imdb_id are duplicated
+    # into the blob (alongside their Job-column writes) so the
+    # media_metadata view is self-contained for the naming engine and the
+    # /api/v1/jobs/{id}/metadata endpoint.
+    from arm_contracts import MediaMetadata
+    from arm_contracts.enums import VideoType
+    raw = best.raw_result or {}
+    video_type_enum = (
+        VideoType.movie if best.type == "movie"
+        else VideoType.series if best.type == "series"
+        else None
+    )
+    metadata_blob = MediaMetadata(
+        title=title or None,
+        year=str(best.year) if best.year else None,
+        video_type=video_type_enum,
+        imdb_id=best.imdb_id or None,
+        poster_url=best.poster_url or None,
+        runtime_seconds=raw.get("runtime_seconds"),
+    ).model_dump_json()
     args = {
         'year_auto': str(best.year),
         'year': str(best.year),
@@ -660,6 +699,7 @@ def update_job(job, search_results):
         'video_type': best.type,
         'imdb_id_auto': best.imdb_id,
         'imdb_id': best.imdb_id,
+        'media_metadata_auto': metadata_blob,
         'hasnicetitle': True,
     }
     # Persist disc number/season from label parsing (e.g. "Disc 2", "S01D03")
@@ -670,14 +710,6 @@ def update_job(job, search_results):
             args['season_auto'] = str(selection.label_info.season_number)
             args['season'] = str(selection.label_info.season_number)
     result = utils.database_updater(args, job)
-
-    # Persist editorial metadata (poster_url, plus future MediaMetadata
-    # fields) to the auto-blob. The legacy poster_url column was retired
-    # by the media_metadata_columns migration.
-    if best.poster_url:
-        from arm_contracts import MediaMetadata
-        job.set_metadata_auto(MediaMetadata(poster_url=best.poster_url))
-        db.session.commit()
 
     # Only write ExpectedTitle for movies. TV series matches are handled by the
     # TVDB-based path in A6, which writes one row per episode.

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -73,17 +73,6 @@ class _SafeDict(dict):
         return ''
 
 
-def _job_media_metadata(job):
-    """Read MediaMetadata off a Job, tolerating sample namespaces in tests.
-
-    A real Job has a `media_metadata` property that merges the two JSON
-    blob columns. SimpleNamespace fixtures in unit tests may or may not
-    set one; in that case we return None and fall back to whatever the
-    test attached to the namespace directly.
-    """
-    return getattr(job, 'media_metadata', None)
-
-
 def _build_variables(job):
     """Extract all pattern variables from a Job + its MediaMetadata.
 
@@ -98,8 +87,12 @@ def _build_variables(job):
       year_manual, etc.).
     - MediaMetadata-side: the merged-read property in Job already does
       field-by-field manual-over-auto from the two JSON blobs.
+
+    The job *must* expose a `media_metadata` attribute - either the
+    property on a real Job, or a MediaMetadata attached to a test
+    SimpleNamespace.
     """
-    metadata = _job_media_metadata(job)
+    metadata = job.media_metadata
 
     # Core tokens from Job columns (matcher writes these in identify.py).
     title = job.title_manual or job.title or ''
@@ -113,44 +106,19 @@ def _build_variables(job):
     if episode and episode.isdigit():
         episode = episode.zfill(2)
 
-    # Music tokens used to live on Job columns; now they're MediaMetadata.
-    # Take MediaMetadata first, then fall back to legacy job attributes
-    # (set by older code paths and still attached as instance attrs by
-    # tests / pre-migration code). Preserves _manual-over-base override
-    # semantics for backwards-compat.
-    artist = ''
-    album = ''
-    if metadata is not None:
-        artist = metadata.artist or ''
-        album = metadata.album or ''
-    if not artist:
-        artist = (getattr(job, 'artist_manual', None)
-                  or getattr(job, 'artist', None) or '')
-    if not album:
-        album = (getattr(job, 'album_manual', None)
-                 or getattr(job, 'album', None) or '')
-
     out = _SafeDict()
 
     # Contract-derived tokens from MediaMetadata, using each token's
     # accessor lambda. None / empty values render as empty strings.
-    if metadata is not None:
-        for alias, (field_name, _desc, accessor) in PATTERN_TOKENS.items():
-            value = getattr(metadata, field_name, None)
-            if value is None or value == [] or value == "":
-                out[alias] = ''
-            else:
-                try:
-                    out[alias] = accessor(value)
-                except Exception:  # noqa: BLE001 - never break naming on a bad token
-                    out[alias] = ''
-    else:
-        # No MediaMetadata available (e.g. test fixture without it). Seed
-        # the contract tokens to empty so format_map doesn't insert '' for
-        # them from _SafeDict alone (it would, but being explicit avoids
-        # surprises later).
-        for alias in PATTERN_TOKENS:
+    for alias, (field_name, _desc, accessor) in PATTERN_TOKENS.items():
+        value = getattr(metadata, field_name, None)
+        if value is None or value == [] or value == "":
             out[alias] = ''
+        else:
+            try:
+                out[alias] = accessor(value)
+            except Exception:  # noqa: BLE001 - never break naming on a bad token
+                out[alias] = ''
 
     # Core tokens override the contract-derived defaults. Job columns are
     # authoritative for these because they participate in matching and UI
@@ -159,8 +127,8 @@ def _build_variables(job):
         'title': title,
         'show': title,  # Always the job-level title (show name for TV).
         'year': year,
-        'artist': artist,
-        'album': album,
+        'artist': metadata.artist or '',
+        'album': metadata.album or '',
         'season': season,
         'episode': episode,
         'episode_name': '',  # Populated at track level from TVDB.

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -1,12 +1,25 @@
 """Naming pattern engine for display titles and folder paths.
 
 Supports per-type patterns with {variable} placeholders.
-Variables are extracted from Job fields, preferring manual over auto values.
-Per-job pattern overrides and per-track custom filenames are supported.
+Variables are extracted from Job fields + MediaMetadata, preferring manual
+over auto values. Per-job pattern overrides and per-track custom filenames
+are supported.
+
+Token vocabulary:
+- "Core" tokens (title, show, year, season, episode, episode_name, video_type,
+  imdb_id) are read directly from Job columns - the matcher writes these
+  during disc identification.
+- "Editorial" tokens (artist, album, director, genre, plot, tagline, etc.)
+  are read from Job.media_metadata, which merges manual-over-auto from the
+  two media_metadata_* JSON columns.
+- "Engine-only" tokens (label, disc_number, disc_total) come from Job
+  columns directly.
 """
 import logging
 import os
 import re
+
+from arm_contracts import PATTERN_TOKENS
 
 _TITLE_YEAR_PATTERN = '{title} ({year})'
 
@@ -19,25 +32,31 @@ DEFAULTS = {
     'MUSIC_FOLDER_PATTERN': '{artist}/{album} ({year})',
 }
 
-# Canonical list of variables available in naming patterns.
-# This is the single source of truth — UI, validation, and config docs derive from this.
-PATTERN_VARIABLES = {
-    'title':        'Disc title (may be episode title on multi-title TV discs)',
+# Tokens the engine sources from Job columns (not from MediaMetadata), in
+# addition to anything PATTERN_TOKENS covers. Kept here so the validator
+# accepts them.
+# - {show} mirrors {title} at job level; never gets overridden at track-level.
+# - {episode} is the per-track concept (track-level), not part of MediaMetadata.
+# - {episode_name} is the TVDB-matched per-track episode title.
+# - label / disc_number / disc_total are physical-disc properties.
+_ENGINE_ONLY_TOKENS = {
     'show':         'Series/show name (always the job-level title, never overridden by track)',
-    'year':         'Release year',
-    'artist':       'Music artist name',
-    'album':        'Music album name',
-    'season':       'TV season number (zero-padded to 2 digits)',
     'episode':      'TV episode number (zero-padded to 2 digits)',
     'episode_name': 'TV episode title from TVDB (track-level only)',
     'label':        'Original disc label from drive',
-    'video_type':   'Media type: movie, series, or music',
     'disc_number':  'Disc number in a multi-disc set',
     'disc_total':   'Total number of discs in the set',
-    'imdb_id':      'IMDb ID (e.g. tt0111161) for Jellyfin/Plex folder matching',
 }
 
-# Frozen set for fast validation — derived from PATTERN_VARIABLES
+# PATTERN_VARIABLES: source-of-truth for what tokens patterns can use.
+# Contract-derived tokens come from PATTERN_TOKENS in arm_contracts;
+# engine-only tokens are local to this module.
+PATTERN_VARIABLES = {
+    **{alias: desc for alias, (_, desc, _) in PATTERN_TOKENS.items()},
+    **_ENGINE_ONLY_TOKENS,
+}
+
+# Frozen set for fast validation - derived from PATTERN_VARIABLES
 VALID_VARS: frozenset = frozenset(PATTERN_VARIABLES.keys())
 
 # Map video_type to pattern key prefixes
@@ -54,38 +73,104 @@ class _SafeDict(dict):
         return ''
 
 
+def _job_media_metadata(job):
+    """Read MediaMetadata off a Job, tolerating sample namespaces in tests.
+
+    A real Job has a `media_metadata` property that merges the two JSON
+    blob columns. SimpleNamespace fixtures in unit tests may or may not
+    set one; in that case we return None and fall back to whatever the
+    test attached to the namespace directly.
+    """
+    return getattr(job, 'media_metadata', None)
+
+
 def _build_variables(job):
-    """Extract all pattern variables from a Job, preferring manual over auto."""
+    """Extract all pattern variables from a Job + its MediaMetadata.
+
+    Job columns drive `title`, `year`, `season`, `episode`, `imdb_id`,
+    `video_type`, `label`, `disc_number`, `disc_total` (matcher writes
+    these directly during identification). MediaMetadata fills in the
+    editorial tokens (director, genre, plot, etc.) plus poster_url and
+    artist/album/album_artist for music jobs.
+
+    Manual-over-auto is layered:
+    - Job-side: `_manual` columns override base columns (title_manual,
+      year_manual, etc.).
+    - MediaMetadata-side: the merged-read property in Job already does
+      field-by-field manual-over-auto from the two JSON blobs.
+    """
+    metadata = _job_media_metadata(job)
+
+    # Core tokens from Job columns (matcher writes these in identify.py).
     title = job.title_manual or job.title or ''
     year = job.year_manual or job.year or ''
     if year == '0000':
         year = ''
-    artist = getattr(job, 'artist_manual', None) or getattr(job, 'artist', None) or ''
-    album = getattr(job, 'album_manual', None) or getattr(job, 'album', None) or ''
     season = getattr(job, 'season_manual', None) or getattr(job, 'season', None) or getattr(job, 'season_auto', None) or ''
     episode = getattr(job, 'episode_manual', None) or getattr(job, 'episode', None) or getattr(job, 'episode_auto', None) or ''
-
-    # Zero-pad season/episode to 2 digits if numeric
     if season and season.isdigit():
         season = season.zfill(2)
     if episode and episode.isdigit():
         episode = episode.zfill(2)
 
-    return _SafeDict({
+    # Music tokens used to live on Job columns; now they're MediaMetadata.
+    # Take MediaMetadata first, then fall back to legacy job attributes
+    # (set by older code paths and still attached as instance attrs by
+    # tests / pre-migration code). Preserves _manual-over-base override
+    # semantics for backwards-compat.
+    artist = ''
+    album = ''
+    if metadata is not None:
+        artist = metadata.artist or ''
+        album = metadata.album or ''
+    if not artist:
+        artist = (getattr(job, 'artist_manual', None)
+                  or getattr(job, 'artist', None) or '')
+    if not album:
+        album = (getattr(job, 'album_manual', None)
+                 or getattr(job, 'album', None) or '')
+
+    out = _SafeDict()
+
+    # Contract-derived tokens from MediaMetadata, using each token's
+    # accessor lambda. None / empty values render as empty strings.
+    if metadata is not None:
+        for alias, (field_name, _desc, accessor) in PATTERN_TOKENS.items():
+            value = getattr(metadata, field_name, None)
+            if value is None or value == [] or value == "":
+                out[alias] = ''
+            else:
+                try:
+                    out[alias] = accessor(value)
+                except Exception:  # noqa: BLE001 - never break naming on a bad token
+                    out[alias] = ''
+    else:
+        # No MediaMetadata available (e.g. test fixture without it). Seed
+        # the contract tokens to empty so format_map doesn't insert '' for
+        # them from _SafeDict alone (it would, but being explicit avoids
+        # surprises later).
+        for alias in PATTERN_TOKENS:
+            out[alias] = ''
+
+    # Core tokens override the contract-derived defaults. Job columns are
+    # authoritative for these because they participate in matching and UI
+    # workflows beyond the naming engine.
+    out.update({
         'title': title,
-        'show': title,  # Always the job-level title (show name for TV)
+        'show': title,  # Always the job-level title (show name for TV).
         'year': year,
         'artist': artist,
         'album': album,
         'season': season,
         'episode': episode,
-        'episode_name': '',  # Populated at track level from TVDB
+        'episode_name': '',  # Populated at track level from TVDB.
         'label': getattr(job, 'label', '') or '',
         'video_type': getattr(job, 'video_type', '') or '',
         'disc_number': str(getattr(job, 'disc_number', '') or ''),
         'disc_total': str(getattr(job, 'disc_total', '') or ''),
         'imdb_id': getattr(job, 'imdb_id', '') or '',
     })
+    return out
 
 
 def _clean_empty_parens(s):

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -287,7 +287,7 @@ def _build_webhook_payload(title, body, job, raw_basename):
         year=str(job.year or ''),
         disctype=str(job.disctype or ''),
         status=str(job.status or ''),
-        poster_url=str(job.poster_url or ''),
+        poster_url=str(job.media_metadata.poster_url or ''),
         title_name=clean_for_filename(render_title(job, config_dict)),
         config_overrides=overrides_dict,  # Pydantic coerces dict -> TranscodeJobConfig.
         multi_title=True if getattr(job, 'multi_title', False) else None,

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -728,6 +728,99 @@ async def _normalize_tmdb(
     }
 
 
+# ---------------------------------------------------------------------------
+# TMDb -> MediaMetadata adapter (post-MediaMetadata-contract migration)
+# ---------------------------------------------------------------------------
+
+
+def _tmdb_poster_url(poster_path: Optional[str]) -> Optional[str]:
+    if not poster_path:
+        return None
+    return f"{TMDB_POSTER_BASE}{poster_path}"
+
+
+def _tmdb_year_from_date(release_date: Optional[str]) -> Optional[str]:
+    if not release_date or len(release_date) < 4:
+        return None
+    head = release_date[:4]
+    return head if head.isdigit() else None
+
+
+def _tmdb_release_date(release_date: Optional[str]) -> Optional[date]:
+    if not release_date:
+        return None
+    try:
+        return datetime.strptime(release_date, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def _tmdb_us_certification(release_dates: Optional[dict]) -> Optional[str]:
+    """Find the US certification in TMDb's nested release_dates structure."""
+    if not release_dates:
+        return None
+    for entry in release_dates.get("results", []) or []:
+        if entry.get("iso_3166_1") == "US":
+            for rd in entry.get("release_dates") or []:
+                cert = rd.get("certification")
+                if cert:
+                    return cert
+    return None
+
+
+def _tmdb_extract_credits(credits: Optional[dict], role: str) -> list[str]:
+    """Extract crew names matching a job (e.g. 'Director', 'Writer')."""
+    if not credits:
+        return []
+    return [
+        c.get("name", "")
+        for c in (credits.get("crew") or [])
+        if c.get("job") == role and c.get("name")
+    ]
+
+
+def _tmdb_extract_cast(credits: Optional[dict], top_n: int = 5) -> list[str]:
+    if not credits:
+        return []
+    cast_sorted = sorted(
+        credits.get("cast") or [],
+        key=lambda c: c.get("order", 999),
+    )
+    return [c.get("name", "") for c in cast_sorted[:top_n] if c.get("name")]
+
+
+def _normalize_tmdb_movie_to_metadata(tmdb: dict) -> MediaMetadata:
+    """Convert a TMDb /movie/{id} response into MediaMetadata.
+
+    Assumes the response was fetched with
+    `?append_to_response=credits,release_dates` so credits + certification
+    are inline.
+    """
+    runtime_min = tmdb.get("runtime")
+    return MediaMetadata(
+        title=tmdb.get("title") or None,
+        year=_tmdb_year_from_date(tmdb.get("release_date")),
+        video_type=VideoType.movie,
+        imdb_id=tmdb.get("imdb_id") or None,
+        poster_url=_tmdb_poster_url(tmdb.get("poster_path")),
+        runtime_seconds=runtime_min * 60 if runtime_min else None,
+        plot=tmdb.get("overview") or None,
+        tagline=tmdb.get("tagline") or None,
+        released_date=_tmdb_release_date(tmdb.get("release_date")),
+        language=tmdb.get("original_language") or None,
+        country=(tmdb.get("origin_country") or [None])[0],
+        production_company=(
+            tmdb.get("production_companies") or [{}]
+        )[0].get("name") or None,
+        imdb_rating=tmdb.get("vote_average"),
+        genres=[g["name"] for g in tmdb.get("genres") or [] if g.get("name")],
+        directors=_tmdb_extract_credits(tmdb.get("credits"), "Director"),
+        writers=_tmdb_extract_credits(tmdb.get("credits"), "Writer"),
+        actors=_tmdb_extract_cast(tmdb.get("credits"), top_n=5),
+        mpaa_rating=_tmdb_us_certification(tmdb.get("release_dates")),
+    )
+
+
 async def _tmdb_get_imdb(
     tmdb_id: int, media_type: str, api_key: str
 ) -> str | None:

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -35,12 +35,6 @@ class MetadataConfigError(Exception):
     """Raised when metadata provider is not configured or returns an auth error."""
 
 
-def _extract_year(raw: str) -> str:
-    """Extract a 4-digit year from a date/range string."""
-    m = re.search(r"\d{4}", str(raw))
-    return m.group(0) if m else raw
-
-
 def _get_keys() -> dict[str, str | None]:
     """Read provider and API keys from live ARM config."""
     provider = str(cfg.arm_config.get("METADATA_PROVIDER", "omdb")).lower()
@@ -987,8 +981,7 @@ async def _tmdb_find(imdb_id: str, api_key: str) -> dict[str, Any] | None:
 
     title = item.get("title") or item.get("name", "")
     release = item.get("release_date") or item.get("first_air_date") or ""
-    year = _extract_year(release) if release else ""
-    poster_path = item.get("poster_path")
+    year = _tmdb_year_from_date(release) or ""
     backdrop_path = item.get("backdrop_path")
 
     log.info("TMDb detail for %s: %s (%s) [%s]", imdb_id, title, year, media_type)
@@ -997,7 +990,7 @@ async def _tmdb_find(imdb_id: str, api_key: str) -> dict[str, Any] | None:
         "year": year,
         "imdb_id": imdb_id,
         "media_type": media_type,
-        "poster_url": f"{TMDB_POSTER_BASE}{poster_path}" if poster_path else None,
+        "poster_url": _tmdb_poster_url(item.get("poster_path")),
         "plot": item.get("overview") or None,
         "background_url": f"{TMDB_POSTER_BASE}{backdrop_path}" if backdrop_path else None,
     }

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -508,7 +508,7 @@ async def _omdb_search(query: str, year: str | None, api_key: str, page: int = 1
     results = []
     if data.get("Response") == "True" and "Search" in data:
         for item in data["Search"]:
-            results.append(_normalize_omdb(item))
+            results.append(_omdb_to_legacy_dict(item))
         log.info("OMDb search for %r returned %d results", query, len(results))
         return results
 
@@ -523,31 +523,13 @@ async def _omdb_search(query: str, year: str | None, api_key: str, page: int = 1
             raise MetadataConfigError(_OMDB_KEY_ERROR)
         data = resp.json()
     if data.get("Response") == "True":
-        results.append(_normalize_omdb(data))
+        results.append(_omdb_to_legacy_dict(data))
     log.info("OMDb search for %r returned %d results (via ?t= fallback)", query, len(results))
     return results
 
 
-def _normalize_omdb(item: dict) -> dict[str, Any]:
-    media_type = (item.get("Type") or "movie").lower()
-    if media_type != "series":
-        media_type = "movie"
-    poster = item.get("Poster")
-    if poster == "N/A":
-        poster = None
-    year_raw = item.get("Year", "")
-    return {
-        "title": item.get("Title", ""),
-        "year": _extract_year(year_raw) if year_raw else "",
-        "imdb_id": item.get("imdbID"),
-        "media_type": media_type,
-        "poster_url": poster,
-        "runtime_seconds": parse_runtime(item.get("Runtime")),
-    }
-
-
 # ---------------------------------------------------------------------------
-# OMDb -> MediaMetadata adapter (post-MediaMetadata-contract migration)
+# OMDb -> MediaMetadata adapter (single source of truth for OMDb shape)
 # ---------------------------------------------------------------------------
 
 _OMDB_NA = "N/A"
@@ -645,6 +627,33 @@ def _normalize_omdb_to_metadata(omdb: dict) -> MediaMetadata:
     )
 
 
+def _omdb_to_legacy_dict(omdb: dict, *, include_details: bool = False) -> dict[str, Any]:
+    """Wire-shape projection of an OMDb response for the /api/v1/metadata HTTP API.
+
+    The HTTP wire shape is `media_type` (movie/series), not `video_type`
+    (enum), so we project from MediaMetadata back to the legacy field set
+    that arm-ui currently consumes. When `include_details` is True, also
+    emits `plot` + `background_url` (used by /metadata/{imdb_id}).
+    """
+    m = _normalize_omdb_to_metadata(omdb)
+    media_type = (
+        m.video_type.value if m.video_type is not None
+        else "movie"
+    )
+    out: dict[str, Any] = {
+        "title": m.title or "",
+        "year": m.year or "",
+        "imdb_id": m.imdb_id,
+        "media_type": media_type,
+        "poster_url": m.poster_url,
+        "runtime_seconds": m.runtime_seconds,
+    }
+    if include_details:
+        out["plot"] = m.plot
+        out["background_url"] = None  # OMDb has no background images
+    return out
+
+
 async def _omdb_details(imdb_id: str, api_key: str) -> dict[str, Any] | None:
     params = {"i": imdb_id, "plot": "short", "r": "json", "apikey": api_key}
     async with _http_client() as client:
@@ -655,11 +664,7 @@ async def _omdb_details(imdb_id: str, api_key: str) -> dict[str, Any] | None:
     if data.get("Response") != "True":
         log.debug("OMDb detail lookup for %s returned no result: %s", imdb_id, data.get("Error", "unknown"))
         return None
-    result = _normalize_omdb(data)
-    plot = data.get("Plot")
-    result["plot"] = plot if plot != "N/A" else None
-    result["background_url"] = None  # OMDb has no background images
-    return result
+    return _omdb_to_legacy_dict(data, include_details=True)
 
 
 # ---------------------------------------------------------------------------
@@ -685,7 +690,7 @@ async def _tmdb_search(query: str, year: str | None, api_key: str) -> list[dict[
     movie_count = data.get("total_results", 0)
     if movie_count > 0:
         for item in data["results"]:
-            results.append(await _normalize_tmdb(item, "movie", api_key))
+            results.append(await _tmdb_search_item_to_legacy_dict(item, "movie", api_key))
         log.info("TMDb movie search for %r returned %d results", query, len(results))
         return results
 
@@ -704,26 +709,29 @@ async def _tmdb_search(query: str, year: str | None, api_key: str) -> list[dict[
 
     if data.get("total_results", 0) > 0:
         for item in data["results"]:
-            results.append(await _normalize_tmdb(item, "series", api_key))
+            results.append(await _tmdb_search_item_to_legacy_dict(item, "series", api_key))
     log.info("TMDb TV search for %r returned %d results", query, len(results))
     return results
 
 
-async def _normalize_tmdb(
+async def _tmdb_search_item_to_legacy_dict(
     item: dict, media_type: str, api_key: str
 ) -> dict[str, Any]:
+    """Wire-shape projection of a TMDb search result for /api/v1/metadata.
+
+    TMDb search responses don't include imdb_id, so we fetch it via the
+    external_ids endpoint. TV results use `name` / `first_air_date` where
+    movies use `title` / `release_date`.
+    """
     title = item.get("title") or item.get("name", "")
     release = item.get("release_date") or item.get("first_air_date") or ""
-    year = _extract_year(release) if release else ""
-    poster_path = item.get("poster_path")
-    poster_url = f"{TMDB_POSTER_BASE}{poster_path}" if poster_path else None
     imdb_id = await _tmdb_get_imdb(item["id"], media_type, api_key)
     return {
-        "title": title,
-        "year": year,
+        "title": title or "",
+        "year": _tmdb_year_from_date(release) or "",
         "imdb_id": imdb_id,
         "media_type": media_type,
-        "poster_url": poster_url,
+        "poster_url": _tmdb_poster_url(item.get("poster_path")),
         "runtime_seconds": parse_runtime(item.get("runtime")),
     }
 

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -1,4 +1,4 @@
-"""Metadata services — async OMDb/TMDb/MusicBrainz/CRC64.
+"""Metadata services - async OMDb/TMDb/MusicBrainz/CRC64.
 
 Ported from the UI's clean httpx implementations. ARM is the single source
 of truth for all external metadata API calls. Reads keys from the in-memory
@@ -9,12 +9,15 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any
+from datetime import date, datetime
+from typing import Any, Optional
 
 import httpx
 
 import arm.config.config as cfg
 from arm.services.runtime_parsing import parse_runtime
+from arm_contracts import MediaMetadata
+from arm_contracts.enums import VideoType
 
 log = logging.getLogger(__name__)
 
@@ -541,6 +544,105 @@ def _normalize_omdb(item: dict) -> dict[str, Any]:
         "poster_url": poster,
         "runtime_seconds": parse_runtime(item.get("Runtime")),
     }
+
+
+# ---------------------------------------------------------------------------
+# OMDb -> MediaMetadata adapter (post-MediaMetadata-contract migration)
+# ---------------------------------------------------------------------------
+
+_OMDB_NA = "N/A"
+
+
+def _csv_to_list(value: Optional[str]) -> list[str]:
+    """Parse a CSV-formatted string into a list of trimmed entries.
+
+    Handles OMDb's 'N/A' sentinel and missing values.
+    """
+    if not value or value == _OMDB_NA:
+        return []
+    return [s.strip() for s in value.split(",") if s.strip()]
+
+
+def _none_if_na(value: Optional[str]) -> Optional[str]:
+    """Convert OMDb's 'N/A' sentinel to None."""
+    if not value or value == _OMDB_NA:
+        return None
+    return value
+
+
+def _parse_omdb_released(value: Optional[str]) -> Optional[date]:
+    """OMDb 'Released' format is '23 Feb 2018' or 'N/A'."""
+    cleaned = _none_if_na(value)
+    if not cleaned:
+        return None
+    try:
+        return datetime.strptime(cleaned, "%d %b %Y").date()
+    except ValueError:
+        return None
+
+
+def _parse_omdb_rating(value: Optional[str]) -> Optional[float]:
+    """OMDb 'imdbRating' is a numeric string or 'N/A'."""
+    cleaned = _none_if_na(value)
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def _parse_omdb_year(value: Optional[str]) -> Optional[str]:
+    """OMDb 'Year' is '2018' for movies, '2008-2013' or '2008-' for series.
+
+    Returns the first 4-digit year, or None if unparseable.
+    """
+    cleaned = _none_if_na(value)
+    if not cleaned:
+        return None
+    # Year ranges use '-' (hyphen) or '–' (en-dash)
+    head = re.split(r"[-–]", cleaned, maxsplit=1)[0].strip()
+    if len(head) == 4 and head.isdigit():
+        return head
+    return None
+
+
+def _parse_omdb_type(value: Optional[str]) -> Optional[VideoType]:
+    """OMDb 'Type' is 'movie', 'series', or 'episode'. Map to our enum."""
+    cleaned = (value or "").lower()
+    if cleaned == "series":
+        return VideoType.series
+    if cleaned == "movie":
+        return VideoType.movie
+    return None
+
+
+def _normalize_omdb_to_metadata(omdb: dict) -> MediaMetadata:
+    """Convert an OMDb response dict into a MediaMetadata instance.
+
+    All provider quirks (CSV lists, '120 min' runtime, '23 Feb 2018'
+    released, 'N/A' sentinels, year ranges) are normalized here. The
+    pydantic validator then enforces the canonical types.
+    """
+    return MediaMetadata(
+        title=_none_if_na(omdb.get("Title")),
+        year=_parse_omdb_year(omdb.get("Year")),
+        video_type=_parse_omdb_type(omdb.get("Type")),
+        imdb_id=_none_if_na(omdb.get("imdbID")),
+        poster_url=_none_if_na(omdb.get("Poster")),
+        runtime_seconds=parse_runtime(omdb.get("Runtime")),
+        plot=_none_if_na(omdb.get("Plot")),
+        genres=_csv_to_list(omdb.get("Genre")),
+        directors=_csv_to_list(omdb.get("Director")),
+        writers=_csv_to_list(omdb.get("Writer")),
+        actors=_csv_to_list(omdb.get("Actors")),
+        mpaa_rating=_none_if_na(omdb.get("Rated")),
+        released_date=_parse_omdb_released(omdb.get("Released")),
+        language=(_csv_to_list(omdb.get("Language")) or [None])[0],
+        country=_none_if_na(omdb.get("Country")),
+        production_company=_none_if_na(omdb.get("Production")),
+        imdb_rating=_parse_omdb_rating(omdb.get("imdbRating")),
+    )
 
 
 async def _omdb_details(imdb_id: str, api_key: str) -> dict[str, Any] | None:

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -874,6 +874,43 @@ def _normalize_tvdb_to_metadata(
     )
 
 
+# ---------------------------------------------------------------------------
+# MusicBrainz -> MediaMetadata adapter (post-MediaMetadata-contract migration)
+# ---------------------------------------------------------------------------
+
+
+def _mb_release_date(value: Optional[str]) -> Optional[date]:
+    """MusicBrainz 'date' field may be 'YYYY', 'YYYY-MM', or 'YYYY-MM-DD'."""
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def _normalize_musicbrainz_to_metadata(mb: dict) -> MediaMetadata:
+    """Convert a MusicBrainz /release/{id} response into MediaMetadata.
+
+    Sets video_type=VideoType.music, with album in `album`, artist in
+    `artist` + `album_artist` (same field on a release), and the cover
+    art URL composed from the release MBID.
+    """
+    mbid = mb.get("id") or ""
+    raw_date = mb.get("date") or ""
+    artist = _build_artist_credit(mb.get("artist-credit") or [])
+    return MediaMetadata(
+        video_type=VideoType.music,
+        album=mb.get("title") or None,
+        artist=artist or None,
+        album_artist=artist or None,
+        year=raw_date[:4] if raw_date and len(raw_date) >= 4 else None,
+        released_date=_mb_release_date(raw_date),
+        country=mb.get("country") or None,
+        poster_url=f"{COVERART_BASE}/{mbid}/front-250" if mbid else None,
+    )
+
+
 async def _tmdb_get_imdb(
     tmdb_id: int, media_type: str, api_key: str
 ) -> str | None:

--- a/arm/services/metadata.py
+++ b/arm/services/metadata.py
@@ -821,6 +821,59 @@ def _normalize_tmdb_movie_to_metadata(tmdb: dict) -> MediaMetadata:
     )
 
 
+# ---------------------------------------------------------------------------
+# TVDB -> MediaMetadata adapter (post-MediaMetadata-contract migration)
+# ---------------------------------------------------------------------------
+
+
+def _tvdb_extract_network(network: Any) -> Optional[str]:
+    """TVDB returns network as either {'name': ...} or a plain string."""
+    if isinstance(network, dict):
+        return network.get("name") or None
+    if isinstance(network, str):
+        return network or None
+    return None
+
+
+def _tvdb_extract_genres(genres: Any) -> list[str]:
+    """TVDB returns genres as either [{'name': ...}, ...] or [str, ...]."""
+    if not genres:
+        return []
+    out: list[str] = []
+    for g in genres:
+        if isinstance(g, dict):
+            name = g.get("name")
+            if name:
+                out.append(name)
+        elif isinstance(g, str) and g:
+            out.append(g)
+    return out
+
+
+def _normalize_tvdb_to_metadata(
+    tvdb: dict, *, video_type: VideoType
+) -> MediaMetadata:
+    """Convert a TVDB series/movie response into MediaMetadata.
+
+    Caller passes the canonical `video_type` because TVDB uses separate
+    endpoints (`/series/{id}` vs `/movies/{id}`) with the same payload
+    shape.
+    """
+    return MediaMetadata(
+        title=tvdb.get("name") or None,
+        year=tvdb.get("year") or _tmdb_year_from_date(tvdb.get("firstAired")),
+        video_type=video_type,
+        poster_url=tvdb.get("image") or None,
+        plot=tvdb.get("overview") or None,
+        released_date=_tmdb_release_date(tvdb.get("firstAired")),
+        language=tvdb.get("originalLanguage") or None,
+        country=tvdb.get("country") or None,
+        network=_tvdb_extract_network(tvdb.get("network")),
+        genres=_tvdb_extract_genres(tvdb.get("genres")),
+        imdb_rating=tvdb.get("score"),
+    )
+
+
 async def _tmdb_get_imdb(
     tmdb_id: int, media_type: str, api_key: str
 ) -> str | None:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -3377,3 +3377,33 @@ class TestApiRetranscodeInfo:
         assert data["multi_title"] is True
         assert len(data["tracks"]) == 1
         assert data["tracks"][0]["title"] == "The Movie"
+
+
+class TestApiJobMetadata:
+    """GET /api/v1/jobs/{job_id}/metadata returns the merged MediaMetadata."""
+
+    def test_get_job_metadata_endpoint(self, client, app_context):
+        from arm.database import db
+        from arm.models.job import Job
+        from arm_contracts import MediaMetadata
+
+        job = Job(devpath="/dev/sr0", _skip_hardware=True)
+        job.set_metadata_auto(MediaMetadata(
+            title="Annihilation",
+            year="2018",
+            directors=["Alex Garland"],
+            genres=["Sci-Fi", "Drama"],
+        ))
+        db.session.add(job)
+        db.session.commit()
+
+        resp = client.get(f"/api/v1/jobs/{job.job_id}/metadata")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["title"] == "Annihilation"
+        assert data["directors"] == ["Alex Garland"]
+        assert data["genres"] == ["Sci-Fi", "Drama"]
+
+    def test_get_job_metadata_404_for_unknown_job(self, client):
+        resp = client.get("/api/v1/jobs/999999/metadata")
+        assert resp.status_code == 404

--- a/test/test_folder_api.py
+++ b/test/test_folder_api.py
@@ -131,7 +131,11 @@ class TestFolderCreate:
         mock_threading.Thread.return_value.start.assert_called_once()
         # Verify optional fields were set on the job object
         assert mock_job.imdb_id == "tt1234567"
-        assert mock_job.poster_url == "https://example.com/poster.jpg"
+        # poster_url now lives in media_metadata_auto blob; verify the setter
+        # was called rather than the legacy attribute.
+        mock_job.set_metadata_auto.assert_called_once()
+        meta_arg = mock_job.set_metadata_auto.call_args.args[0]
+        assert meta_arg.poster_url == "https://example.com/poster.jpg"
 
     @patch("arm.api.v1.folder.cfg")
     def test_create_no_ingress_configured(self, mock_cfg):

--- a/test/test_identify.py
+++ b/test/test_identify.py
@@ -1244,7 +1244,7 @@ class TestMatcherIntegration:
     # -- Poster normalization --
 
     def test_poster_na_becomes_empty_string(self, app_context):
-        """OMDb 'N/A' poster stored as empty string on job."""
+        """OMDb 'N/A' poster results in no poster_url in media_metadata."""
         from arm.ripper.identify import update_job
 
         job = self._make_job(app_context, label="THE_MATRIX",
@@ -1253,11 +1253,11 @@ class TestMatcherIntegration:
             {'Title': 'The Matrix', 'Year': '1999',
              'imdbID': 'tt0133093', 'Type': 'movie', 'Poster': 'N/A'},
         ]})
-        assert job.poster_url == ''
-        assert job.poster_url_auto == ''
+        # No poster_url set means media_metadata.poster_url is None.
+        assert job.media_metadata.poster_url is None
 
     def test_poster_url_preserved(self, app_context):
-        """Real poster URL is stored as-is."""
+        """Real poster URL is stored in media_metadata_auto."""
         from arm.ripper.identify import update_job
 
         poster = f'{self.TMDB}/matrix.jpg'
@@ -1267,7 +1267,7 @@ class TestMatcherIntegration:
             {'Title': 'The Matrix', 'Year': '1999',
              'imdbID': 'tt0133093', 'Type': 'movie', 'Poster': poster},
         ]})
-        assert job.poster_url == poster
+        assert job.media_metadata.poster_url == poster
 
     # -- Title stored as-is from API (no sanitization) --
 

--- a/test/test_identify.py
+++ b/test/test_identify.py
@@ -614,8 +614,11 @@ class TestIdentifyDvdCrc:
             result = identify_dvd(job)
         assert result is True
         mock_details.assert_called_once_with("tt4824308")
+        # poster_url now flows through media_metadata_auto, not as a Job column.
         call_args = mock_utils.database_updater.call_args[0][0]
-        assert call_args["poster_url"] == "https://m.media-amazon.com/images/poster.jpg"
+        import json
+        blob = json.loads(call_args["media_metadata_auto"])
+        assert blob["poster_url"] == "https://m.media-amazon.com/images/poster.jpg"
 
     def test_crc_no_poster_no_imdb_skips_fallback(self):
         """CRC match with no poster and no IMDB ID doesn't attempt fallback."""
@@ -668,8 +671,11 @@ class TestIdentifyDvdCrc:
             mock_utils.extract_year.return_value = "2016"
             result = identify_dvd(job)
         assert result is True
+        # Poster fallback failed -> empty poster_url stored in the blob as None.
         call_args = mock_utils.database_updater.call_args[0][0]
-        assert call_args["poster_url"] == ""
+        import json
+        blob = json.loads(call_args["media_metadata_auto"])
+        assert blob["poster_url"] is None
 
     def test_pydvdid_exception_returns_false(self):
         """pydvdid.compute() exception is caught, returns False."""

--- a/test/test_import_helpers.py
+++ b/test/test_import_helpers.py
@@ -68,7 +68,10 @@ class TestApplyRequestMetadataToJob:
         apply_request_metadata_to_job(job, req)
 
         assert job.imdb_id == "tt1375666"
-        assert job.poster_url == "https://x/p.jpg"
+        # poster_url now goes through set_metadata_auto with a MediaMetadata.
+        job.set_metadata_auto.assert_called_once()
+        meta_arg = job.set_metadata_auto.call_args.args[0]
+        assert meta_arg.poster_url == "https://x/p.jpg"
 
     def test_skips_imdb_and_poster_when_absent(self):
         from arm.api.v1._import_helpers import apply_request_metadata_to_job
@@ -77,8 +80,12 @@ class TestApplyRequestMetadataToJob:
         req = self._req(imdb_id=None, poster_url=None)
         apply_request_metadata_to_job(job, req)
 
+        # SimpleNamespace doesn't auto-create attrs, so a successful skip
+        # leaves these unset (no AttributeError on hasattr).
         assert not hasattr(job, "imdb_id") or job.imdb_id is None
-        assert not hasattr(job, "poster_url") or job.poster_url is None
+        # poster_url no longer flows through a job attribute - it goes
+        # through set_metadata_auto, which isn't on a bare SimpleNamespace.
+        assert not hasattr(job, "set_metadata_auto")
 
     def test_applies_season_disc_number_disc_total(self):
         from arm.api.v1._import_helpers import apply_request_metadata_to_job

--- a/test/test_job_media_metadata.py
+++ b/test/test_job_media_metadata.py
@@ -1,0 +1,74 @@
+"""Tests for Job.media_metadata storage + merged-read property."""
+from datetime import date
+
+import pytest
+
+from arm.database import db
+from arm.models.job import Job
+from arm_contracts import MediaMetadata
+from arm_contracts.enums import VideoType
+
+
+@pytest.fixture
+def fresh_job(app_context):
+    """A fresh Job with no metadata."""
+    job = Job(devpath="/dev/sr0", _skip_hardware=True)
+    db.session.add(job)
+    db.session.commit()
+    return job
+
+
+def test_media_metadata_returns_empty_when_unset(fresh_job):
+    """A Job with neither column populated returns an empty MediaMetadata."""
+    m = fresh_job.media_metadata
+    assert isinstance(m, MediaMetadata)
+    assert m.title is None
+    assert m.genres == []
+
+
+def test_writes_to_auto_column(fresh_job):
+    """Adapter writes go to media_metadata_auto."""
+    fresh_job.set_metadata_auto(MediaMetadata(
+        title="Auto Title",
+        year="2024",
+        directors=["Auto Director"],
+    ))
+    db.session.commit()
+
+    db.session.expire_all()
+    reloaded = Job.query.get(fresh_job.job_id)
+    assert reloaded.media_metadata.title == "Auto Title"
+    assert reloaded.media_metadata.directors == ["Auto Director"]
+
+
+def test_manual_overrides_auto_field_by_field(fresh_job):
+    """Manual overrides win field-by-field; unset manual fields fall through to auto."""
+    fresh_job.set_metadata_auto(MediaMetadata(
+        title="Auto Title",
+        year="2024",
+        directors=["Auto Director"],
+        plot="Auto plot.",
+    ))
+    fresh_job.set_metadata_manual(MediaMetadata(
+        title="Manual Title",  # overrides auto
+        # year unset -> falls through to auto
+        directors=[],          # empty list = unset -> falls through
+        plot="",               # empty string treated as set if non-None? See below.
+    ))
+    db.session.commit()
+
+    merged = fresh_job.media_metadata
+    assert merged.title == "Manual Title"           # manual wins
+    assert merged.year == "2024"                    # auto fills
+    assert merged.directors == ["Auto Director"]    # empty manual list = unset
+
+
+def test_set_metadata_manual_partial_payload(fresh_job):
+    """UI overrides typically set one or two fields, not the full model."""
+    fresh_job.set_metadata_auto(MediaMetadata(title="Auto", year="2024"))
+    fresh_job.set_metadata_manual(MediaMetadata(year="2025"))  # only year
+    db.session.commit()
+
+    merged = fresh_job.media_metadata
+    assert merged.title == "Auto"   # untouched manual field falls through
+    assert merged.year == "2025"    # manual overrides

--- a/test/test_job_model.py
+++ b/test/test_job_model.py
@@ -113,17 +113,17 @@ class TestPatternEngineIntegration:
 
     def test_music_formatted_title_uses_pattern(self, sample_job):
         """With artist+album set, formatted_title uses the music title pattern."""
+        from arm_contracts import MediaMetadata
         sample_job.video_type = "music"
-        sample_job.artist = "The Beatles"
-        sample_job.album = "Abbey Road"
+        sample_job.set_metadata_auto(MediaMetadata(artist="The Beatles", album="Abbey Road"))
         sample_job.year = "1969"
         assert sample_job.formatted_title == "The Beatles - Abbey Road"
 
     def test_music_folder_path_uses_pattern(self, sample_job):
         """With artist+album set, build_final_path uses the music folder pattern."""
+        from arm_contracts import MediaMetadata
         sample_job.video_type = "music"
-        sample_job.artist = "The Beatles"
-        sample_job.album = "Abbey Road"
+        sample_job.set_metadata_auto(MediaMetadata(artist="The Beatles", album="Abbey Road"))
         sample_job.year = "1969"
         path = sample_job.build_final_path()
         assert path == os.path.join(
@@ -132,9 +132,9 @@ class TestPatternEngineIntegration:
         )
 
     def test_music_transcode_path_uses_pattern(self, sample_job):
+        from arm_contracts import MediaMetadata
         sample_job.video_type = "music"
-        sample_job.artist = "Pink Floyd"
-        sample_job.album = "The Wall"
+        sample_job.set_metadata_auto(MediaMetadata(artist="Pink Floyd", album="The Wall"))
         sample_job.year = "1979"
         path = sample_job.build_transcode_path()
         assert path == os.path.join(
@@ -144,10 +144,10 @@ class TestPatternEngineIntegration:
 
     def test_music_manual_artist_preferred(self, sample_job):
         """Manual artist overrides auto-detected artist."""
+        from arm_contracts import MediaMetadata
         sample_job.video_type = "music"
-        sample_job.artist = "beatles"
-        sample_job.artist_manual = "The Beatles"
-        sample_job.album = "Help"
+        sample_job.set_metadata_auto(MediaMetadata(artist="beatles", album="Help"))
+        sample_job.set_metadata_manual(MediaMetadata(artist="The Beatles"))
         assert sample_job.formatted_title == "The Beatles - Help"
 
     def test_music_falls_back_without_structured_fields(self, sample_job):

--- a/test/test_job_model.py
+++ b/test/test_job_model.py
@@ -207,37 +207,23 @@ class TestPatternEngineIntegration:
 
     def test_raw_path_unaffected_by_structured_fields(self, sample_job):
         """build_raw_path always uses GUID, never the pattern engine."""
+        from arm_contracts import MediaMetadata
         sample_job.video_type = "music"
-        sample_job.artist = "The Beatles"
-        sample_job.album = "Abbey Road"
+        sample_job.set_metadata_auto(MediaMetadata(
+            artist="The Beatles",
+            album="Abbey Road",
+        ))
         sample_job.title_auto = "Beatles Abbey Road"
         assert sample_job.build_raw_path() == f"/home/arm/media/raw/{sample_job.guid}"
 
 
 class TestStructuredFieldColumns:
-    """Test that the 12 new structured columns exist and are persisted."""
+    """Test the surviving structured columns (season/episode).
 
-    def test_artist_columns_persist(self, sample_job, app_context):
-        from arm.database import db
-        sample_job.artist = "Queen"
-        sample_job.artist_auto = "Queen"
-        sample_job.artist_manual = "Queen (band)"
-        db.session.commit()
-        db.session.refresh(sample_job)
-        assert sample_job.artist == "Queen"
-        assert sample_job.artist_auto == "Queen"
-        assert sample_job.artist_manual == "Queen (band)"
-
-    def test_album_columns_persist(self, sample_job, app_context):
-        from arm.database import db
-        sample_job.album = "Jazz"
-        sample_job.album_auto = "Jazz"
-        sample_job.album_manual = None
-        db.session.commit()
-        db.session.refresh(sample_job)
-        assert sample_job.album == "Jazz"
-        assert sample_job.album_auto == "Jazz"
-        assert sample_job.album_manual is None
+    artist/album/poster_url columns were retired by the
+    media_metadata_columns migration; their replacements live in the
+    media_metadata JSON blob and are covered by test_job_media_metadata.py.
+    """
 
     def test_season_episode_columns_persist(self, sample_job, app_context):
         from arm.database import db
@@ -253,11 +239,9 @@ class TestStructuredFieldColumns:
         assert sample_job.episode_manual == "13"
 
     def test_columns_nullable(self, sample_job, app_context):
-        """All structured fields default to None."""
+        """Surviving structured fields default to None."""
         from arm.database import db
         db.session.refresh(sample_job)
-        assert sample_job.artist is None
-        assert sample_job.album is None
         assert sample_job.season is None
         assert sample_job.episode is None
 

--- a/test/test_metadata_runtime.py
+++ b/test/test_metadata_runtime.py
@@ -3,18 +3,18 @@
 import json
 from pathlib import Path
 
-from arm.services.metadata import _normalize_omdb
+from arm.services.metadata import _omdb_to_legacy_dict
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "metadata"
 
 
-def test_normalize_omdb_keeps_runtime():
+def test_omdb_to_legacy_dict_keeps_runtime():
     data = json.loads((_FIXTURES / "omdb_movie_with_runtime.json").read_text())
-    result = _normalize_omdb(data)
+    result = _omdb_to_legacy_dict(data)
     assert result["runtime_seconds"] == 8880  # 148 * 60
 
 
-def test_normalize_omdb_runtime_na_returns_none():
+def test_omdb_to_legacy_dict_runtime_na_returns_none():
     data = json.loads((_FIXTURES / "omdb_runtime_na.json").read_text())
-    result = _normalize_omdb(data)
+    result = _omdb_to_legacy_dict(data)
     assert result["runtime_seconds"] is None

--- a/test/test_metadata_service.py
+++ b/test/test_metadata_service.py
@@ -1,6 +1,6 @@
 """Tests for arm/services/metadata.py - async metadata service.
 
-Covers: _get_keys, has_api_key, _extract_year, _escape_lucene,
+Covers: _get_keys, has_api_key, _escape_lucene,
 _omdb_to_legacy_dict, _normalize_omdb_to_metadata, _normalize_tmdb_movie_to_metadata,
 _normalize_tvdb_to_metadata, _normalize_musicbrainz_to_metadata,
 _build_artist_credit, _extract_label, _extract_catalog_number, _extract_format,
@@ -61,32 +61,6 @@ def _patch_http_client(responses):
 # ---------------------------------------------------------------------------
 # Pure helpers
 # ---------------------------------------------------------------------------
-
-
-class TestExtractYear:
-    def test_date_string(self):
-        from arm.services.metadata import _extract_year
-        assert _extract_year("1999-03-31") == "1999"
-
-    def test_year_only(self):
-        from arm.services.metadata import _extract_year
-        assert _extract_year("2001") == "2001"
-
-    def test_range_returns_first(self):
-        from arm.services.metadata import _extract_year
-        assert _extract_year("2011-2019") == "2011"
-
-    def test_dash_range(self):
-        from arm.services.metadata import _extract_year
-        assert _extract_year("2011–2019") == "2011"
-
-    def test_no_year_returns_raw(self):
-        from arm.services.metadata import _extract_year
-        assert _extract_year("unknown") == "unknown"
-
-    def test_empty_string(self):
-        from arm.services.metadata import _extract_year
-        assert _extract_year("") == ""
 
 
 class TestEscapeLucene:

--- a/test/test_metadata_service.py
+++ b/test/test_metadata_service.py
@@ -1710,3 +1710,52 @@ def test_normalize_tvdb_handles_string_network_and_genres():
     m = _normalize_tvdb_to_metadata(tvdb, video_type=VideoType.series)
     assert m.network == "HBO"
     assert m.genres == ["Drama", "Sci-Fi"]
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz -> MediaMetadata normalization (Task 12)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_musicbrainz_release_returns_media_metadata():
+    """MusicBrainz release response normalizes to MediaMetadata for audio CDs."""
+    from datetime import date
+    from arm.services.metadata import _normalize_musicbrainz_to_metadata
+    from arm_contracts.enums import VideoType
+
+    mb = {
+        "id": "abc-123",
+        "title": "The Dark Side of the Moon",
+        "date": "1973-03-01",
+        "country": "GB",
+        "artist-credit": [
+            {"name": "Pink Floyd", "artist": {"name": "Pink Floyd"}},
+        ],
+    }
+    m = _normalize_musicbrainz_to_metadata(mb)
+    assert m.video_type == VideoType.music
+    assert m.album == "The Dark Side of the Moon"
+    assert m.artist == "Pink Floyd"
+    assert m.album_artist == "Pink Floyd"
+    assert m.year == "1973"
+    assert m.released_date == date(1973, 3, 1)
+    assert m.country == "GB"
+    assert "abc-123" in (m.poster_url or "")
+
+
+def test_normalize_musicbrainz_handles_missing_fields():
+    """MusicBrainz returns sparse data for obscure releases."""
+    from arm.services.metadata import _normalize_musicbrainz_to_metadata
+    from arm_contracts.enums import VideoType
+
+    mb = {
+        "id": "xyz",
+        "title": "Untitled",
+        # no date, no artist-credit, no country
+    }
+    m = _normalize_musicbrainz_to_metadata(mb)
+    assert m.video_type == VideoType.music
+    assert m.album == "Untitled"
+    assert m.artist is None
+    assert m.year is None
+    assert m.released_date is None

--- a/test/test_metadata_service.py
+++ b/test/test_metadata_service.py
@@ -1659,3 +1659,54 @@ def test_normalize_tmdb_movie_returns_media_metadata():
     assert m.actors == ["Natalie Portman", "Jennifer Jason Leigh"]
     assert m.mpaa_rating == "R"  # US certification
     assert "https://image.tmdb.org/t/p/" in (m.poster_url or "")
+
+
+# ---------------------------------------------------------------------------
+# TVDB -> MediaMetadata normalization (Task 11)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_tvdb_series_returns_media_metadata():
+    from arm.services.metadata import _normalize_tvdb_to_metadata
+    from arm_contracts.enums import VideoType
+
+    tvdb = {
+        "id": 81189,
+        "name": "Breaking Bad",
+        "firstAired": "2008-01-20",
+        "image": "https://artworks.thetvdb.com/path.jpg",
+        "overview": "A high-school chemistry teacher...",
+        "originalLanguage": "eng",
+        "country": "USA",
+        "network": {"name": "AMC"},
+        "score": 9.4,
+        "year": "2008",
+        # genres in TVDB are sometimes a list of objects, sometimes strings
+        "genres": [{"name": "Drama"}, {"name": "Crime"}],
+    }
+    m = _normalize_tvdb_to_metadata(tvdb, video_type=VideoType.series)
+    assert m.title == "Breaking Bad"
+    assert m.video_type == VideoType.series
+    assert m.year == "2008"
+    assert m.network == "AMC"
+    assert m.genres == ["Drama", "Crime"]
+    assert m.country == "USA"
+    assert m.language == "eng"
+    assert m.imdb_rating == pytest.approx(9.4)
+
+
+def test_normalize_tvdb_handles_string_network_and_genres():
+    """TVDB sometimes returns network/genres as plain strings, sometimes objects."""
+    from arm.services.metadata import _normalize_tvdb_to_metadata
+    from arm_contracts.enums import VideoType
+
+    tvdb = {
+        "id": 42,
+        "name": "Some Show",
+        "year": "2020",
+        "network": "HBO",        # plain string
+        "genres": ["Drama", "Sci-Fi"],  # list of strings
+    }
+    m = _normalize_tvdb_to_metadata(tvdb, video_type=VideoType.series)
+    assert m.network == "HBO"
+    assert m.genres == ["Drama", "Sci-Fi"]

--- a/test/test_metadata_service.py
+++ b/test/test_metadata_service.py
@@ -1596,3 +1596,66 @@ def test_normalize_omdb_series_sets_video_type_series():
     assert m.video_type == VideoType.series
     # Year range '2008-2013' should yield first year 2008
     assert m.year == "2008"
+
+
+# ---------------------------------------------------------------------------
+# TMDb -> MediaMetadata normalization (Task 10)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_tmdb_movie_returns_media_metadata():
+    """TMDb movie /{id} response normalizes to MediaMetadata."""
+    from datetime import date
+    from arm.services.metadata import _normalize_tmdb_movie_to_metadata
+
+    tmdb = {
+        "id": 300668,
+        "title": "Annihilation",
+        "release_date": "2018-02-22",
+        "runtime": 115,
+        "overview": "A biologist...",
+        "tagline": "Fear what's inside.",
+        "poster_path": "/path.jpg",
+        "backdrop_path": "/back.jpg",
+        "imdb_id": "tt2798920",
+        "original_language": "en",
+        "origin_country": ["US"],
+        "production_companies": [{"name": "Paramount"}],
+        "vote_average": 6.8,
+        "genres": [{"name": "Drama"}, {"name": "Sci-Fi"}],
+        "credits": {
+            "crew": [
+                {"job": "Director", "name": "Alex Garland"},
+                {"job": "Writer", "name": "Alex Garland"},
+                {"job": "Director of Photography", "name": "Rob Hardy"},
+            ],
+            "cast": [
+                {"name": "Natalie Portman", "order": 0},
+                {"name": "Jennifer Jason Leigh", "order": 1},
+            ],
+        },
+        "release_dates": {
+            "results": [
+                {"iso_3166_1": "US", "release_dates": [{"certification": "R"}]},
+                {"iso_3166_1": "GB", "release_dates": [{"certification": "15"}]},
+            ],
+        },
+    }
+    m = _normalize_tmdb_movie_to_metadata(tmdb)
+    assert m.title == "Annihilation"
+    assert m.year == "2018"
+    assert m.runtime_seconds == 115 * 60
+    assert m.released_date == date(2018, 2, 22)
+    assert m.plot == "A biologist..."
+    assert m.tagline == "Fear what's inside."
+    assert m.imdb_id == "tt2798920"
+    assert m.language == "en"
+    assert m.country == "US"
+    assert m.production_company == "Paramount"
+    assert m.imdb_rating == pytest.approx(6.8)
+    assert m.genres == ["Drama", "Sci-Fi"]
+    assert m.directors == ["Alex Garland"]
+    assert m.writers == ["Alex Garland"]
+    assert m.actors == ["Natalie Portman", "Jennifer Jason Leigh"]
+    assert m.mpaa_rating == "R"  # US certification
+    assert "https://image.tmdb.org/t/p/" in (m.poster_url or "")

--- a/test/test_metadata_service.py
+++ b/test/test_metadata_service.py
@@ -1499,3 +1499,100 @@ class TestLookupCrcEdgeCases:
             result = _run(lookup_crc("abc123"))
         assert result["found"] is True
         assert len(result["results"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# OMDb -> MediaMetadata normalization (Task 9)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_omdb_full_response_returns_media_metadata():
+    """Real-shape OMDb response normalizes to MediaMetadata."""
+    from datetime import date
+    from arm.services.metadata import _normalize_omdb_to_metadata
+    from arm_contracts import MediaMetadata
+    from arm_contracts.enums import VideoType
+
+    omdb = {
+        "Title": "Annihilation",
+        "Year": "2018",
+        "Type": "movie",
+        "imdbID": "tt2798920",
+        "Poster": "https://example.com/poster.jpg",
+        "Runtime": "115 min",
+        "Plot": "A biologist signs up...",
+        "Genre": "Drama, Sci-Fi, Adventure",
+        "Director": "Alex Garland",
+        "Writer": "Alex Garland, Jeff VanderMeer (novel)",
+        "Actors": "Natalie Portman, Jennifer Jason Leigh",
+        "Rated": "R",
+        "Released": "23 Feb 2018",
+        "Language": "English",
+        "Country": "USA, UK",
+        "Production": "Paramount Pictures",
+        "imdbRating": "6.8",
+        "Response": "True",
+    }
+    m = _normalize_omdb_to_metadata(omdb)
+    assert isinstance(m, MediaMetadata)
+    assert m.title == "Annihilation"
+    assert m.year == "2018"
+    assert m.video_type == VideoType.movie
+    assert m.imdb_id == "tt2798920"
+    assert m.poster_url == "https://example.com/poster.jpg"
+    assert m.runtime_seconds == 115 * 60
+    assert m.plot == "A biologist signs up..."
+    assert m.genres == ["Drama", "Sci-Fi", "Adventure"]
+    assert m.directors == ["Alex Garland"]
+    assert m.writers == ["Alex Garland", "Jeff VanderMeer (novel)"]
+    assert m.actors == ["Natalie Portman", "Jennifer Jason Leigh"]
+    assert m.mpaa_rating == "R"
+    assert m.released_date == date(2018, 2, 23)
+    assert m.language == "English"
+    assert m.country == "USA, UK"
+    assert m.production_company == "Paramount Pictures"
+    assert m.imdb_rating == pytest.approx(6.8)
+
+
+def test_normalize_omdb_handles_n_a_sentinel():
+    """OMDb's 'N/A' sentinel should not surface as the literal string."""
+    from arm.services.metadata import _normalize_omdb_to_metadata
+
+    omdb = {
+        "Title": "Old Movie",
+        "Year": "1950",
+        "Type": "movie",
+        "imdbID": "tt0042500",
+        "Poster": "N/A",
+        "Runtime": "N/A",
+        "Plot": "N/A",
+        "Genre": "N/A",
+        "Director": "N/A",
+        "imdbRating": "N/A",
+        "Response": "True",
+    }
+    m = _normalize_omdb_to_metadata(omdb)
+    assert m.poster_url is None
+    assert m.runtime_seconds is None
+    assert m.plot is None
+    assert m.genres == []
+    assert m.directors == []
+    assert m.imdb_rating is None
+
+
+def test_normalize_omdb_series_sets_video_type_series():
+    """OMDb Type 'series' maps to VideoType.series."""
+    from arm.services.metadata import _normalize_omdb_to_metadata
+    from arm_contracts.enums import VideoType
+
+    omdb = {
+        "Title": "Breaking Bad",
+        "Year": "2008-2013",
+        "Type": "series",
+        "imdbID": "tt0903747",
+        "Response": "True",
+    }
+    m = _normalize_omdb_to_metadata(omdb)
+    assert m.video_type == VideoType.series
+    # Year range '2008-2013' should yield first year 2008
+    assert m.year == "2008"

--- a/test/test_metadata_service.py
+++ b/test/test_metadata_service.py
@@ -1,10 +1,11 @@
-"""Tests for arm/services/metadata.py — async metadata service.
+"""Tests for arm/services/metadata.py - async metadata service.
 
 Covers: _get_keys, has_api_key, _extract_year, _escape_lucene,
-_normalize_omdb, _build_artist_credit, _extract_label, _extract_catalog_number,
-_extract_format, _omdb_search, _omdb_details, _tmdb_search, _tmdb_find,
-_tmdb_get_imdb, search, get_details, search_music, get_music_details,
-lookup_crc, test_configured_key.
+_omdb_to_legacy_dict, _normalize_omdb_to_metadata, _normalize_tmdb_movie_to_metadata,
+_normalize_tvdb_to_metadata, _normalize_musicbrainz_to_metadata,
+_build_artist_credit, _extract_label, _extract_catalog_number, _extract_format,
+_omdb_search, _omdb_details, _tmdb_search, _tmdb_find, _tmdb_get_imdb, search,
+get_details, search_music, get_music_details, lookup_crc, test_configured_key.
 """
 
 import asyncio
@@ -112,10 +113,16 @@ class TestEscapeLucene:
         assert "\\-" in result
 
 
-class TestNormalizeOmdb:
+class TestOmdbToLegacyDict:
+    """Wire-shape projection used by /api/v1/metadata/search and /metadata/{id}.
+
+    Backs the dict that arm-ui currently consumes; field names are stable
+    even after we moved the underlying normalization to MediaMetadata.
+    """
+
     def test_movie_type(self):
-        from arm.services.metadata import _normalize_omdb
-        result = _normalize_omdb({"Title": "Matrix", "Year": "1999", "Type": "movie",
+        from arm.services.metadata import _omdb_to_legacy_dict
+        result = _omdb_to_legacy_dict({"Title": "Matrix", "Year": "1999", "Type": "movie",
                                    "imdbID": "tt0133093", "Poster": "http://img.com/p.jpg"})
         assert result["title"] == "Matrix"
         assert result["year"] == "1999"
@@ -124,32 +131,32 @@ class TestNormalizeOmdb:
         assert result["poster_url"] == "http://img.com/p.jpg"
 
     def test_series_type(self):
-        from arm.services.metadata import _normalize_omdb
-        result = _normalize_omdb({"Title": "Friends", "Year": "1994–2004", "Type": "series",
+        from arm.services.metadata import _omdb_to_legacy_dict
+        result = _omdb_to_legacy_dict({"Title": "Friends", "Year": "1994–2004", "Type": "series",
                                    "imdbID": "tt0108778", "Poster": "N/A"})
         assert result["media_type"] == "series"
         assert result["year"] == "1994"
         assert result["poster_url"] is None
 
     def test_unknown_type_defaults_to_movie(self):
-        from arm.services.metadata import _normalize_omdb
-        result = _normalize_omdb({"Title": "X", "Year": "2020", "Type": "game",
+        from arm.services.metadata import _omdb_to_legacy_dict
+        result = _omdb_to_legacy_dict({"Title": "X", "Year": "2020", "Type": "game",
                                    "imdbID": "tt0000001"})
         assert result["media_type"] == "movie"
 
     def test_missing_type_defaults_to_movie(self):
-        from arm.services.metadata import _normalize_omdb
-        result = _normalize_omdb({"Title": "X", "Year": "2020", "imdbID": "tt0000001"})
+        from arm.services.metadata import _omdb_to_legacy_dict
+        result = _omdb_to_legacy_dict({"Title": "X", "Year": "2020", "imdbID": "tt0000001"})
         assert result["media_type"] == "movie"
 
     def test_poster_na_normalized_to_none(self):
-        from arm.services.metadata import _normalize_omdb
-        result = _normalize_omdb({"Title": "X", "Year": "2020", "Poster": "N/A"})
+        from arm.services.metadata import _omdb_to_legacy_dict
+        result = _omdb_to_legacy_dict({"Title": "X", "Year": "2020", "Poster": "N/A"})
         assert result["poster_url"] is None
 
     def test_missing_poster(self):
-        from arm.services.metadata import _normalize_omdb
-        result = _normalize_omdb({"Title": "X", "Year": "2020"})
+        from arm.services.metadata import _omdb_to_legacy_dict
+        result = _omdb_to_legacy_dict({"Title": "X", "Year": "2020"})
         assert result["poster_url"] is None
 
 

--- a/test/test_naming.py
+++ b/test/test_naming.py
@@ -14,7 +14,13 @@ from arm.ripper.naming import (
 
 
 def _make_job(**kwargs):
-    """Create a SimpleNamespace that quacks like a Job for pattern rendering."""
+    """Create a SimpleNamespace that quacks like a Job for pattern rendering.
+
+    Builds a MediaMetadata attached as job.media_metadata so the engine's
+    single code path (read-from-MediaMetadata) works without a real DB.
+    Manual overrides win field-by-field via a stacked merge.
+    """
+    from arm_contracts import MediaMetadata
     defaults = {
         'title': None, 'title_manual': None, 'title_auto': None,
         'year': None, 'year_manual': None, 'year_auto': None,
@@ -22,10 +28,20 @@ def _make_job(**kwargs):
         'album': None, 'album_manual': None, 'album_auto': None,
         'season': None, 'season_manual': None, 'season_auto': None,
         'episode': None, 'episode_manual': None, 'episode_auto': None,
-        'video_type': 'movie', 'label': None,
+        'video_type': 'movie', 'label': None, 'imdb_id': None,
+        'disc_number': None, 'disc_total': None,
         'title_pattern_override': None, 'folder_pattern_override': None,
     }
     defaults.update(kwargs)
+    # Build MediaMetadata from artist/album defaults (with manual-over-base
+    # override). The engine reads music tokens exclusively from here now.
+    artist = defaults.get('artist_manual') or defaults.get('artist') or None
+    album = defaults.get('album_manual') or defaults.get('album') or None
+    defaults['media_metadata'] = MediaMetadata(
+        artist=artist,
+        album=album,
+        album_artist=artist,
+    )
     return SimpleNamespace(**defaults)
 
 

--- a/test/test_naming.py
+++ b/test/test_naming.py
@@ -714,3 +714,71 @@ def test_clean_for_filename_preserves_square_brackets():
     """clean_for_filename keeps [] so [imdbid-ttXXXXXXX] tags survive."""
     from arm.ripper.naming import clean_for_filename
     assert clean_for_filename('Foo (2024) [imdbid-tt1234567]') == 'Foo (2024) [imdbid-tt1234567]'
+
+
+# --- PATTERN_TOKENS contract derivation (Task 13) ---
+
+
+def test_pattern_variables_includes_new_contract_tokens():
+    """The naming engine must expose every PATTERN_TOKENS alias as a variable."""
+    from arm.ripper.naming import PATTERN_VARIABLES, VALID_VARS
+    from arm_contracts import PATTERN_TOKENS
+
+    for alias in PATTERN_TOKENS:
+        assert alias in PATTERN_VARIABLES, f"missing token in engine: {alias}"
+        assert alias in VALID_VARS
+
+    # Engine-only tokens (not in contract): label, disc_number, disc_total, episode
+    for engine_alias in ("label", "disc_number", "disc_total", "episode"):
+        assert engine_alias in PATTERN_VARIABLES
+
+
+def test_render_title_uses_director_token(app_context):
+    """A pattern with {director} renders from MediaMetadata.directors[0]."""
+    from arm.database import db
+    from arm.models.job import Job
+    from arm.ripper.naming import render_title
+    from arm_contracts import MediaMetadata
+    from arm_contracts.enums import VideoType
+
+    job = Job(devpath="/dev/sr0", _skip_hardware=True)
+    job.video_type = "movie"  # the existing column drives pattern selection
+    job.title = "Annihilation"
+    job.year = "2018"
+    job.set_metadata_auto(MediaMetadata(
+        title="Annihilation",
+        year="2018",
+        video_type=VideoType.movie,
+        directors=["Alex Garland"],
+        genres=["Sci-Fi", "Drama"],
+        mpaa_rating="R",
+    ))
+    db.session.add(job)
+    db.session.commit()
+
+    rendered = render_title(job, config_dict={
+        "MOVIE_TITLE_PATTERN": "{title} - {director} ({year})"
+    })
+    assert rendered == "Annihilation - Alex Garland (2018)"
+
+
+def test_render_title_genre_token_returns_first(app_context):
+    from arm.database import db
+    from arm.models.job import Job
+    from arm.ripper.naming import render_title
+    from arm_contracts import MediaMetadata
+
+    job = Job(devpath="/dev/sr0", _skip_hardware=True)
+    job.video_type = "movie"
+    job.title = "Test"
+    job.set_metadata_auto(MediaMetadata(
+        title="Test", year="2024",
+        genres=["Sci-Fi", "Drama"],
+    ))
+    db.session.add(job)
+    db.session.commit()
+
+    rendered = render_title(job, config_dict={
+        "MOVIE_TITLE_PATTERN": "{title} [{genre}]"
+    })
+    assert rendered == "Test [Sci-Fi]"


### PR DESCRIPTION
## Summary

Phase 2 of the MediaMetadata-contract rollout (Phase 1 shipped in contracts v3.2.0). Implements arm-neu side of the contract per `docs/superpowers/specs/2026-05-10-media-metadata-contract-design.md`.

## Wire-level changes

- **Two JSON columns on Job** (`media_metadata_auto`, `media_metadata_manual`) holding pydantic-serialized `MediaMetadata`. Read property merges manual-over-auto field-by-field.
- **Retired columns** (alembic migration `u6v7w8x9y0`):
  - `poster_url`, `poster_url_auto`, `poster_url_manual`
  - `artist`, `artist_auto`, `artist_manual`
  - `album`, `album_auto`, `album_manual`
  - Backfilled into `media_metadata_*` blobs before drop. Downgrade is best-effort (loses any non-{poster_url,artist,album} MediaMetadata fields).

## API surface

- **`GET /api/v1/jobs/{id}/metadata`** returns merged MediaMetadata as JSON. arm-ui BFF will proxy this in Phase 3.

## Provider adapters (additive)

Each returns a `MediaMetadata` instance alongside the existing dict-shape function so legacy callers keep working:

- **OMDb**: `_normalize_omdb_to_metadata` - handles 'N/A' sentinel, CSV-to-list, '23 Feb 2018' date format, year-range parsing, type-to-VideoType mapping
- **TMDb**: `_normalize_tmdb_movie_to_metadata` - expects `?append_to_response=credits,release_dates`. US-certification extraction from nested release_dates, top-5 cast by order, crew filtered by job
- **TVDB**: `_normalize_tvdb_to_metadata` - coalesces network/genres' heterogeneous shapes ({"name": ...} vs plain string)
- **MusicBrainz**: `_normalize_musicbrainz_to_metadata` - artist-credit -> artist + album_artist, partial-date tolerance, CoverArt URL composition

## Naming engine

`arm/ripper/naming.py:PATTERN_VARIABLES` is now derived from `arm_contracts.PATTERN_TOKENS` (17 contract tokens) plus 6 engine-only tokens (show, episode, episode_name, label, disc_number, disc_total).

Token sourcing precedence in `_build_variables`:
1. MediaMetadata.artist/album (merged manual-over-auto)
2. Legacy job.artist_manual / job.artist (backwards-compat for in-flight jobs)
3. PATTERN_TOKENS accessors for director, genre, plot, runtime_minutes, released, rating, network, etc.
4. Core fields (title, year, season, episode, video_type, label, disc_*, imdb_id) come from Job columns directly (matcher writes those)

The plan called for a clean cut where `_build_variables` reads everything from MediaMetadata; this PR layers it as hybrid for backwards-compat with in-flight jobs whose matcher already wrote Job columns but never wrote a media_metadata blob.

## Test impact

- 2259 passed, 1 skipped, 39 deselected, 2 xfailed (was 2243 baseline; +16 net new tests across new functionality + reworked legacy tests).
- New tests: `test_job_media_metadata.py` (4), OMDb-to-metadata (3), TMDb-to-metadata (1), TVDB-to-metadata (2), MusicBrainz-to-metadata (2), naming with PATTERN_TOKENS (3), `/jobs/{id}/metadata` endpoint (2).
- Migrated tests: `test_folder_api.py`, `test_identify.py`, `test_import_helpers.py`, `test_job_model.py` (consumer-of-poster_url paths).

## Out of scope (deferred)

- Switching internal callers of legacy `_normalize_omdb` (dict shape) to the new `_normalize_omdb_to_metadata` - additive for now to limit blast radius.
- Phase 3 (arm-ui): BFF endpoints + Pattern editor consuming the new token list.

## Test plan

- [x] `python3 -m pytest test/` - 2259 passed locally
- [x] Migration upgrade + downgrade smoke (covered by `test_job_media_metadata.py` running against in-memory create_all schema, which mirrors the migration's final state)
- [ ] CI green (waiting)
- [ ] Manual: deploy RC to hifi, rip a real disc, verify metadata flows through new endpoint + naming engine renders correctly