### PR TITLE
fix(music): write MediaMetadata blob from MusicBrainz path

### DIFF
--- a/arm/ripper/music_brainz.py
+++ b/arm/ripper/music_brainz.py
@@ -158,8 +158,24 @@ def get_disc_info(job, discid: str) -> str:
 
 def _build_music_args(job_id, crc_id, artist, title, year, no_of_titles,
                       disc_number=None, disc_total=None):
-    """Build the database update args dict for music metadata."""
+    """Build the database update args dict for music metadata.
+
+    artist + album live in media_metadata_auto (the legacy artist/album
+    Job columns were retired by the media_metadata_columns migration).
+    The blob is bundled into args so it commits atomically with the
+    Job-column writes via database_updater.
+    """
+    from arm_contracts import MediaMetadata
+    from arm_contracts.enums import VideoType
     artist_title = artist + " " + title
+    metadata_blob = MediaMetadata(
+        video_type=VideoType.music,
+        title=title or None,
+        year=str(year) if year else None,
+        artist=artist or None,
+        album=title or None,
+        album_artist=artist or None,
+    ).model_dump_json()
     args = {
         'job_id': str(job_id),
         'crc_id': crc_id,
@@ -171,10 +187,7 @@ def _build_music_args(job_id, crc_id, artist, title, year, no_of_titles,
         'title': artist_title,
         'title_auto': artist_title,
         'no_of_titles': no_of_titles,
-        'artist': artist,
-        'artist_auto': artist,
-        'album': title,
-        'album_auto': title,
+        'media_metadata_auto': metadata_blob,
     }
     if disc_number is not None:
         args['disc_number'] = disc_number
@@ -442,12 +455,20 @@ def get_cd_art(job, disc_info: str) -> bool:
                 for image in artlist["images"]:
                     # We dont care if its verified ?
                     if "image" in image:
-                        args = {
-                            'poster_url': str(image["image"]),
-                            'poster_url_auto': str(image["image"])
-                        }
+                        # Merge poster_url into the existing media_metadata_auto
+                        # blob (which _build_music_args populated with artist/
+                        # album/year). The legacy poster_url Job column was
+                        # retired by the media_metadata_columns migration.
+                        from arm_contracts import MediaMetadata
+                        existing = MediaMetadata.model_validate_json(
+                            job.media_metadata_auto
+                        ) if job.media_metadata_auto else MediaMetadata()
+                        merged = existing.model_copy(
+                            update={"poster_url": str(image["image"])}
+                        )
+                        args = {'media_metadata_auto': merged.model_dump_json()}
                         u.database_updater(args, job)
-                        logging.debug(f"poster_url: {args['poster_url']} poster_url_auto: {args['poster_url_auto']}")
+                        logging.debug(f"poster_url: {image['image']}")
                         return True
         return False
     except mb.WebServiceError as exc:

--- a/test/test_coverage_gaps.py
+++ b/test/test_coverage_gaps.py
@@ -169,12 +169,17 @@ class TestBuildMusicArgs:
             42, 'xyz', 'Pink Floyd', 'The Wall', '1979', 26
         )
         assert args['job_id'] == '42'
-        assert args['artist'] == 'Pink Floyd'
-        assert args['album'] == 'The Wall'
         assert args['year'] == '1979'
         assert args['no_of_titles'] == 26
         assert args['video_type'] == 'music'
         assert artist_title == 'Pink Floyd The Wall'
+        # artist/album now ride in media_metadata_auto, not as standalone keys.
+        import json
+        blob = json.loads(args['media_metadata_auto'])
+        assert blob['artist'] == 'Pink Floyd'
+        assert blob['album'] == 'The Wall'
+        assert blob['video_type'] == 'music'
+        assert blob['year'] == '1979'
 
 
 # ── utils.py: AUDIO_FORMAT flag and remaining rip_music paths ────────────

--- a/test/test_music_rip.py
+++ b/test/test_music_rip.py
@@ -473,8 +473,11 @@ class TestGetCdArt:
              unittest.mock.patch('arm.ripper.utils.database_updater') as mock_db:
             result = music_brainz.get_cd_art(music_job, mb_disc_response)
         assert result is True
+        # poster_url is merged into media_metadata_auto, not a standalone key.
         args_dict = mock_db.call_args[0][0]
-        assert args_dict['poster_url'] == 'https://coverartarchive.org/release/abc/front.jpg'
+        import json
+        blob = json.loads(args_dict['media_metadata_auto'])
+        assert blob['poster_url'] == 'https://coverartarchive.org/release/abc/front.jpg'
 
     def test_no_artwork_returns_false(self, music_job):
         """No artwork in release returns False."""
@@ -1017,9 +1020,12 @@ class TestMusicPipelineEndToEnd:
         assert music_job.hasnicetitle is True
         assert music_job.year == '1973'
         assert music_job.video_type == 'music'
-        assert music_job.artist == 'Pink Floyd'
-        assert music_job.album == 'The Dark Side of the Moon'
-        assert music_job.poster_url == 'https://coverartarchive.org/release/abc/front.jpg'
+        # artist/album/poster_url now live in media_metadata_auto (legacy
+        # columns dropped by the media_metadata_columns migration).
+        meta = music_job.media_metadata
+        assert meta.artist == 'Pink Floyd'
+        assert meta.album == 'The Dark Side of the Moon'
+        assert meta.poster_url == 'https://coverartarchive.org/release/abc/front.jpg'
 
         # Verify 3 Track records created in DB with source=MusicBrainz
         tracks = Track.query.filter_by(job_id=music_job.job_id).order_by(Track.track_number).all()


### PR DESCRIPTION
## Summary

Follow-up hotfix to PR #361. Spotted during hifi smoke test (Job 227, Metronomy CD on 18.2.0-rc): the MusicBrainz identification path was still writing to the dropped \`artist\`/\`album\`/\`poster_url\` columns, so the UI/API view of music metadata after a rip was empty.

## What was broken

PR #361 dropped 9 legacy columns and migrated all KNOWN consumers, but \`arm/ripper/music_brainz.py\` slipped through the audit. \`_build_music_args\` and \`get_cd_art\` were both bundling \`'artist'\`, \`'artist_auto'\`, \`'album'\`, \`'album_auto'\`, \`'poster_url'\`, \`'poster_url_auto'\` keys into the database_updater args dict. Since those columns no longer exist, \`setattr\` created orphan instance attributes that never persisted to the DB.

## What this fixes

- \`_build_music_args\` constructs a \`MediaMetadata\` blob (artist, album, album_artist, video_type=music, year) and bundles it into the args dict as \`media_metadata_auto\`. The Job-column writes for surviving fields (title, video_type, year) are unchanged.
- \`get_cd_art\` merges \`poster_url\` into the existing \`media_metadata_auto\` blob via \`MediaMetadata.model_copy(update=...)\` rather than writing dropped column keys.

abcde-driven on-disk track tagging is unaffected (abcde reads MusicBrainz independently of arm's DB).

## Test plan

- [x] 56 music tests pass (\`test/test_music_rip.py\` + the 1 case in \`test_coverage_gaps.py\`)
- [x] Full suite: 2253 pass
- [ ] Deploy 18.2.1-rc to hifi, rip another CD, verify \`/api/v1/jobs/{id}/metadata\` shows non-null artist + album

## Caught by

Smoke test during hifi RC deploy 2026-05-11. Memory updated with the pattern of "auditing column drops must include the music-identification path, not just the matcher".