### PR TITLE
feat(notifications): persist apprise service_id for editable channels

### DIFF
--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -588,3 +588,48 @@ def test_merge_patch_config_none_incoming_keeps_existing():
     from arm.api.v1.notifications import _merge_patch_config
     existing = {"type": "apprise", "url": "discord://x/y"}
     assert _merge_patch_config(existing, None) == existing
+
+
+# -------------------- apprise service_id --------------------
+
+def test_create_channel_apprise_persists_service_id(client):
+    body = {
+        "type": "apprise",
+        "name": "Discord w/ service id",
+        "config": {"type": "apprise", "url": "discord://1/2", "service_id": "discord"},
+        "subscribed_events": ["job.started"],
+    }
+    resp = client.post("/api/v1/notifications/channels", json=body)
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["config"]["service_id"] == "discord"
+
+
+def test_patch_channel_apprise_updates_service_id_and_url(client):
+    create = client.post("/api/v1/notifications/channels", json={
+        "type": "apprise", "name": "c",
+        "config": {"type": "apprise", "url": "discord://1/2", "service_id": "discord"},
+        "subscribed_events": ["job.started"],
+    })
+    cid = create.json()["id"]
+    resp = client.patch(f"/api/v1/notifications/channels/{cid}", json={
+        "config": {"type": "apprise", "url": "slack://a/b/c", "service_id": "slack"},
+    })
+    assert resp.status_code == 200, resp.text
+    cfg = resp.json()["config"]
+    assert cfg["url"] == "slack://a/b/c"
+    assert cfg["service_id"] == "slack"
+
+
+def test_patch_channel_without_config_keeps_apprise_url(client):
+    create = client.post("/api/v1/notifications/channels", json={
+        "type": "apprise", "name": "c",
+        "config": {"type": "apprise", "url": "discord://1/2", "service_id": "discord"},
+        "subscribed_events": ["job.started"],
+    })
+    cid = create.json()["id"]
+    resp = client.patch(f"/api/v1/notifications/channels/{cid}", json={"name": "renamed"})
+    assert resp.status_code == 200, resp.text
+    cfg = resp.json()["config"]
+    assert cfg["url"] == "discord://1/2"
+    assert cfg["service_id"] == "discord"
+    assert resp.json()["name"] == "renamed"


### PR DESCRIPTION
## Summary
- Bumps the `components/contracts` submodule to include the new optional `service_id` on `AppriseChannelConfig` (contracts PR merged separately).
- Verifies (tests-only — no code change needed) that `service_id` persists through `create_channel` + `patch_channel`, and that a PATCH omitting `config` leaves the stored apprise url + service_id untouched (the "blank = keep current" path the UI relies on).

Part 2 of a 3-repo change (contracts → neu → ui) for editable apprise channels. Spec: `arm-ai/arm-neu/docs/superpowers/specs/2026-05-25-editable-apprise-channels-design.md`.

## Test plan
- [x] `pytest test/notifications/` — 176 pass (3 new: persist service_id on create, update on patch, keep-on-omit)
- [ ] CI: lockstep (contracts submodule at main tip), CodeQL, SonarCloud, codecov, test-pr-build