### PR TITLE
chore(migration): backfill media_metadata_auto blob via metadata adapter

### DIFF
--- a/arm/migrations/versions/v7w8x9y0z1_backfill_media_metadata_blob.py
+++ b/arm/migrations/versions/v7w8x9y0z1_backfill_media_metadata_blob.py
@@ -1,0 +1,111 @@
+"""Best-effort backfill of media_metadata_auto for pre-Phase-2 jobs.
+
+The prior migration (u6v7w8x9y0) backfilled the blob from the legacy
+poster_url_auto column. Jobs matched on the pre-Phase-2 code path often
+had imdb_id_auto set without a poster_url_auto value, so the migration
+correctly skipped them and they now have imdb_id but no blob.
+
+This migration re-fetches metadata for those rows via the same adapter
+the live matcher uses (metadata.get_details), so dashboard cards render
+posters for already-completed jobs. Fail-soft: any row whose API call
+errors is left as-is and the migration completes. The new code path
+covers all future rips regardless.
+
+Revision ID: v7w8x9y0z1
+Revises: u6v7w8x9y0
+Create Date: 2026-05-11
+"""
+import asyncio
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = 'v7w8x9y0z1'
+down_revision = 'u6v7w8x9y0'
+branch_labels = None
+depends_on = None
+
+log = logging.getLogger("alembic.runtime.migration")
+
+
+def _normalize_video_type(value):
+    """Map the legacy string to the contract enum, or None for anything else."""
+    from arm_contracts.enums import VideoType
+    if value == "movie":
+        return VideoType.movie
+    if value == "series":
+        return VideoType.series
+    return None
+
+
+def _legacy_dict_to_blob(legacy):
+    """Build a MediaMetadata JSON blob from the adapter's legacy-shape dict."""
+    from arm_contracts import MediaMetadata
+    payload = dict(legacy)
+    payload["video_type"] = _normalize_video_type(payload.pop("video_type", None))
+    allowed = set(MediaMetadata.model_fields.keys())
+    filtered = {k: v for k, v in payload.items() if k in allowed and v not in (None, "", [])}
+    return MediaMetadata(**filtered).model_dump_json()
+
+
+def _candidates(bind):
+    rows = bind.execute(sa.text(
+        "SELECT job_id, imdb_id FROM job "
+        "WHERE imdb_id IS NOT NULL AND imdb_id != '' "
+        "AND (media_metadata_auto IS NULL OR media_metadata_auto = '')"
+    )).fetchall()
+    return [(r._mapping["job_id"], r._mapping["imdb_id"]) for r in rows]
+
+
+def upgrade():
+    # Import lazily so a missing-key environment (e.g. a fresh test DB
+    # with no arm.yaml) still loads the migration module.
+    from arm.services import metadata
+    from arm.services.metadata import MetadataConfigError
+
+    bind = op.get_bind()
+    try:
+        rows = _candidates(bind)
+    except Exception as exc:
+        log.warning("backfill-media-metadata: skip (candidate query failed): %s", exc)
+        return
+
+    if not rows:
+        log.info("backfill-media-metadata: no jobs eligible")
+        return
+
+    log.info("backfill-media-metadata: %d job(s) eligible", len(rows))
+    wrote = 0
+    for job_id, imdb_id in rows:
+        try:
+            legacy = asyncio.run(metadata.get_details(imdb_id))
+        except MetadataConfigError as exc:
+            log.warning("backfill-media-metadata: stopping early - %s", exc)
+            break
+        except Exception as exc:
+            log.debug("backfill-media-metadata: skip job %s (fetch error): %s", job_id, exc)
+            continue
+
+        if not legacy:
+            continue
+
+        try:
+            blob = _legacy_dict_to_blob(legacy)
+        except Exception as exc:
+            log.debug("backfill-media-metadata: skip job %s (validate error): %s", job_id, exc)
+            continue
+
+        bind.execute(
+            sa.text("UPDATE job SET media_metadata_auto = :blob WHERE job_id = :job_id"),
+            {"blob": blob, "job_id": job_id},
+        )
+        wrote += 1
+    log.info("backfill-media-metadata: wrote blob for %d/%d eligible jobs", wrote, len(rows))
+
+
+def downgrade():
+    # Best-effort backfill is idempotent and a downgrade has nothing to
+    # actively undo - the upgrade only writes blob, never deletes.
+    pass

--- a/test/test_migration_backfill_media_metadata.py
+++ b/test/test_migration_backfill_media_metadata.py
@@ -1,0 +1,137 @@
+"""Exercise the v7w8x9y0z1 migration end-to-end via alembic.
+
+Seeds a job with imdb_id_auto set but an empty media_metadata_auto
+column at the post-u6v7w8x9y0 schema (the legacy triples are already
+dropped), patches the network adapter to return a fake legacy dict,
+and confirms the migration writes the blob.
+"""
+import asyncio
+import os
+import unittest.mock
+
+import pytest
+import sqlalchemy as sa
+
+from alembic import command
+from alembic.config import Config as AlembicConfig
+
+
+_MIGRATIONS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    'arm', 'migrations',
+)
+_BEFORE = 'u6v7w8x9y0'
+_AFTER = 'v7w8x9y0z1'
+
+
+def _make_config(db_path):
+    cfg = AlembicConfig()
+    cfg.set_main_option('script_location', _MIGRATIONS_DIR)
+    cfg.set_main_option('sqlalchemy.url', f'sqlite:///{db_path}')
+    return cfg
+
+
+@pytest.fixture
+def upgraded_db(tmp_path):
+    """Upgrade to the schema right before the backfill migration."""
+    db_path = tmp_path / 'test.db'
+    cfg = _make_config(str(db_path))
+    command.upgrade(cfg, _BEFORE)
+    engine = sa.create_engine(f'sqlite:///{db_path}')
+    yield cfg, engine
+    engine.dispose()
+
+
+def _insert(engine, job_id, imdb_id, blob=None):
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO job (job_id, imdb_id, imdb_id_auto, media_metadata_auto, guid) "
+                "VALUES (:jid, :imdb, :imdb, :blob, :guid)"
+            ),
+            {"jid": job_id, "imdb": imdb_id, "blob": blob, "guid": f"g-{job_id}"},
+        )
+
+
+def _fetch_blob(engine, job_id):
+    with engine.connect() as conn:
+        return conn.execute(
+            sa.text("SELECT media_metadata_auto FROM job WHERE job_id = :jid"),
+            {"jid": job_id},
+        ).scalar()
+
+
+def test_backfill_writes_blob_for_imdb_only_rows(upgraded_db):
+    cfg, engine = upgraded_db
+    _insert(engine, 1, "tt7777")
+
+    async def fake(imdb_id):
+        return {"poster_url": f"http://api/{imdb_id}.jpg", "video_type": "movie"}
+
+    with unittest.mock.patch("arm.services.metadata.get_details", side_effect=fake):
+        command.upgrade(cfg, _AFTER)
+
+    blob = _fetch_blob(engine, 1)
+    assert blob is not None
+    assert "http://api/tt7777.jpg" in blob
+
+
+def test_backfill_leaves_existing_blob_untouched(upgraded_db):
+    cfg, engine = upgraded_db
+    _insert(engine, 2, "tt8888", blob='{"poster_url": "existing"}')
+
+    with unittest.mock.patch("arm.services.metadata.get_details") as m:
+        command.upgrade(cfg, _AFTER)
+        m.assert_not_called()
+
+    assert _fetch_blob(engine, 2) == '{"poster_url": "existing"}'
+
+
+def test_backfill_fail_soft_on_network_error(upgraded_db):
+    cfg, engine = upgraded_db
+    _insert(engine, 3, "tt9999")
+
+    async def boom(imdb_id):
+        raise RuntimeError("network down")
+
+    with unittest.mock.patch("arm.services.metadata.get_details", side_effect=boom):
+        command.upgrade(cfg, _AFTER)
+
+    assert _fetch_blob(engine, 3) is None  # row left as-is
+
+
+def test_backfill_fail_soft_on_config_error(upgraded_db):
+    cfg, engine = upgraded_db
+    _insert(engine, 4, "tt1111")
+
+    from arm.services.metadata import MetadataConfigError
+
+    async def no_key(imdb_id):
+        raise MetadataConfigError("no key configured")
+
+    with unittest.mock.patch("arm.services.metadata.get_details", side_effect=no_key):
+        command.upgrade(cfg, _AFTER)
+
+    assert _fetch_blob(engine, 4) is None
+
+
+def test_backfill_handles_empty_adapter_result(upgraded_db):
+    cfg, engine = upgraded_db
+    _insert(engine, 5, "tt2222")
+
+    async def empty(imdb_id):
+        return None
+
+    with unittest.mock.patch("arm.services.metadata.get_details", side_effect=empty):
+        command.upgrade(cfg, _AFTER)
+
+    assert _fetch_blob(engine, 5) is None
+
+
+def test_backfill_no_op_when_nothing_to_do(upgraded_db):
+    cfg, engine = upgraded_db
+    # No rows inserted - migration should run cleanly and call nothing.
+
+    with unittest.mock.patch("arm.services.metadata.get_details") as m:
+        command.upgrade(cfg, _AFTER)
+        m.assert_not_called()

--- a/test/test_migration_backfill_media_metadata.py
+++ b/test/test_migration_backfill_media_metadata.py
@@ -46,8 +46,8 @@ def _insert(engine, job_id, imdb_id, blob=None):
     with engine.begin() as conn:
         conn.execute(
             sa.text(
-                "INSERT INTO job (job_id, imdb_id, imdb_id_auto, media_metadata_auto, guid) "
-                "VALUES (:jid, :imdb, :imdb, :blob, :guid)"
+                "INSERT INTO job (job_id, status, disctype, imdb_id, imdb_id_auto, media_metadata_auto, guid) "
+                "VALUES (:jid, 'success', 'dvd', :imdb, :imdb, :blob, :guid)"
             ),
             {"jid": job_id, "imdb": imdb_id, "blob": blob, "guid": f"g-{job_id}"},
         )

--- a/test/test_migration_backfill_media_metadata.py
+++ b/test/test_migration_backfill_media_metadata.py
@@ -66,14 +66,14 @@ def test_backfill_writes_blob_for_imdb_only_rows(upgraded_db):
     _insert(engine, 1, "tt7777")
 
     async def fake(imdb_id):
-        return {"poster_url": f"http://api/{imdb_id}.jpg", "video_type": "movie"}
+        return {"poster_url": f"https://api/{imdb_id}.jpg", "video_type": "movie"}
 
     with unittest.mock.patch("arm.services.metadata.get_details", side_effect=fake):
         command.upgrade(cfg, _AFTER)
 
     blob = _fetch_blob(engine, 1)
     assert blob is not None
-    assert "http://api/tt7777.jpg" in blob
+    assert "https://api/tt7777.jpg" in blob
 
 
 def test_backfill_leaves_existing_blob_untouched(upgraded_db):


### PR DESCRIPTION
## Summary
Closes the data-quality gap left by Phase 2: 25 production jobs have \`imdb_id\` set on the Job row but no \`media_metadata_auto\` blob. The prior backfill migration (u6v7w8x9y0) only preserved blob data from the legacy \`poster_url_auto\` column - jobs matched on the older code path that wrote only \`imdb_id_auto\` were silently skipped.

This migration re-fetches metadata via the same \`metadata.get_details()\` adapter the live matcher uses now and writes the blob in one pass.

Trade-off accepted: migration time briefly depends on OMDB/TMDB. Fail-soft mitigates - any row whose API call errors is left as-is and the migration completes. Failed rows can be retried by manual operator action (run a single-job refetch script, hopefully unnecessary).

Picked migration over a permanent boot-time background task per "don't want to keep this around too long" - migration runs once, lives in history, zero ongoing code surface.

## Test plan
- [x] \`test_backfill_writes_blob_for_imdb_only_rows\` - happy path
- [x] \`test_backfill_leaves_existing_blob_untouched\` - idempotent
- [x] \`test_backfill_fail_soft_on_network_error\`
- [x] \`test_backfill_fail_soft_on_config_error\` (no API key)
- [x] \`test_backfill_handles_empty_adapter_result\`
- [x] \`test_backfill_no_op_when_nothing_to_do\`
- [ ] Hifi smoke after deploy: \`/api/v1/jobs?status=success\` shows posters on jobs 1 (Code Conspiracy), 200/202/211 (Mirrormask), 224 (Annihilation), 69+ (Kolchak), etc.