### PR TITLE
fix(jobs): project media_metadata in list + drive-summary wire shapes

### DIFF
--- a/arm/api/v1/drives.py
+++ b/arm/api/v1/drives.py
@@ -85,7 +85,13 @@ def list_drives_with_jobs():
         job = Job.query.get(job_id)
         if not job:
             return None
-        return JobSummary.model_validate(job).model_dump(mode="json")
+        summary = JobSummary.model_validate(job).model_dump(mode="json")
+        # Project MediaMetadata into the JobSummary's poster_url field after
+        # the Phase 2 column purge moved it into the blob.
+        meta = job.media_metadata
+        if meta is not None and meta.poster_url:
+            summary["poster_url"] = meta.poster_url
+        return summary
 
     result = []
     for d in drives:

--- a/arm/api/v1/jobs.py
+++ b/arm/api/v1/jobs.py
@@ -160,9 +160,11 @@ def _job_to_dict(job):
 
     # Project MediaMetadata into the JobContract's legacy flat fields so the
     # wire shape stays back-compat after the columns moved into the blob.
+    # Only the three dropped columns (poster_url/artist/album) need this -
+    # year/imdb_id/video_type are still real columns and remain authoritative.
     meta = job.media_metadata
     if meta is not None:
-        for legacy_field in ("poster_url", "artist", "album", "year", "imdb_id", "video_type"):
+        for legacy_field in ("poster_url", "artist", "album"):
             value = getattr(meta, legacy_field, None)
             if value not in (None, "", []):
                 data[legacy_field] = value

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -434,6 +434,18 @@ class Job(db.Model):
         for key, value in self.__dict__.items():
             if '_sa_instance_state' not in key:
                 return_dict[str(key)] = str(value)
+
+        # Project MediaMetadata into the legacy flat keys so list-shape
+        # consumers (arm-ui dashboard cards, joblist) see poster_url/artist/
+        # album after the Phase 2 column purge moved them into the blob.
+        # Only the three dropped columns need this; other metadata fields
+        # (year/imdb_id/video_type) remain real columns and authoritative.
+        meta = self.media_metadata
+        if meta is not None:
+            for legacy_field in ("poster_url", "artist", "album"):
+                value = getattr(meta, legacy_field, None)
+                if value not in (None, "", []):
+                    return_dict[legacy_field] = str(value)
         return return_dict
 
     def eject(self):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -2806,6 +2806,26 @@ class TestApiDrivesWithJobs:
         for drive in data["drives"]:
             assert drive["current_job"] is None
 
+    def test_drives_with_jobs_projects_poster_url(self, client, sample_drives, sample_job, app_context):
+        """Regression: dashboard 'drive currently working on' badge reads poster_url.
+
+        _job_summary on /api/v1/drives/with-jobs projects MediaMetadata.poster_url
+        into the JobSummary wire shape after the Phase 2 column purge.
+        """
+        from arm.database import db
+        from arm_contracts import MediaMetadata
+
+        sample_job.set_metadata_auto(MediaMetadata(
+            poster_url="https://example.com/badge-poster.jpg",
+        ))
+        sample_drives[0].job_id_current = sample_job.job_id
+        db.session.commit()
+
+        response = client.get('/api/v1/drives/with-jobs')
+        assert response.status_code == 200
+        drive = next(d for d in response.json()["drives"] if d["name"] == "Living Room")
+        assert drive["current_job"]["poster_url"] == "https://example.com/badge-poster.jpg"
+
 
 class TestApiJobDetail:
     """Test GET /api/v1/jobs/<id>/detail endpoint."""

--- a/test/test_jobs_api.py
+++ b/test/test_jobs_api.py
@@ -516,8 +516,10 @@ def test_job_detail_track_includes_process_and_skip_reason(client, app_context, 
 def test_job_detail_projects_media_metadata_into_flat_fields(client, app_context, sample_job):
     """Regression: arm-ui disc review reads poster_url/artist/album at job top level.
 
-    After the Phase 2 column purge those fields live in the media_metadata blob;
-    the serializer projects them back out so the wire shape stays back-compat.
+    Only the three columns dropped in Phase 2 (poster_url/artist/album) live
+    in the media_metadata blob; the detail serializer projects them back out
+    so the wire shape stays back-compat. year/imdb_id/video_type remain real
+    columns and are not touched by the projection.
     """
     from arm_contracts import MediaMetadata
 
@@ -525,9 +527,6 @@ def test_job_detail_projects_media_metadata_into_flat_fields(client, app_context
         poster_url="https://example.com/poster.jpg",
         artist="Metronomy",
         album="Small World",
-        year="2022",
-        imdb_id="tt1234567",
-        video_type="movie",
     ))
     db.session.commit()
 
@@ -537,6 +536,49 @@ def test_job_detail_projects_media_metadata_into_flat_fields(client, app_context
     assert job["poster_url"] == "https://example.com/poster.jpg"
     assert job["artist"] == "Metronomy"
     assert job["album"] == "Small World"
-    assert job["year"] == "2022"
-    assert job["imdb_id"] == "tt1234567"
-    assert job["video_type"] == "movie"
+
+
+def test_job_list_projects_media_metadata_into_flat_fields(client, app_context, sample_job):
+    """Regression: dashboard cards + joblist read poster_url at job top level.
+
+    Job.get_d() is the list-shape serializer (used by /api/v1/jobs joblist
+    and active endpoints). After the Phase 2 column purge it must project
+    the three dropped fields out of media_metadata back into the flat keys.
+    """
+    from arm_contracts import MediaMetadata
+
+    sample_job.set_metadata_auto(MediaMetadata(
+        poster_url="https://example.com/poster2.jpg",
+        artist="Fatboy Slim",
+        album="You've Come a Long Way, Baby",
+    ))
+    db.session.commit()
+
+    d = sample_job.get_d()
+    assert d["poster_url"] == "https://example.com/poster2.jpg"
+    assert d["artist"] == "Fatboy Slim"
+    assert d["album"] == "You've Come a Long Way, Baby"
+
+
+def test_drives_with_jobs_projects_poster_url(client, app_context, sample_job, sample_drives):
+    """Regression: dashboard 'drive currently working on' badge reads poster_url.
+
+    _job_summary on /api/v1/drives/with-jobs projects MediaMetadata.poster_url
+    into the JobSummary wire shape after the column purge.
+    """
+    from arm_contracts import MediaMetadata
+    from arm.models.system_drives import SystemDrives
+
+    sample_job.set_metadata_auto(MediaMetadata(
+        poster_url="https://example.com/badge-poster.jpg",
+    ))
+    drive = SystemDrives.query.first()
+    drive.job_id_current = sample_job.job_id
+    db.session.commit()
+
+    response = client.get("/api/v1/drives/with-jobs")
+    assert response.status_code == 200
+    drives = response.json()["drives"]
+    matching = [d for d in drives if d.get("current_job") and d["current_job"].get("job_id") == sample_job.job_id]
+    assert matching, "expected at least one drive with current_job set to sample_job"
+    assert matching[0]["current_job"]["poster_url"] == "https://example.com/badge-poster.jpg"

--- a/test/test_jobs_api.py
+++ b/test/test_jobs_api.py
@@ -560,25 +560,3 @@ def test_job_list_projects_media_metadata_into_flat_fields(client, app_context, 
     assert d["album"] == "You've Come a Long Way, Baby"
 
 
-def test_drives_with_jobs_projects_poster_url(client, app_context, sample_job, sample_drives):
-    """Regression: dashboard 'drive currently working on' badge reads poster_url.
-
-    _job_summary on /api/v1/drives/with-jobs projects MediaMetadata.poster_url
-    into the JobSummary wire shape after the column purge.
-    """
-    from arm_contracts import MediaMetadata
-    from arm.models.system_drives import SystemDrives
-
-    sample_job.set_metadata_auto(MediaMetadata(
-        poster_url="https://example.com/badge-poster.jpg",
-    ))
-    drive = SystemDrives.query.first()
-    drive.job_id_current = sample_job.job_id
-    db.session.commit()
-
-    response = client.get("/api/v1/drives/with-jobs")
-    assert response.status_code == 200
-    drives = response.json()["drives"]
-    matching = [d for d in drives if d.get("current_job") and d["current_job"].get("job_id") == sample_job.job_id]
-    assert matching, "expected at least one drive with current_job set to sample_job"
-    assert matching[0]["current_job"]["poster_url"] == "https://example.com/badge-poster.jpg"


### PR DESCRIPTION
## Summary
Follow-up to #364. The detail serializer (\`_job_to_dict\`) was fixed there, but two other Job-to-wire paths still drop the projection:

1. \`Job.get_d()\` - used by the /api/v1/jobs joblist/active endpoints (via \`svc_jobs.get_x_jobs\`). Hifi has 25/105 jobs with populated \`media_metadata_auto\`, and all 25 currently show \`poster_url: null\` in the list response because \`get_d\` only iterates \`self.__dict__\` (no @properties).
2. \`_job_summary\` in /api/v1/drives.py - JobSummary for the dashboard 'drive currently working on' badge. Same gap.

Also tightens the projection scope from PR #364: only the three columns dropped in Phase 2 (poster_url/artist/album) need projection. year/imdb_id/video_type are still real columns and authoritative; projecting them was either a no-op or risked shadowing column writes.

## Test plan
- [x] \`test_job_detail_projects_media_metadata_into_flat_fields\` updated to assert the corrected scope (only the three dropped fields)
- [x] New \`test_job_list_projects_media_metadata_into_flat_fields\` exercises Job.get_d()
- [x] New \`test_drives_with_jobs_projects_poster_url\` exercises _job_summary via /api/v1/drives/with-jobs
- [ ] Hifi smoke after deploy: \`/api/v1/jobs?status=success\` returns non-null poster_url for the 25 jobs with metadata; dashboard cards render posters