### PR TITLE
fix(jobs): project media_metadata into wire shape (disc review poster regression)

### DIFF
--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -157,6 +157,15 @@ def _job_to_dict(job):
         except (json.JSONDecodeError, TypeError):
             data["transcode_overrides"] = None
     data["expected_titles"] = list(job.expected_titles or [])
+
+    # Project MediaMetadata into the JobContract's legacy flat fields so the
+    # wire shape stays back-compat after the columns moved into the blob.
+    meta = job.media_metadata
+    if meta is not None:
+        for legacy_field in ("poster_url", "artist", "album", "year", "imdb_id", "video_type"):
+            value = getattr(meta, legacy_field, None)
+            if value not in (None, "", []):
+                data[legacy_field] = value
     return JobContract.model_validate(data).model_dump(mode="json")
 
 

--- a/test/test_jobs_api.py
+++ b/test/test_jobs_api.py
@@ -511,3 +511,32 @@ def test_job_detail_track_includes_process_and_skip_reason(client, app_context, 
     assert tracks["1"]["skip_reason"] == "too_short"
     assert tracks["2"]["process"] is True
     assert tracks["2"]["skip_reason"] is None
+
+
+def test_job_detail_projects_media_metadata_into_flat_fields(client, app_context, sample_job):
+    """Regression: arm-ui disc review reads poster_url/artist/album at job top level.
+
+    After the Phase 2 column purge those fields live in the media_metadata blob;
+    the serializer projects them back out so the wire shape stays back-compat.
+    """
+    from arm_contracts import MediaMetadata
+
+    sample_job.set_metadata_auto(MediaMetadata(
+        poster_url="https://example.com/poster.jpg",
+        artist="Metronomy",
+        album="Small World",
+        year="2022",
+        imdb_id="tt1234567",
+        video_type="movie",
+    ))
+    db.session.commit()
+
+    response = client.get(f"/api/v1/jobs/{sample_job.job_id}/detail")
+    assert response.status_code == 200
+    job = response.json()["job"]
+    assert job["poster_url"] == "https://example.com/poster.jpg"
+    assert job["artist"] == "Metronomy"
+    assert job["album"] == "Small World"
+    assert job["year"] == "2022"
+    assert job["imdb_id"] == "tt1234567"
+    assert job["video_type"] == "movie"


### PR DESCRIPTION
## Summary
- Disc review widget on arm-ui stopped rendering poster after a match because `_job_to_dict` iterates `Job.__table__.columns` and the legacy `poster_url`/`artist`/`album`/`year`/`imdb_id`/`video_type` columns were dropped in Phase 2.
- The MediaMetadata blob (auto + manual) is the source of truth now, but the wire shape needs the flat fields for back-compat with the JobContract and arm-ui's generated types.
- Producer-side fix: after building the column dict, read the merged `job.media_metadata` and project the six legacy fields back in.

## Test plan
- [x] New regression test `test_job_detail_projects_media_metadata_into_flat_fields` exercises the full `/api/v1/jobs/{id}/detail` round-trip - sets `media_metadata_auto` via `set_metadata_auto`, asserts wire dict has flat `poster_url`/`artist`/`album`/`year`/`imdb_id`/`video_type`
- [ ] CI green
- [ ] Hifi smoke: open disc review for a freshly matched job and confirm poster renders