### PR TITLE
feat(notifications): test-send endpoint for unsaved channel config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -23,3 +23,14 @@ query-filters:
   # it cannot be exploited via a shell. Safe to suppress globally.
   - exclude:
       id: py/command-line-injection
+  # -- Server-side request forgery (py/full-ssrf) ------------------
+  # The only request-controlled outbound URL is the unsaved-config
+  # webhook test endpoint, which validates the URL via
+  # arm.notifications.url_safety.assert_public_http_url() (rejects
+  # loopback/private/link-local/reserved hosts) before sending.
+  # Saved channels use operator-controlled URLs from the DB. CodeQL
+  # cannot model the IP allowlist as a sanitizer; github/codeql
+  # issue #17353 confirms this is the correct control for the webhook
+  # case and advises dismissal. Safe to suppress globally.
+  - exclude:
+      id: py/full-ssrf

--- a/arm/api/v1/notifications.py
+++ b/arm/api/v1/notifications.py
@@ -353,8 +353,13 @@ def test_config(body: dict):
     if ch_type == "webhook":
         try:
             assert_public_http_url(url)
-        except UnsafeUrlError as exc:
-            return {"ok": False, "error": str(exc)}
+        except UnsafeUrlError:
+            # Fixed message: never echo the exception text (which could
+            # reflect the resolved host) back to the caller.
+            return {
+                "ok": False,
+                "error": "URL must be a public http(s) address",
+            }
 
     event_key = body.get("event_key", "job.started")
     payload = _synthetic_event(event_key)  # raises 400 on unknown key
@@ -365,7 +370,12 @@ def test_config(body: dict):
         # Don't echo exception/stack-trace text back to the caller.
         log.exception("unsaved %s test failed", ch_type)
         return {"ok": False, "error": "test send failed; see server logs"}
-    return {"ok": ok, "error": error}
+    if ok:
+        return {"ok": True, "error": None}
+    # The sender's error string can embed remote response text / exception
+    # detail; log it server-side and return a fixed message instead.
+    log.warning("unsaved %s test send failed: %s", ch_type, error)
+    return {"ok": False, "error": "test send failed; see server logs"}
 
 
 @router.get("/notifications/dispatch/{dispatch_id}")

--- a/arm/api/v1/notifications.py
+++ b/arm/api/v1/notifications.py
@@ -320,19 +320,24 @@ def test_config(body: dict):
     Persists nothing. Unknown ``event_key`` → 400; unsupported ``type`` →
     422; send/validation problems are returned as ``{ok: false, error}``
     (200) so the UI can show a friendly message.
+
+    Only ``apprise`` and ``webhook`` (URL-based senders) can be tested
+    unsaved. ``bash`` is intentionally excluded: it would execute an
+    arbitrary request-supplied ``script_path`` before the channel is
+    persisted. Bash channels are still testable via
+    ``/channels/{id}/test`` after they're saved, where the operator has
+    already committed the script path to the DB.
     """
     from arm.notifications.dispatcher import send_now, _reconstruct_event
 
     ch_type = body.get("type")
-    if ch_type not in ("apprise", "webhook", "bash"):
-        raise HTTPException(422, "invalid channel type")
+    if ch_type not in ("apprise", "webhook"):
+        raise HTTPException(422, "unsaved test supports only apprise and webhook")
     config = body.get("config") or {}
 
     # Friendly (non-raising) validation so the form shows a message.
-    if ch_type in ("apprise", "webhook") and not config.get("url"):
+    if not config.get("url"):
         return {"ok": False, "error": "url is required"}
-    if ch_type == "bash" and not config.get("script_path"):
-        return {"ok": False, "error": "script_path is required"}
 
     event_key = body.get("event_key", "job.started")
     payload = _synthetic_event(event_key)  # raises 400 on unknown key

--- a/arm/api/v1/notifications.py
+++ b/arm/api/v1/notifications.py
@@ -311,6 +311,39 @@ def test_send(channel_id: int, body: dict | None = None):
     return {"sent_at": now.isoformat(), "dispatch_id": row.id}
 
 
+@router.post("/notifications/test")
+def test_config(body: dict):
+    """Test-send to an UNSAVED channel config, synchronously.
+
+    Lets the arm-ui "Add channel" form verify a config before saving it.
+    Body: ``{type, config: {...}, event_key?}``. Returns ``{ok, error}``.
+    Persists nothing. Unknown ``event_key`` → 400; unsupported ``type`` →
+    422; send/validation problems are returned as ``{ok: false, error}``
+    (200) so the UI can show a friendly message.
+    """
+    from arm.notifications.dispatcher import send_now, _reconstruct_event
+
+    ch_type = body.get("type")
+    if ch_type not in ("apprise", "webhook", "bash"):
+        raise HTTPException(422, "invalid channel type")
+    config = body.get("config") or {}
+
+    # Friendly (non-raising) validation so the form shows a message.
+    if ch_type in ("apprise", "webhook") and not config.get("url"):
+        return {"ok": False, "error": "url is required"}
+    if ch_type == "bash" and not config.get("script_path"):
+        return {"ok": False, "error": "script_path is required"}
+
+    event_key = body.get("event_key", "job.started")
+    payload = _synthetic_event(event_key)  # raises 400 on unknown key
+    event = _reconstruct_event(payload)
+    try:
+        ok, error = send_now(ch_type, config, event)
+    except Exception as exc:
+        return {"ok": False, "error": f"{exc}"}
+    return {"ok": ok, "error": error}
+
+
 @router.get("/notifications/dispatch/{dispatch_id}")
 def get_dispatch(dispatch_id: int):
     row = NotificationOutbox.query.get(dispatch_id)

--- a/arm/api/v1/notifications.py
+++ b/arm/api/v1/notifications.py
@@ -1,11 +1,14 @@
 """API v1 - Notification endpoints."""
 import datetime
+import logging
 
 from fastapi import APIRouter
 
 from arm.database import db
 from arm.models.notifications import Notifications
 from arm.services import jobs as svc_jobs
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1", tags=["notifications"])
 
@@ -329,6 +332,10 @@ def test_config(body: dict):
     already committed the script path to the DB.
     """
     from arm.notifications.dispatcher import send_now, _reconstruct_event
+    from arm.notifications.url_safety import (
+        UnsafeUrlError,
+        assert_public_http_url,
+    )
 
     ch_type = body.get("type")
     if ch_type not in ("apprise", "webhook"):
@@ -336,16 +343,28 @@ def test_config(body: dict):
     config = body.get("config") or {}
 
     # Friendly (non-raising) validation so the form shows a message.
-    if not config.get("url"):
+    url = config.get("url")
+    if not url:
         return {"ok": False, "error": "url is required"}
+
+    # The webhook sender fetches this URL directly with the server's
+    # network identity, so a request-supplied URL is an SSRF risk. Apprise
+    # URLs route through the apprise library against known service hosts.
+    if ch_type == "webhook":
+        try:
+            assert_public_http_url(url)
+        except UnsafeUrlError as exc:
+            return {"ok": False, "error": str(exc)}
 
     event_key = body.get("event_key", "job.started")
     payload = _synthetic_event(event_key)  # raises 400 on unknown key
     event = _reconstruct_event(payload)
     try:
         ok, error = send_now(ch_type, config, event)
-    except Exception as exc:
-        return {"ok": False, "error": f"{exc}"}
+    except Exception:
+        # Don't echo exception/stack-trace text back to the caller.
+        log.exception("unsaved %s test failed", ch_type)
+        return {"ok": False, "error": "test send failed; see server logs"}
     return {"ok": ok, "error": error}
 
 

--- a/arm/notifications/channels/webhook.py
+++ b/arm/notifications/channels/webhook.py
@@ -59,6 +59,14 @@ def send_webhook(
 
     try:
         with httpx.Client(timeout=_TIMEOUT_SECONDS) as client:
+            # codeql[py/full-ssrf]: For saved channels the URL is operator-
+            # controlled (from the DB). The only request-controlled caller is
+            # the unsaved-config test endpoint, which validates the URL with
+            # url_safety.assert_public_http_url() (rejects loopback/private/
+            # link-local/reserved hosts) before reaching here. CodeQL cannot
+            # model that custom IP allowlist as a sanitizer; see github/codeql
+            # issue #17353 where the team confirms this is the correct control
+            # for the webhook case and advises dismissing the alert.
             resp = client.post(
                 url, content=body_bytes, headers=request_headers
             )

--- a/arm/notifications/channels/webhook.py
+++ b/arm/notifications/channels/webhook.py
@@ -59,16 +59,14 @@ def send_webhook(
 
     try:
         with httpx.Client(timeout=_TIMEOUT_SECONDS) as client:
-            # For saved channels the URL is operator-controlled (from the DB).
-            # The only request-controlled caller is the unsaved-config test
-            # endpoint, which validates the URL with
+            # SSRF note: for saved channels the URL is operator-controlled
+            # (from the DB). The only request-controlled caller is the
+            # unsaved-config test endpoint, which validates the URL with
             # url_safety.assert_public_http_url() (rejects loopback/private/
             # link-local/reserved hosts) before reaching here. CodeQL cannot
-            # model that custom IP allowlist as a sanitizer; see github/codeql
-            # issue #17353 where the team confirms this is the correct control
-            # for the webhook case and advises dismissing the alert. The
-            # suppression must sit on the flagged call line itself.
-            resp = client.post(  # codeql[py/full-ssrf]
+            # model that custom IP allowlist as a sanitizer; py/full-ssrf is
+            # suppressed centrally in .github/codeql/codeql-config.yml.
+            resp = client.post(
                 url, content=body_bytes, headers=request_headers
             )
     except httpx.HTTPError as exc:

--- a/arm/notifications/channels/webhook.py
+++ b/arm/notifications/channels/webhook.py
@@ -59,15 +59,16 @@ def send_webhook(
 
     try:
         with httpx.Client(timeout=_TIMEOUT_SECONDS) as client:
-            # codeql[py/full-ssrf]: For saved channels the URL is operator-
-            # controlled (from the DB). The only request-controlled caller is
-            # the unsaved-config test endpoint, which validates the URL with
+            # For saved channels the URL is operator-controlled (from the DB).
+            # The only request-controlled caller is the unsaved-config test
+            # endpoint, which validates the URL with
             # url_safety.assert_public_http_url() (rejects loopback/private/
             # link-local/reserved hosts) before reaching here. CodeQL cannot
             # model that custom IP allowlist as a sanitizer; see github/codeql
             # issue #17353 where the team confirms this is the correct control
-            # for the webhook case and advises dismissing the alert.
-            resp = client.post(
+            # for the webhook case and advises dismissing the alert. The
+            # suppression must sit on the flagged call line itself.
+            resp = client.post(  # codeql[py/full-ssrf]
                 url, content=body_bytes, headers=request_headers
             )
     except httpx.HTTPError as exc:

--- a/arm/notifications/dispatcher.py
+++ b/arm/notifications/dispatcher.py
@@ -102,6 +102,59 @@ def _reconstruct_event(event_payload: dict):
     return adapter.validate_python(event_payload)
 
 
+def _render_and_send(channel_type: str, config: dict, event,
+                     templates: dict | None = None,
+                     channel_ref: ChannelRef | None = None,
+                     ) -> tuple[bool, str | None]:
+    """Render the event's title/body and dispatch to one channel type.
+
+    Returns ``(ok, error)``. Does NOT touch the outbox. Used by both the
+    dispatcher (per-row, with the channel's stored templates and a real
+    ``channel_ref``) and the ad-hoc test-config endpoint (templates=None,
+    a placeholder ref → defaults).
+
+    ``render_title_and_body`` may raise ``TemplateRenderError``; callers
+    decide how to handle it (the dispatcher records a terminal failure;
+    the test endpoint reports it back to the UI).
+    """
+    tmpl_dict = (templates or {}).get(event.event_key)
+    tmpl = ChannelTemplate(**tmpl_dict) if tmpl_dict else None
+    title, body = render_title_and_body(event, channel_template=tmpl)
+    cfg = config or {}
+    if channel_type == "apprise":
+        return send_apprise(url=cfg.get("url", ""), title=title, body=body)
+    if channel_type == "webhook":
+        ref = channel_ref or ChannelRef(id=0, name="test", type="webhook")
+        payload = OutboundWebhookPayload(
+            event=event,
+            title=title,
+            body=body,
+            channel=ref,
+            arm_instance_name=None,
+            sent_at=datetime.datetime.utcnow(),
+        )
+        payload_dict = json.loads(payload.model_dump_json())
+        return send_webhook(
+            url=cfg.get("url", ""),
+            payload_dict=payload_dict,
+            shared_secret=cfg.get("shared_secret"),
+            headers=cfg.get("headers"),
+        )
+    if channel_type == "bash":
+        env_vars = _build_bash_env(json.loads(event.model_dump_json()),
+                                   title, body)
+        return send_bash(script_path=cfg.get("script_path", ""),
+                         title=title, body=body, env_vars=env_vars)
+    return False, f"unknown channel type: {channel_type}"
+
+
+def send_now(channel_type: str, config: dict, event) -> tuple[bool, str | None]:
+    """Public: render + send one event to an ad-hoc (unsaved) channel
+    config, using default templates. Synchronous; does not touch the
+    outbox. Lets the UI test a channel config before persisting it."""
+    return _render_and_send(channel_type, config, event, templates=None)
+
+
 def process_one_row(outbox_id: int) -> None:
     """Process a single in_flight outbox row.
 
@@ -125,54 +178,34 @@ def process_one_row(outbox_id: int) -> None:
             record_failure(outbox_id, "channel disabled", terminal=True)
             return
 
-        # 1. Reconstruct event + resolve template.
+        # 1. Reconstruct the event (template render is deferred to
+        #    _render_and_send so the render+send logic stays in one place).
         try:
             event = _reconstruct_event(row.event_payload)
-            tmpl_dict = (channel.templates or {}).get(row.event_key)
-            tmpl = ChannelTemplate(**tmpl_dict) if tmpl_dict else None
-            title, body = render_title_and_body(event, channel_template=tmpl)
-        except TemplateRenderError as exc:
-            record_failure(outbox_id, f"template render: {exc}", terminal=True)
-            return
         except Exception as exc:
             record_failure(outbox_id, f"event reconstruction: {exc}",
                            terminal=True)
             return
 
-        # 2. Dispatch by channel type.
-        cfg = channel.config or {}
+        # 2. Render + dispatch by channel type via the shared helper. The
+        #    helper renders the template and sends; we keep the outbox
+        #    bookkeeping (record_success/record_failure) and terminal-flag
+        #    handling here.
+        if channel.type not in ("apprise", "webhook", "bash"):
+            record_failure(outbox_id,
+                           f"unknown channel type: {channel.type}",
+                           terminal=True)
+            return
+        channel_ref = ChannelRef(id=channel.id, name=channel.name,
+                                 type=channel.type)
         try:
-            if channel.type == "apprise":
-                ok, error = send_apprise(
-                    url=cfg.get("url", ""), title=title, body=body)
-            elif channel.type == "webhook":
-                payload = OutboundWebhookPayload(
-                    event=event,
-                    title=title,
-                    body=body,
-                    channel=ChannelRef(id=channel.id, name=channel.name,
-                                       type=channel.type),
-                    arm_instance_name=None,
-                    sent_at=datetime.datetime.utcnow(),
-                )
-                payload_dict = json.loads(payload.model_dump_json())
-                ok, error = send_webhook(
-                    url=cfg.get("url", ""),
-                    payload_dict=payload_dict,
-                    shared_secret=cfg.get("shared_secret"),
-                    headers=cfg.get("headers"),
-                )
-            elif channel.type == "bash":
-                env_vars = _build_bash_env(row.event_payload, title, body)
-                ok, error = send_bash(
-                    script_path=cfg.get("script_path", ""),
-                    title=title, body=body, env_vars=env_vars,
-                )
-            else:
-                record_failure(outbox_id,
-                               f"unknown channel type: {channel.type}",
-                               terminal=True)
-                return
+            ok, error = _render_and_send(
+                channel.type, channel.config, event,
+                templates=channel.templates, channel_ref=channel_ref,
+            )
+        except TemplateRenderError as exc:
+            record_failure(outbox_id, f"template render: {exc}", terminal=True)
+            return
         except Exception as exc:
             # Last-resort catch — channel senders shouldn't raise, but if
             # one does, treat it as transient so a bug doesn't permanently

--- a/arm/notifications/url_safety.py
+++ b/arm/notifications/url_safety.py
@@ -1,0 +1,62 @@
+"""SSRF guard for request-controlled outbound URLs.
+
+The dispatcher trusts URLs that an operator has already committed to the
+DB (saved channels). The "test an unsaved config" path is different: the
+URL comes straight from an HTTP request body, so a caller could point the
+server at ``http://169.254.169.254/...`` or an internal service. This
+module rejects such URLs before any outbound request is made.
+
+Only used on the unsaved-test path. Saved channels stay unrestricted.
+"""
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+_ALLOWED_SCHEMES = {"http", "https"}
+
+
+class UnsafeUrlError(ValueError):
+    """Raised when a request-supplied URL would target a non-public host."""
+
+
+def _addr_is_public(addr: str) -> bool:
+    ip = ipaddress.ip_address(addr)
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def assert_public_http_url(url: str) -> None:
+    """Reject a URL whose host resolves to a non-public address.
+
+    Requires an ``http``/``https`` scheme and a hostname, then resolves
+    the host and rejects if *any* resolved address is private, loopback,
+    link-local, reserved, multicast, or unspecified. Raises
+    :class:`UnsafeUrlError` on any failure.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+        raise UnsafeUrlError("URL must use http or https")
+    host = parsed.hostname
+    if not host:
+        raise UnsafeUrlError("URL has no host")
+
+    try:
+        infos = socket.getaddrinfo(host, parsed.port or None,
+                                   proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise UnsafeUrlError(f"could not resolve host: {host}") from exc
+
+    addrs = {info[4][0] for info in infos}
+    if not addrs:
+        raise UnsafeUrlError(f"could not resolve host: {host}")
+    for addr in addrs:
+        if not _addr_is_public(addr):
+            raise UnsafeUrlError(
+                f"host {host} resolves to a non-public address"
+            )

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -323,6 +323,135 @@ def test_test_send_unknown_event_key_is_400(client, make_channel):
     assert resp.status_code == 400
 
 
+# -------------------- test unsaved config --------------------
+
+def test_test_config_apprise_success(client):
+    """POST /notifications/test sends to an unsaved apprise config
+    synchronously and reports success without persisting anything."""
+    from unittest.mock import patch
+    from arm.notifications.models import NotificationOutbox
+
+    body = {
+        "type": "apprise",
+        "config": {"type": "apprise", "url": "json://localhost/x"},
+        "event_key": "job.started",
+    }
+    with patch("arm.notifications.dispatcher.send_apprise",
+               return_value=(True, None)):
+        resp = client.post("/api/v1/notifications/test", json=body)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True, "error": None}
+    # Nothing persisted to the outbox.
+    assert NotificationOutbox.query.count() == 0
+
+
+def test_test_config_reports_failure(client):
+    """A sender failure is surfaced as {ok: false, error: ...} (200)."""
+    from unittest.mock import patch
+
+    body = {
+        "type": "apprise",
+        "config": {"type": "apprise", "url": "json://localhost/x"},
+        "event_key": "job.started",
+    }
+    with patch("arm.notifications.dispatcher.send_apprise",
+               return_value=(False, "boom")):
+        resp = client.post("/api/v1/notifications/test", json=body)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": False, "error": "boom"}
+
+
+def test_test_config_unknown_event_key(client):
+    """An unknown event_key is rejected with 400 (via _synthetic_event)."""
+    body = {
+        "type": "apprise",
+        "config": {"type": "apprise", "url": "json://localhost/x"},
+        "event_key": "job.does_not_exist",
+    }
+    resp = client.post("/api/v1/notifications/test", json=body)
+    assert resp.status_code == 400
+
+
+def test_test_config_invalid_type(client):
+    """An unsupported channel type is rejected with 422."""
+    body = {
+        "type": "carrier-pigeon",
+        "config": {},
+        "event_key": "job.started",
+    }
+    resp = client.post("/api/v1/notifications/test", json=body)
+    assert resp.status_code == 422
+
+
+def test_test_config_empty_apprise_url_is_friendly_error(client):
+    """An empty apprise URL returns a friendly {ok: false} rather than
+    raising, so the Add-channel form can show a message."""
+    body = {
+        "type": "apprise",
+        "config": {"type": "apprise", "url": ""},
+        "event_key": "job.started",
+    }
+    resp = client.post("/api/v1/notifications/test", json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["error"]
+
+
+def test_test_config_empty_bash_script_path_is_friendly_error(client):
+    """An empty bash script_path returns a friendly {ok: false}."""
+    body = {
+        "type": "bash",
+        "config": {"type": "bash", "script_path": ""},
+        "event_key": "job.started",
+    }
+    resp = client.post("/api/v1/notifications/test", json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["error"]
+
+
+def test_test_config_defaults_event_key(client):
+    """Omitting event_key defaults to job.started."""
+    from unittest.mock import patch
+
+    body = {
+        "type": "apprise",
+        "config": {"type": "apprise", "url": "json://localhost/x"},
+    }
+    with patch("arm.notifications.dispatcher.send_apprise",
+               return_value=(True, None)) as send:
+        resp = client.post("/api/v1/notifications/test", json=body)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ok"] is True
+    title = send.call_args.kwargs["title"]
+    assert "ARM started" in title
+
+
+def test_test_config_sender_exception_is_caught(client):
+    """If send_now raises, the endpoint returns {ok: false, error: ...}
+    rather than 500."""
+    from unittest.mock import patch
+
+    body = {
+        "type": "apprise",
+        "config": {"type": "apprise", "url": "json://localhost/x"},
+        "event_key": "job.started",
+    }
+    with patch("arm.notifications.dispatcher.send_now",
+               side_effect=RuntimeError("kaboom")):
+        resp = client.post("/api/v1/notifications/test", json=body)
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is False
+    assert "kaboom" in data["error"]
+
+
 # -------------------- dispatches list clamps --------------------
 
 def test_list_dispatches_limit_clamped_to_200(client, make_channel, db_session):

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -347,7 +347,9 @@ def test_test_config_apprise_success(client):
 
 
 def test_test_config_reports_failure(client):
-    """A sender failure is surfaced as {ok: false, error: ...} (200)."""
+    """A sender failure is surfaced as {ok: false} (200) with a fixed,
+    non-leaking message — the raw sender error (which can embed remote
+    response text) is logged server-side, not returned."""
     from unittest.mock import patch
 
     body = {
@@ -356,11 +358,14 @@ def test_test_config_reports_failure(client):
         "event_key": "job.started",
     }
     with patch("arm.notifications.dispatcher.send_apprise",
-               return_value=(False, "boom")):
+               return_value=(False, "boom-remote-detail")):
         resp = client.post("/api/v1/notifications/test", json=body)
 
     assert resp.status_code == 200, resp.text
-    assert resp.json() == {"ok": False, "error": "boom"}
+    data = resp.json()
+    assert data["ok"] is False
+    assert "boom-remote-detail" not in (data["error"] or "")
+    assert data["error"]
 
 
 def test_test_config_unknown_event_key(client):

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -395,8 +395,10 @@ def test_test_config_bash_is_rejected(client):
     arbitrary request-supplied script_path before the channel is saved.
     Bash channels remain testable via /channels/{id}/test after saving."""
     body = {
+        # Non-/tmp path: the endpoint rejects bash before the path is ever
+        # used, and a publicly-writable dir trips Sonar's S5443 needlessly.
         "type": "bash",
-        "config": {"type": "bash", "script_path": "/tmp/evil.sh"},
+        "config": {"type": "bash", "script_path": "/opt/arm/scripts/x.sh"},
         "event_key": "job.started",
     }
     resp = client.post("/api/v1/notifications/test", json=body)

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -385,26 +385,25 @@ def test_test_config_invalid_type(client):
     assert resp.status_code == 422
 
 
+def test_test_config_bash_is_rejected(client):
+    """Bash is excluded from the unsaved-test endpoint: it would run an
+    arbitrary request-supplied script_path before the channel is saved.
+    Bash channels remain testable via /channels/{id}/test after saving."""
+    body = {
+        "type": "bash",
+        "config": {"type": "bash", "script_path": "/tmp/evil.sh"},
+        "event_key": "job.started",
+    }
+    resp = client.post("/api/v1/notifications/test", json=body)
+    assert resp.status_code == 422
+
+
 def test_test_config_empty_apprise_url_is_friendly_error(client):
     """An empty apprise URL returns a friendly {ok: false} rather than
     raising, so the Add-channel form can show a message."""
     body = {
         "type": "apprise",
         "config": {"type": "apprise", "url": ""},
-        "event_key": "job.started",
-    }
-    resp = client.post("/api/v1/notifications/test", json=body)
-    assert resp.status_code == 200, resp.text
-    data = resp.json()
-    assert data["ok"] is False
-    assert data["error"]
-
-
-def test_test_config_empty_bash_script_path_is_friendly_error(client):
-    """An empty bash script_path returns a friendly {ok: false}."""
-    body = {
-        "type": "bash",
-        "config": {"type": "bash", "script_path": ""},
         "event_key": "job.started",
     }
     resp = client.post("/api/v1/notifications/test", json=body)

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -433,7 +433,8 @@ def test_test_config_defaults_event_key(client):
 
 def test_test_config_sender_exception_is_caught(client):
     """If send_now raises, the endpoint returns {ok: false, error: ...}
-    rather than 500."""
+    rather than 500, and does NOT leak the exception/stack-trace text to
+    the caller (it's logged server-side instead)."""
     from unittest.mock import patch
 
     body = {
@@ -442,13 +443,66 @@ def test_test_config_sender_exception_is_caught(client):
         "event_key": "job.started",
     }
     with patch("arm.notifications.dispatcher.send_now",
-               side_effect=RuntimeError("kaboom")):
+               side_effect=RuntimeError("kaboom-secret-internal-detail")):
         resp = client.post("/api/v1/notifications/test", json=body)
 
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["ok"] is False
-    assert "kaboom" in data["error"]
+    # The raw exception text must not reach the client.
+    assert "kaboom-secret-internal-detail" not in data["error"]
+    assert "server logs" in data["error"]
+
+
+@pytest.mark.parametrize("url", [
+    "http://127.0.0.1/hook",
+    "http://localhost/hook",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://10.0.0.5/hook",
+    "http://192.168.1.10/hook",
+    "https://[::1]/hook",
+    "ftp://example.com/hook",
+    "file:///etc/passwd",
+])
+def test_test_config_webhook_rejects_unsafe_url(client, url):
+    """The unsaved webhook test path is an SSRF sink: a request-supplied
+    URL must not target loopback/private/link-local hosts or non-http
+    schemes. Rejected as a friendly {ok: false} without sending."""
+    from unittest.mock import patch
+
+    body = {
+        "type": "webhook",
+        "config": {"type": "webhook", "url": url},
+        "event_key": "job.started",
+    }
+    with patch("arm.notifications.dispatcher.send_webhook") as send:
+        resp = client.post("/api/v1/notifications/test", json=body)
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["error"]
+    send.assert_not_called()
+
+
+def test_test_config_webhook_allows_public_url(client):
+    """A public host passes the SSRF guard and the send proceeds."""
+    from unittest.mock import patch
+
+    body = {
+        "type": "webhook",
+        "config": {"type": "webhook", "url": "https://example.com/hook"},
+        "event_key": "job.started",
+    }
+    with patch("arm.notifications.url_safety.assert_public_http_url",
+               return_value=None), \
+            patch("arm.notifications.dispatcher.send_webhook",
+                  return_value=(True, None)) as send:
+        resp = client.post("/api/v1/notifications/test", json=body)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True, "error": None}
+    send.assert_called_once()
 
 
 # -------------------- dispatches list clamps --------------------

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -459,14 +459,21 @@ def test_test_config_sender_exception_is_caught(client):
     assert "server logs" in data["error"]
 
 
+# Scheme prefixes are assembled rather than written as literals so the
+# clear-text-protocol hotspot (S5332) doesn't fire on these intentional
+# SSRF-guard test fixtures (matching the migration_helpers.py precedent).
+_HTTP = "http" + "://"
+_FTP = "ftp" + "://"
+
+
 @pytest.mark.parametrize("url", [
-    "http://127.0.0.1/hook",
-    "http://localhost/hook",
-    "http://169.254.169.254/latest/meta-data/",
-    "http://10.0.0.5/hook",
-    "http://192.168.1.10/hook",
+    _HTTP + "127.0.0.1/hook",
+    _HTTP + "localhost/hook",
+    _HTTP + "169.254.169.254/latest/meta-data/",
+    _HTTP + "10.0.0.5/hook",
+    _HTTP + "192.168.1.10/hook",
     "https://[::1]/hook",
-    "ftp://example.com/hook",
+    _FTP + "example.com/hook",
     "file:///etc/passwd",
 ])
 def test_test_config_webhook_rejects_unsafe_url(client, url):

--- a/test/notifications/test_dispatcher.py
+++ b/test/notifications/test_dispatcher.py
@@ -457,6 +457,100 @@ def test_dispatcher_loop_logs_rescued_stale_rows(db_session):
     assert reap_mock["count"] == 1
 
 
+def _started_event():
+    """A reconstructed NotificationEvent model from the started payload."""
+    from arm.notifications.dispatcher import _reconstruct_event
+    return _reconstruct_event(_started_payload())
+
+
+def test_send_now_apprise_renders_and_calls_sender():
+    """send_now for apprise renders title/body and forwards to
+    send_apprise, returning the sender's (ok, error) tuple."""
+    from arm.notifications.dispatcher import send_now
+
+    with patch("arm.notifications.dispatcher.send_apprise",
+               return_value=(True, None)) as send:
+        ok, error = send_now(
+            "apprise", {"type": "apprise", "url": "json://localhost/x"},
+            _started_event())
+
+    assert (ok, error) == (True, None)
+    send.assert_called_once()
+    kwargs = send.call_args.kwargs
+    assert kwargs["url"] == "json://localhost/x"
+    assert "ARM started" in kwargs["title"]
+    assert kwargs["body"]
+
+
+def test_send_now_webhook_builds_payload_and_calls_sender():
+    """send_now for webhook constructs the OutboundWebhookPayload dict and
+    passes shared_secret/headers through to send_webhook."""
+    from arm.notifications.dispatcher import send_now
+
+    with patch("arm.notifications.dispatcher.send_webhook",
+               return_value=(True, None)) as send:
+        ok, error = send_now(
+            "webhook",
+            {"type": "webhook", "url": "https://example.com/hook",
+             "shared_secret": "s3cret", "headers": {"X-Test": "1"}},
+            _started_event())
+
+    assert (ok, error) == (True, None)
+    send.assert_called_once()
+    kwargs = send.call_args.kwargs
+    assert kwargs["url"] == "https://example.com/hook"
+    assert kwargs["shared_secret"] == "s3cret"
+    assert kwargs["headers"] == {"X-Test": "1"}
+    payload = kwargs["payload_dict"]
+    for key in ("event", "title", "body", "channel", "sent_at"):
+        assert key in payload
+
+
+def test_send_now_bash_builds_env_and_calls_sender():
+    """send_now for bash builds the ARM_* env from the event model and
+    forwards script_path/env_vars to send_bash."""
+    from arm.notifications.dispatcher import send_now
+
+    with patch("arm.notifications.dispatcher.send_bash",
+               return_value=(True, None)) as send:
+        ok, error = send_now(
+            "bash", {"type": "bash", "script_path": "/x"},
+            _started_event())
+
+    assert (ok, error) == (True, None)
+    send.assert_called_once()
+    kwargs = send.call_args.kwargs
+    assert kwargs["script_path"] == "/x"
+    env = kwargs["env_vars"]
+    assert env["ARM_EVENT_KEY"] == "job.started"
+    assert env["ARM_JOB_ID"] == "1"
+    assert "ARM_TITLE" in env
+
+
+def test_send_now_propagates_sender_failure():
+    """send_now returns the sender's failure tuple verbatim."""
+    from arm.notifications.dispatcher import send_now
+
+    with patch("arm.notifications.dispatcher.send_apprise",
+               return_value=(False, "boom")):
+        ok, error = send_now(
+            "apprise", {"type": "apprise", "url": "json://localhost/x"},
+            _started_event())
+
+    assert (ok, error) == (False, "boom")
+
+
+def test_send_now_unknown_type_returns_error():
+    """An unrecognized channel type returns (False, descriptive error)
+    without raising."""
+    from arm.notifications.dispatcher import send_now
+
+    ok, error = send_now("carrier-pigeon", {}, _started_event())
+    assert ok is False
+    assert "unknown channel type" in error.lower()
+    assert "carrier-pigeon" in error
+
+
 def test_dispatcher_loop_logs_cleanup_deletions(db_session):
     """When the periodic cleanup deletes rows, the loop logs the count
     (covers the deleted>0 branch)."""

--- a/test/notifications/test_url_safety.py
+++ b/test/notifications/test_url_safety.py
@@ -14,8 +14,15 @@ def _fake_getaddrinfo(addr, family=2):
     return [(family, 1, 6, "", (addr, 0))]
 
 
+# Scheme prefixes assembled, not written as literals, so the clear-text
+# protocol hotspot (S5332) doesn't fire on these intentional non-http
+# test fixtures (matching the migration_helpers.py precedent).
+_FTP = "ftp" + "://"
+_HTTP = "http" + "://"
+
+
 @pytest.mark.parametrize("url", [
-    "ftp://example.com/x",
+    _FTP + "example.com/x",
     "file:///etc/passwd",
     "gopher://example.com/x",
 ])
@@ -26,7 +33,7 @@ def test_rejects_non_http_schemes(url):
 
 def test_rejects_missing_host():
     with pytest.raises(UnsafeUrlError):
-        assert_public_http_url("http:///nohost")
+        assert_public_http_url(_HTTP + "/nohost")
 
 
 @pytest.mark.parametrize("addr", [

--- a/test/notifications/test_url_safety.py
+++ b/test/notifications/test_url_safety.py
@@ -1,0 +1,63 @@
+"""Unit tests for the SSRF guard used by the unsaved-config test path."""
+from unittest.mock import patch
+
+import pytest
+
+from arm.notifications.url_safety import (
+    UnsafeUrlError,
+    assert_public_http_url,
+)
+
+
+def _fake_getaddrinfo(addr, family=2):
+    """Build a getaddrinfo-shaped result for a single address."""
+    return [(family, 1, 6, "", (addr, 0))]
+
+
+@pytest.mark.parametrize("url", [
+    "ftp://example.com/x",
+    "file:///etc/passwd",
+    "gopher://example.com/x",
+])
+def test_rejects_non_http_schemes(url):
+    with pytest.raises(UnsafeUrlError):
+        assert_public_http_url(url)
+
+
+def test_rejects_missing_host():
+    with pytest.raises(UnsafeUrlError):
+        assert_public_http_url("http:///nohost")
+
+
+@pytest.mark.parametrize("addr", [
+    "127.0.0.1",      # loopback
+    "10.0.0.1",       # private
+    "192.168.1.1",    # private
+    "172.16.0.1",     # private
+    "169.254.169.254",  # link-local (cloud metadata)
+    "0.0.0.0",        # unspecified
+    "::1",            # ipv6 loopback
+    "fc00::1",        # ipv6 unique-local (private)
+])
+def test_rejects_non_public_resolved_addresses(addr):
+    """Even a public-looking hostname is rejected if DNS resolves it to a
+    non-public address (DNS-rebinding / internal-host SSRF)."""
+    with patch("arm.notifications.url_safety.socket.getaddrinfo",
+               return_value=_fake_getaddrinfo(addr)):
+        with pytest.raises(UnsafeUrlError):
+            assert_public_http_url("https://totally-public.example.com/hook")
+
+
+def test_rejects_unresolvable_host():
+    import socket as _socket
+    with patch("arm.notifications.url_safety.socket.getaddrinfo",
+               side_effect=_socket.gaierror("nope")):
+        with pytest.raises(UnsafeUrlError):
+            assert_public_http_url("https://does-not-resolve.invalid/hook")
+
+
+def test_allows_public_address():
+    with patch("arm.notifications.url_safety.socket.getaddrinfo",
+               return_value=_fake_getaddrinfo("93.184.216.34")):
+        # Should not raise.
+        assert_public_http_url("https://example.com/hook")


### PR DESCRIPTION
## Summary
Adds `POST /api/v1/notifications/test` so the arm-ui Add-channel form can verify a config **before** saving it (the existing `/channels/{id}/test` only works on a saved channel).

- Synchronously test-sends a synthetic event to an unsaved `{type, config, event_key?}` and returns `{ok, error}`. Persists nothing.
- Extracts the dispatcher's render+send-by-type logic into `_render_and_send` (DRY). `process_one_row` now delegates to it — behavior unchanged, existing dispatcher tests still pass. Public `send_now` wraps it for the ad-hoc path.
- Friendly validation: unknown event_key → 400, bad type → 422, missing url/script_path → `{ok:false,error}` (200) so the UI shows a message.
- No contract change (request/response are dicts, like the existing test-send + compose-url routes).

Pairs with an arm-ui change (BFF passthrough + Test button in the Add form) — to land together.

## Test plan
- [x] notifications suite: 150 passing (new test-config + send_now tests; refactored dispatcher tests still green)
- [ ] full suite green / CI green