### PR TITLE
feat: backfill MediaMetadata blob for pre-Phase-2 jobs on boot

### DIFF
--- a/arm/app.py
+++ b/arm/app.py
@@ -1,4 +1,5 @@
 """ARM API server - FastAPI."""
+import asyncio
 import functools
 import inspect
 import logging
@@ -116,6 +117,12 @@ async def lifespan(app: FastAPI):
         cfg.arm_config.get("INSTALLPATH", ""),
     ])
     start_background_refresh()
+
+    # Schedule the MediaMetadata blob backfill for pre-Phase-2 jobs in the
+    # background so it never blocks startup. Self-terminates once every job
+    # with imdb_id but no blob has been (best-effort) refetched.
+    from arm.services.metadata_backfill import backfill_media_metadata
+    asyncio.create_task(backfill_media_metadata())
 
     log.info("ARM API server starting up.")
     yield

--- a/arm/services/metadata_backfill.py
+++ b/arm/services/metadata_backfill.py
@@ -1,0 +1,125 @@
+"""One-shot best-effort backfill for jobs created before the MediaMetadata
+column purge (Phase 2, migration u6v7w8x9y0).
+
+Those jobs have imdb_id_auto set on the Job row (the matcher ran on the
+pre-Phase-2 code path and only wrote columns, not the blob), but the
+media_metadata_auto JSON blob is empty because the migration's backfill
+relied on poster_url_auto which was often empty even when imdb_id_auto
+had a value.
+
+On every boot we re-fetch via the same metadata adapter the live matcher
+uses now and write the blob. Fail-soft: rows whose API call errors are
+skipped silently and retried on the next boot.
+"""
+import asyncio
+import logging
+from typing import Iterable
+
+from arm_contracts import MediaMetadata
+from arm_contracts.enums import VideoType
+
+from arm.database import db
+from arm.models.job import Job
+from arm.services import metadata
+from arm.services.metadata import MetadataConfigError
+
+log = logging.getLogger("arm")
+
+
+def _normalize_video_type(value: str | None) -> VideoType | None:
+    if value == "movie":
+        return VideoType.movie
+    if value == "series":
+        return VideoType.series
+    return None
+
+
+def _legacy_dict_to_metadata(legacy: dict) -> MediaMetadata:
+    """Build a MediaMetadata from the legacy-shape dict the adapter returns.
+
+    The adapter emits flat keys (poster_url, plot, runtime_seconds, ...).
+    Pass them through to MediaMetadata; the model silently ignores any
+    unknown keys.
+    """
+    payload = dict(legacy)
+    vt = payload.pop("video_type", None)
+    payload["video_type"] = _normalize_video_type(vt)
+    # Filter to known MediaMetadata fields so a future adapter addition
+    # doesn't crash with a validation error before we update the contract.
+    allowed = set(MediaMetadata.model_fields.keys())
+    return MediaMetadata(**{k: v for k, v in payload.items() if k in allowed and v not in (None, "", [])})
+
+
+async def _backfill_one(job_id: int, imdb_id: str) -> bool:
+    """Fetch metadata for one job and persist as the auto blob.
+
+    Returns True on success (blob written or already-correct skip),
+    False on error (will retry next boot).
+    """
+    try:
+        legacy = await metadata.get_details(imdb_id)
+    except MetadataConfigError as exc:
+        log.debug("metadata-backfill: skipping job %s (config): %s", job_id, exc)
+        return False
+    except Exception as exc:
+        log.debug("metadata-backfill: skipping job %s (fetch error): %s", job_id, exc)
+        return False
+
+    if not legacy:
+        log.debug("metadata-backfill: imdb_id=%s returned no result for job %s", imdb_id, job_id)
+        return False
+
+    try:
+        meta = _legacy_dict_to_metadata(legacy)
+    except Exception as exc:
+        log.warning("metadata-backfill: validation error for job %s imdb=%s: %s", job_id, imdb_id, exc)
+        return False
+
+    # Re-fetch the job inside this task's session so we don't touch
+    # rows another task is operating on.
+    job = Job.query.get(job_id)
+    if job is None or job.media_metadata_auto:
+        # Job was deleted, or another path wrote the blob first - nothing to do.
+        return True
+    job.set_metadata_auto(meta)
+    db.session.commit()
+    return True
+
+
+def _candidate_job_ids() -> list[tuple[int, str]]:
+    """Find jobs with imdb_id set but no media_metadata_auto blob."""
+    rows = (
+        db.session.query(Job.job_id, Job.imdb_id)
+        .filter(Job.imdb_id.isnot(None))
+        .filter(Job.imdb_id != "")
+        .filter((Job.media_metadata_auto.is_(None)) | (Job.media_metadata_auto == ""))
+        .all()
+    )
+    return [(r.job_id, r.imdb_id) for r in rows]
+
+
+async def backfill_media_metadata():
+    """Run a single backfill sweep over all candidate jobs.
+
+    Quiet log if there's nothing to do; otherwise logs counts so an
+    operator can tell whether the gap is closing.
+    """
+    try:
+        candidates = _candidate_job_ids()
+    except Exception as exc:
+        log.warning("metadata-backfill: query failed, skipping: %s", exc)
+        return
+
+    if not candidates:
+        return
+
+    log.info("metadata-backfill: %d job(s) eligible for blob backfill", len(candidates))
+    succeeded = 0
+    for job_id, imdb_id in candidates:
+        if await _backfill_one(job_id, imdb_id):
+            succeeded += 1
+    log.info(
+        "metadata-backfill: wrote blob for %d/%d eligible jobs (remainder will retry next boot)",
+        succeeded,
+        len(candidates),
+    )

--- a/test/test_metadata_backfill.py
+++ b/test/test_metadata_backfill.py
@@ -1,0 +1,117 @@
+"""Tests for arm.services.metadata_backfill: best-effort one-shot backfill
+of the media_metadata_auto blob for pre-Phase-2 jobs."""
+import asyncio
+import unittest.mock
+
+import pytest
+
+from arm.database import db
+from arm.services.metadata import MetadataConfigError
+from arm.services.metadata_backfill import (
+    _candidate_job_ids,
+    _legacy_dict_to_metadata,
+    backfill_media_metadata,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestCandidateQuery:
+    def test_skips_jobs_with_blob(self, app_context, sample_job):
+        from arm_contracts import MediaMetadata
+        sample_job.imdb_id = "tt1234567"
+        sample_job.set_metadata_auto(MediaMetadata(poster_url="x"))
+        db.session.commit()
+        assert _candidate_job_ids() == []
+
+    def test_skips_jobs_without_imdb_id(self, app_context, sample_job):
+        sample_job.imdb_id = None
+        db.session.commit()
+        assert _candidate_job_ids() == []
+
+    def test_includes_jobs_with_imdb_no_blob(self, app_context, sample_job):
+        sample_job.imdb_id = "tt7654321"
+        sample_job.media_metadata_auto = None
+        db.session.commit()
+        assert _candidate_job_ids() == [(sample_job.job_id, "tt7654321")]
+
+
+class TestLegacyDictConversion:
+    def test_video_type_movie_normalized_to_enum(self):
+        meta = _legacy_dict_to_metadata({
+            "poster_url": "http://example.com/p.jpg",
+            "video_type": "movie",
+            "imdb_id": "tt1",
+        })
+        from arm_contracts.enums import VideoType
+        assert meta.poster_url == "http://example.com/p.jpg"
+        assert meta.video_type == VideoType.movie
+
+    def test_unknown_video_type_normalized_to_none(self):
+        meta = _legacy_dict_to_metadata({"poster_url": "p", "video_type": "garbage"})
+        assert meta.video_type is None
+
+    def test_unknown_keys_silently_dropped(self):
+        # If the adapter starts emitting a new key before the contract
+        # adds it, the backfill should not crash.
+        meta = _legacy_dict_to_metadata({"poster_url": "p", "future_field": "value"})
+        assert meta.poster_url == "p"
+
+
+class TestBackfillEndToEnd:
+    def test_no_candidates_is_noop(self, app_context, sample_job):
+        from arm_contracts import MediaMetadata
+        sample_job.imdb_id = "tt1"
+        sample_job.set_metadata_auto(MediaMetadata(poster_url="already"))
+        db.session.commit()
+        # Should complete without calling the adapter at all.
+        with unittest.mock.patch("arm.services.metadata_backfill.metadata.get_details") as m:
+            _run(backfill_media_metadata())
+            m.assert_not_called()
+
+    def test_successful_fetch_writes_blob(self, app_context, sample_job):
+        sample_job.imdb_id = "tt2"
+        sample_job.media_metadata_auto = None
+        db.session.commit()
+        async def fake_details(imdb_id):
+            return {"poster_url": "http://api/poster.jpg", "imdb_id": imdb_id, "video_type": "movie"}
+        with unittest.mock.patch("arm.services.metadata_backfill.metadata.get_details", side_effect=fake_details):
+            _run(backfill_media_metadata())
+        db.session.refresh(sample_job)
+        assert sample_job.media_metadata_auto is not None
+        assert "http://api/poster.jpg" in sample_job.media_metadata_auto
+
+    def test_network_error_leaves_blob_empty(self, app_context, sample_job):
+        sample_job.imdb_id = "tt3"
+        sample_job.media_metadata_auto = None
+        db.session.commit()
+        async def boom(imdb_id):
+            raise RuntimeError("network down")
+        with unittest.mock.patch("arm.services.metadata_backfill.metadata.get_details", side_effect=boom):
+            _run(backfill_media_metadata())
+        db.session.refresh(sample_job)
+        assert sample_job.media_metadata_auto in (None, "")
+
+    def test_config_error_leaves_blob_empty(self, app_context, sample_job):
+        sample_job.imdb_id = "tt4"
+        sample_job.media_metadata_auto = None
+        db.session.commit()
+        async def no_key(imdb_id):
+            raise MetadataConfigError("no key configured")
+        with unittest.mock.patch("arm.services.metadata_backfill.metadata.get_details", side_effect=no_key):
+            _run(backfill_media_metadata())
+        db.session.refresh(sample_job)
+        assert sample_job.media_metadata_auto in (None, "")
+
+    def test_empty_adapter_result_leaves_blob_empty(self, app_context, sample_job):
+        sample_job.imdb_id = "tt5"
+        sample_job.media_metadata_auto = None
+        db.session.commit()
+        async def empty(imdb_id):
+            return None
+        with unittest.mock.patch("arm.services.metadata_backfill.metadata.get_details", side_effect=empty):
+            _run(backfill_media_metadata())
+        db.session.refresh(sample_job)
+        assert sample_job.media_metadata_auto in (None, "")


### PR DESCRIPTION
## Summary
Closes the data-quality gap left by Phase 2: 25 production jobs have \`imdb_id\` set on the Job row but no \`media_metadata_auto\` blob, because they were matched on the pre-Phase-2 code path (columns only, no blob) and the migration's backfill relied on the legacy \`poster_url_auto\` column which was empty for these jobs.

Approach: on every boot, schedule a background asyncio task that:
- finds jobs with \`imdb_id IS NOT NULL\` and \`media_metadata_auto IS NULL/empty\`
- refetches via the same \`metadata.get_details()\` adapter the live matcher uses
- writes the blob via \`job.set_metadata_auto()\`

Fail-soft: rows whose API call errors are skipped silently and retried on the next boot. Self-terminates once every eligible job has been (best-effort) processed.

Rejected alternatives:
- Alembic migration: couples deploy time to OMDB/TMDB availability; failures mid-migrate hard to recover from
- CLI script: requires operator memory

## Test plan
- [x] Candidate query: skip jobs with blob; skip jobs without imdb_id; include jobs with imdb_id only
- [x] Legacy-dict conversion: video_type \"movie\"/\"series\" -> enum; \"garbage\" -> None; unknown keys silently dropped
- [x] End-to-end: no-op when nothing to do; success path writes blob; network error / config error / empty result all leave blob empty (silent skip)
- [ ] Hifi smoke after deploy: \`/api/v1/jobs?status=success\` shows posters on jobs 224 (Annihilation), 200/202/211 (Mirrormask), 69+ (Kolchak: The Night Stalker)