### PR TITLE
docs: point CLAUDE.md to arm-ai sibling repo; link contracts in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,19 @@
 
 Plans, specs, and research for this project live in a **separate private repo**, not in this repo. This keeps AI-collaboration artifacts out of the project history and syncs them across machines.
 
-Expected location: `../ai/<project-subdir>/docs/superpowers/`
-  - arm-neu        -> ../ai/arm-neu/docs/superpowers/
-  - arm-ui         -> ../ai/arm-ui/docs/superpowers/
-  - arm-transcoder -> ../ai/arm-transcoder/docs/superpowers/
+Expected location: `../arm-ai/<project-subdir>/docs/superpowers/`
+  - arm-neu        -> ../arm-ai/arm-neu/docs/superpowers/
+  - arm-ui         -> ../arm-ai/arm-ui/docs/superpowers/
+  - arm-transcoder -> ../arm-ai/arm-transcoder/docs/superpowers/
 
-When the brainstorming, writing-plans, or executing-plans skills reference `docs/superpowers/specs/...` or `docs/superpowers/plans/...`, resolve those paths against the sibling `ai/` repo above, not this repo.
+When the brainstorming, writing-plans, or executing-plans skills reference `docs/superpowers/specs/...` or `docs/superpowers/plans/...`, resolve those paths against the sibling `arm-ai/` repo above, not this repo.
 
-If the sibling `ai/` directory does not exist, ask the user before creating specs/plans anywhere else. Other developers using this fork should maintain their own equivalent sibling repo.
+If the sibling `arm-ai/` directory does not exist, ask the user before creating specs/plans anywhere else. Other developers using this fork should maintain their own equivalent sibling repo.
 
-## Git Commits
-- Never include `Co-Authored-By` lines in commit messages
-- Do not sign commits with Claude's name or email
+## Memory
+
+Auto-memory for this repo lives at `../arm-ai/arm-neu/memory/` (start with `MEMORY.md`). Read and write memories there, not in this repo.
+
+## Commit Rules
+
+Engineering standards (branching, PR targets, CI gates, deploy commands) are in `../arm-ai/commit-rules.md` and `../arm-ai/arm-neu/commit-rules.md`. Follow both before committing.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A fork of the [Automatic Ripping Machine](https://github.com/automatic-ripping-m
 ### What's different from upstream
 
 **Architecture**
-- Split into three independently-released services - ripper (this repo), [UI dashboard](https://github.com/uprightbass360/automatic-ripping-machine-ui), and [GPU transcoder](https://github.com/uprightbass360/automatic-ripping-machine-transcoder) - deployable on one host or across machines, with a typed shared-contracts layer keeping them in lockstep.
+- Split into three independently-released services - ripper (this repo), [UI dashboard](https://github.com/uprightbass360/automatic-ripping-machine-ui), and [GPU transcoder](https://github.com/uprightbass360/automatic-ripping-machine-transcoder) - deployable on one host or across machines, with a [typed shared-contracts layer](https://github.com/uprightbass360/automatic-ripping-machine-contracts) keeping them in lockstep.
 
 **What you'll see as a user**
 - Modern SvelteKit + TypeScript dashboard replacing the Flask/Jinja UI, with real-time WebSocket job updates and phase-aware progress bars (rip / transcode / finalize)
@@ -35,6 +35,7 @@ Part of the Automatic Ripping Machine (neu) ecosystem:
 | **automatic-ripping-machine-neu** | Fork of ARM with fixes and improvements (this project) |
 | [automatic-ripping-machine-ui](https://github.com/uprightbass360/automatic-ripping-machine-ui) | Modern replacement dashboard (SvelteKit + FastAPI) |
 | [automatic-ripping-machine-transcoder](https://github.com/uprightbass360/automatic-ripping-machine-transcoder) | GPU-accelerated transcoding service |
+| [automatic-ripping-machine-contracts](https://github.com/uprightbass360/automatic-ripping-machine-contracts) | Typed shared-contracts layer keeping the services in lockstep |
 
 Insert an optical disc (Blu-ray, DVD, CD) and ARM automatically detects, identifies, rips, and transcodes it. Headless and server-based, designed for unattended operation with one or more optical drives. This fork adds bug fixes, better notification payloads for external service integration, and improved compatibility with the companion transcoder and UI projects.
 


### PR DESCRIPTION
## Summary
- Align CLAUDE.md with the format used in arm-ui — sibling docs, memory, and commit-rules live in ../arm-ai/arm-neu/, not in this repo.
- Link the inline "typed shared-contracts layer" mention to the contracts repo, and add it as a row in the Related Projects table.

## Test plan
- [ ] Render README on GitHub and confirm both contracts links resolve.