### PR TITLE
feat(notifications): apprise field-map — server-side mask, merge, recompose

### DIFF
--- a/arm/api/v1/notifications.py
+++ b/arm/api/v1/notifications.py
@@ -124,6 +124,31 @@ def _apprise_field_is_private(service_id: str, key: str) -> bool | None:
     return None
 
 
+def _compose_apprise_url_from_fields(
+    service_id: str | None, fields: dict
+) -> str | None:
+    """Compose an apprise url from a flat fields dict.
+
+    Looks up `service_id` in the catalog, partitions `fields` into
+    required vs advanced by the catalog's `required_fields` keys, and
+    returns the composed url. Returns None when service_id is missing
+    or unknown (callers decide whether that's an error)."""
+    if not service_id:
+        return None
+    from arm.notifications.catalog import build_catalog
+    from arm.notifications.url_composer import compose_apprise_url
+    cat = build_catalog()
+    svc = next((s for s in cat["services"] if s["id"] == service_id), None)
+    if svc is None:
+        return None
+    required_keys = {f["key"] for f in svc.get("required_fields", [])}
+    return compose_apprise_url(
+        service_id=service_id,
+        required={k: v for k, v in fields.items() if k in required_keys},
+        advanced={k: v for k, v in fields.items() if k not in required_keys},
+    )
+
+
 def _mask_config(cfg: dict) -> dict:
     """Replace secret fields with the masked literal for GET responses."""
     if not cfg:
@@ -179,18 +204,9 @@ def _merge_patch_config(existing: dict, incoming: dict | None) -> dict:
         merged["fields"] = merged_fields
         merged["service_id"] = service_id
         # Recompose url from merged fields.
-        if service_id:
-            from arm.notifications.catalog import build_catalog
-            from arm.notifications.url_composer import compose_apprise_url
-            cat = build_catalog()
-            svc = next((s for s in cat["services"] if s["id"] == service_id), None)
-            if svc:
-                required_keys = {f["key"] for f in svc.get("required_fields", [])}
-                required = {k: v for k, v in merged_fields.items() if k in required_keys}
-                advanced = {k: v for k, v in merged_fields.items() if k not in required_keys}
-                merged["url"] = compose_apprise_url(
-                    service_id=service_id, required=required, advanced=advanced
-                )
+        composed = _compose_apprise_url_from_fields(service_id, merged_fields)
+        if composed is not None:
+            merged["url"] = composed
     return merged
 
 
@@ -238,8 +254,6 @@ def get_channel(channel_id: int):
 
 @router.post("/notifications/channels", status_code=201)
 def create_channel(payload: ChannelCreate):
-    if payload.config.type == "apprise":
-        _validate_apprise_url(payload.config.url)
     config_dict = payload.config.model_dump(mode="json")
     # SecretStr -> plaintext for storage.
     if payload.config.type == "webhook":
@@ -247,6 +261,16 @@ def create_channel(payload: ChannelCreate):
         config_dict["shared_secret"] = (
             sec.get_secret_value() if sec is not None else None
         )
+    # Apprise: if the client sent {service_id, fields} (no url), compose
+    # server-side. Otherwise validate the provided url as before.
+    if payload.config.type == "apprise":
+        fields = config_dict.get("fields") or {}
+        service_id = config_dict.get("service_id")
+        if fields and service_id and not config_dict.get("url"):
+            composed = _compose_apprise_url_from_fields(service_id, fields)
+            if composed is not None:
+                config_dict["url"] = composed
+        _validate_apprise_url(config_dict.get("url", ""))
     ch = NotificationChannel(
         type=payload.type,
         name=payload.name,

--- a/arm/api/v1/notifications.py
+++ b/arm/api/v1/notifications.py
@@ -110,6 +110,20 @@ _TEST_SEND_COOLDOWN_SECONDS = 10
 _test_send_last: dict[int, datetime.datetime] = {}
 
 
+def _apprise_field_is_private(service_id: str, key: str) -> bool | None:
+    """Look up a field's `private` flag from the apprise catalog.
+    Returns True/False if found, None for unknown service or key."""
+    from arm.notifications.catalog import build_catalog
+    cat = build_catalog()
+    svc = next((s for s in cat["services"] if s["id"] == service_id), None)
+    if svc is None:
+        return None
+    for f in [*svc.get("required_fields", []), *svc.get("advanced_fields", [])]:
+        if f["key"] == key:
+            return bool(f.get("private"))
+    return None
+
+
 def _mask_config(cfg: dict) -> dict:
     """Replace secret fields with the masked literal for GET responses."""
     if not cfg:

--- a/arm/api/v1/notifications.py
+++ b/arm/api/v1/notifications.py
@@ -132,6 +132,15 @@ def _mask_config(cfg: dict) -> dict:
     if cfg.get("type") == "webhook" and "shared_secret" in cfg:
         if cfg["shared_secret"]:
             out["shared_secret"] = _HIDDEN_LITERAL
+    if cfg.get("type") == "apprise" and isinstance(cfg.get("fields"), dict):
+        service_id = cfg.get("service_id")
+        masked_fields: dict = {}
+        for k, v in cfg["fields"].items():
+            if service_id and _apprise_field_is_private(service_id, k) is True and v:
+                masked_fields[k] = _HIDDEN_LITERAL
+            else:
+                masked_fields[k] = v
+        out["fields"] = masked_fields
     return out
 
 

--- a/arm/api/v1/notifications.py
+++ b/arm/api/v1/notifications.py
@@ -398,13 +398,13 @@ def test_send(channel_id: int, body: dict | None = None):
 
 @router.post("/notifications/test")
 def test_config(body: dict):
-    """Test-send to an UNSAVED channel config, synchronously.
+    """Test-send. Two body shapes:
 
-    Lets the arm-ui "Add channel" form verify a config before saving it.
-    Body: ``{type, config: {...}, event_key?}``. Returns ``{ok, error}``.
-    Persists nothing. Unknown ``event_key`` → 400; unsupported ``type`` →
-    422; send/validation problems are returned as ``{ok: false, error}``
-    (200) so the UI can show a friendly message.
+    - {type, config, event_key?} — unsaved test (Add form). Existing.
+    - {channel_id, fields, event_key?} — saved channel with re-entered
+      fields (editor Send test). Loads stored config, merges fields
+      per the same <hidden>-preserve rules as PATCH, composes the url,
+      sends synchronously. Returns {ok, error}.
 
     Only ``apprise`` and ``webhook`` (URL-based senders) can be tested
     unsaved. ``bash`` is intentionally excluded: it would execute an
@@ -419,6 +419,37 @@ def test_config(body: dict):
         assert_public_http_url,
     )
 
+    event_key = body.get("event_key", "job.started")
+
+    # Branch A: saved-channel test with re-entered fields.
+    if "channel_id" in body:
+        ch = NotificationChannel.query.get(body["channel_id"])
+        if ch is None:
+            raise HTTPException(404, "channel not found")
+        if ch.type != "apprise":
+            raise HTTPException(422, "channel_id test path supports apprise only")
+        incoming_fields = body.get("fields") or {}
+        merged = _merge_patch_config(
+            ch.config or {},
+            {"type": "apprise", "service_id": ch.config.get("service_id"),
+             "fields": incoming_fields},
+        )
+        url = merged.get("url")
+        if not url:
+            return {"ok": False, "error": "could not compose url from fields"}
+        payload = _synthetic_event(event_key)
+        event = _reconstruct_event(payload)
+        try:
+            ok, error = send_now("apprise", {"type": "apprise", "url": url}, event)
+        except Exception:
+            log.exception("editor apprise test send failed")
+            return {"ok": False, "error": "test send failed; see server logs"}
+        if ok:
+            return {"ok": True, "error": None}
+        log.warning("editor apprise test send failed: %s", error)
+        return {"ok": False, "error": "test send failed; see server logs"}
+
+    # Branch B: existing unsaved-config test (Add form).
     ch_type = body.get("type")
     if ch_type not in ("apprise", "webhook"):
         raise HTTPException(422, "unsaved test supports only apprise and webhook")
@@ -443,7 +474,6 @@ def test_config(body: dict):
                 "error": "URL must be a public http(s) address",
             }
 
-    event_key = body.get("event_key", "job.started")
     payload = _synthetic_event(event_key)  # raises 400 on unknown key
     event = _reconstruct_event(payload)
     try:

--- a/arm/api/v1/notifications.py
+++ b/arm/api/v1/notifications.py
@@ -145,17 +145,52 @@ def _mask_config(cfg: dict) -> dict:
 
 
 def _merge_patch_config(existing: dict, incoming: dict | None) -> dict:
-    """When the client sends a PATCH with config.shared_secret=<hidden>,
-    preserve the existing secret instead of overwriting it."""
+    """When the client sends a PATCH with config.<secret>=<hidden>,
+    preserve the existing secret instead of overwriting it.
+    For apprise channels, also merge `fields` per-key and recompose
+    `url` from the merged fields."""
     if incoming is None:
         return existing
     merged = dict(incoming)
+    # Webhook shared_secret (existing behavior).
     if (
         existing.get("type") == "webhook"
         and merged.get("type") == "webhook"
         and merged.get("shared_secret") == _HIDDEN_LITERAL
     ):
         merged["shared_secret"] = existing.get("shared_secret")
+    # Apprise per-field merge + url recompose.
+    if (
+        existing.get("type") == "apprise"
+        and merged.get("type") == "apprise"
+        and isinstance(merged.get("fields"), dict)
+    ):
+        service_id = merged.get("service_id") or existing.get("service_id")
+        stored_fields = existing.get("fields") or {}
+        merged_fields: dict = dict(stored_fields)  # start from stored
+        for k, v in merged["fields"].items():
+            # <hidden> on a private field -> keep stored value
+            if (
+                _apprise_field_is_private(service_id, k) is True
+                and v == _HIDDEN_LITERAL
+            ):
+                continue  # keep stored
+            merged_fields[k] = v
+        merged["fields"] = merged_fields
+        merged["service_id"] = service_id
+        # Recompose url from merged fields.
+        if service_id:
+            from arm.notifications.catalog import build_catalog
+            from arm.notifications.url_composer import compose_apprise_url
+            cat = build_catalog()
+            svc = next((s for s in cat["services"] if s["id"] == service_id), None)
+            if svc:
+                required_keys = {f["key"] for f in svc.get("required_fields", [])}
+                required = {k: v for k, v in merged_fields.items() if k in required_keys}
+                advanced = {k: v for k, v in merged_fields.items() if k not in required_keys}
+                merged["url"] = compose_apprise_url(
+                    service_id=service_id, required=required, advanced=advanced
+                )
     return merged
 
 
@@ -246,7 +281,7 @@ def patch_channel(channel_id: int, payload: ChannelUpdate):
             incoming["shared_secret"] = (
                 sec.get_secret_value() if sec is not None else None
             )
-        if payload.config.type == "apprise":
+        if payload.config.type == "apprise" and payload.config.url:
             _validate_apprise_url(payload.config.url)
         ch.config = _merge_patch_config(ch.config or {}, incoming)
     db.session.commit()

--- a/arm/notifications/catalog.py
+++ b/arm/notifications/catalog.py
@@ -11,6 +11,7 @@ A blocklist filters out operational args that aren't user-facing
 list pins the ten most common services for the UI's primary picker
 slot; everything else lives in the long tail.
 """
+import functools
 import logging
 from typing import Any
 
@@ -118,6 +119,7 @@ def _build_service_entry(plugin_cls) -> dict | None:
     }
 
 
+@functools.lru_cache(maxsize=1)
 def build_catalog() -> dict:
     """Build the service catalog from the live apprise plugin manager.
 

--- a/test/notifications/conftest.py
+++ b/test/notifications/conftest.py
@@ -15,6 +15,15 @@ from sqlalchemy.pool import StaticPool
 from arm.database import db
 
 
+@pytest.fixture(autouse=True)
+def _clear_catalog_cache():
+    """Clear build_catalog() cache before each test so mocks work."""
+    from arm.notifications.catalog import build_catalog
+    build_catalog.cache_clear()
+    yield
+    build_catalog.cache_clear()
+
+
 @pytest.fixture
 def db_session(app_context):
     """Use the shared app_context fixture from test/conftest.py which

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -633,3 +633,14 @@ def test_patch_channel_without_config_keeps_apprise_url(client):
     assert cfg["url"] == "discord://1/2"
     assert cfg["service_id"] == "discord"
     assert resp.json()["name"] == "renamed"
+
+
+def test_apprise_field_private_lookup(app_context):
+    """The mask/merge layer needs a way to look up a field's private
+    flag by service_id + field key. Helper returns True for known
+    private fields, False for known non-private, None for unknown."""
+    from arm.api.v1.notifications import _apprise_field_is_private
+    assert _apprise_field_is_private("discord", "webhook_token") is True
+    assert _apprise_field_is_private("discord", "thread") is False
+    assert _apprise_field_is_private("discord", "no_such_field") is None
+    assert _apprise_field_is_private("no_such_service", "anything") is None

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -682,3 +682,61 @@ def test_mask_config_apprise_without_service_id_passes_through():
         "fields": {"webhook_id": "1", "webhook_token": "2"},
     }
     assert _mask_config(cfg) == cfg
+
+
+def test_merge_patch_config_apprise_hidden_preserves_secret():
+    """A PATCH whose private field value is <hidden> preserves the
+    stored value; new values overwrite."""
+    from arm.api.v1.notifications import _merge_patch_config, _HIDDEN_LITERAL
+    existing = {"type": "apprise", "service_id": "discord", "url": "discord://1/2",
+                "fields": {"webhook_id": "1", "webhook_token": "2", "thread": "5"}}
+    incoming = {"type": "apprise", "service_id": "discord",
+                "fields": {"webhook_id": _HIDDEN_LITERAL, "webhook_token": "NEW", "thread": "7"}}
+    merged = _merge_patch_config(existing, incoming)
+    assert merged["fields"]["webhook_id"] == "1"  # <hidden> -> kept
+    assert merged["fields"]["webhook_token"] == "NEW"  # overwritten
+    assert merged["fields"]["thread"] == "7"  # non-private overwritten
+    # url is recomposed from the merged fields:
+    assert merged["url"].startswith("discord://1/NEW")
+    assert "thread=7" in merged["url"]
+
+
+def test_merge_patch_config_apprise_missing_keys_keeps_stored():
+    """Keys in stored fields but absent from incoming are kept."""
+    from arm.api.v1.notifications import _merge_patch_config
+    existing = {"type": "apprise", "service_id": "discord", "url": "discord://1/2",
+                "fields": {"webhook_id": "1", "webhook_token": "2", "thread": "5"}}
+    incoming = {"type": "apprise", "service_id": "discord",
+                "fields": {"thread": "9"}}  # only sending the one change
+    merged = _merge_patch_config(existing, incoming)
+    assert merged["fields"]["webhook_id"] == "1"
+    assert merged["fields"]["webhook_token"] == "2"
+    assert merged["fields"]["thread"] == "9"
+
+
+def test_patch_channel_apprise_with_hidden_secret_keeps_url_token(client):
+    """End-to-end PATCH: client sends <hidden> for webhook_token; the
+    server keeps the stored token and the recomposed url still uses it."""
+    from arm.api.v1.notifications import _HIDDEN_LITERAL
+    create = client.post("/api/v1/notifications/channels", json={
+        "type": "apprise", "name": "d",
+        "config": {"type": "apprise", "url": "discord://realid/realtoken",
+                   "service_id": "discord",
+                   "fields": {"webhook_id": "realid", "webhook_token": "realtoken"}},
+        "subscribed_events": ["job.started"],
+    })
+    cid = create.json()["id"]
+    resp = client.patch(f"/api/v1/notifications/channels/{cid}", json={
+        "config": {"type": "apprise", "url": "", "service_id": "discord",
+                   "fields": {"webhook_id": _HIDDEN_LITERAL,
+                              "webhook_token": _HIDDEN_LITERAL,
+                              "thread": "9"}},
+    })
+    assert resp.status_code == 200, resp.text
+    cfg = resp.json()["config"]
+    # masked on GET, but the url contains the kept secrets:
+    assert cfg["fields"]["webhook_token"] == _HIDDEN_LITERAL
+    assert cfg["fields"]["thread"] == "9"
+    assert "realid" in cfg["url"]
+    assert "realtoken" in cfg["url"]
+    assert "thread=9" in cfg["url"]

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -760,3 +760,51 @@ def test_create_channel_apprise_composes_url_from_fields(client):
     # fields stored (and masked on GET — webhook_id is private, so the read shows <hidden>)
     from arm.api.v1.notifications import _HIDDEN_LITERAL
     assert cfg["fields"]["webhook_token"] == _HIDDEN_LITERAL
+
+
+def test_test_endpoint_with_channel_id_merges_fields(client):
+    """POST /notifications/test with {channel_id, fields, event_key}
+    loads the stored channel, merges incoming fields (keeping <hidden>
+    secrets), composes the url, and sends. Returns {ok, error}."""
+    from unittest.mock import patch as mockpatch
+    from arm.api.v1.notifications import _HIDDEN_LITERAL
+    create = client.post("/api/v1/notifications/channels", json={
+        "type": "apprise", "name": "d",
+        "config": {"type": "apprise", "url": "discord://realid/realtoken",
+                   "service_id": "discord",
+                   "fields": {"webhook_id": "realid", "webhook_token": "realtoken"}},
+        "subscribed_events": ["job.started"],
+    })
+    cid = create.json()["id"]
+    sent_urls: list[str] = []
+    def fake_send_apprise(*, url, title, body):
+        sent_urls.append(url)
+        return (True, None)
+    with mockpatch("arm.notifications.dispatcher.send_apprise", side_effect=fake_send_apprise):
+        resp = client.post("/api/v1/notifications/test", json={
+            "channel_id": cid,
+            "fields": {"webhook_id": _HIDDEN_LITERAL,
+                       "webhook_token": _HIDDEN_LITERAL,
+                       "thread": "9"},
+            "event_key": "job.started",
+        })
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True, "error": None}
+    assert len(sent_urls) == 1
+    assert "realid" in sent_urls[0]
+    assert "realtoken" in sent_urls[0]
+    assert "thread=9" in sent_urls[0]
+
+
+def test_test_endpoint_existing_unsaved_shape_still_works(client):
+    """The existing {type, config, event_key} body shape (used by the
+    Add form's Send test) keeps working unchanged."""
+    from unittest.mock import patch as mockpatch
+    with mockpatch("arm.notifications.dispatcher.send_apprise", return_value=(True, None)):
+        resp = client.post("/api/v1/notifications/test", json={
+            "type": "apprise",
+            "config": {"type": "apprise", "url": "discord://a/b"},
+            "event_key": "job.started",
+        })
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True, "error": None}

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -740,3 +740,23 @@ def test_patch_channel_apprise_with_hidden_secret_keeps_url_token(client):
     assert "realid" in cfg["url"]
     assert "realtoken" in cfg["url"]
     assert "thread=9" in cfg["url"]
+
+
+def test_create_channel_apprise_composes_url_from_fields(client):
+    """When the client sends {service_id, fields} (no url), neu
+    composes the url server-side and stores both."""
+    body = {
+        "type": "apprise", "name": "d",
+        "config": {"type": "apprise", "url": "",  # url absent / blank
+                   "service_id": "discord",
+                   "fields": {"webhook_id": "1", "webhook_token": "2"}},
+        "subscribed_events": ["job.started"],
+    }
+    resp = client.post("/api/v1/notifications/channels", json=body)
+    assert resp.status_code == 201, resp.text
+    cfg = resp.json()["config"]
+    assert cfg["url"] == "discord://1/2"
+    assert cfg["service_id"] == "discord"
+    # fields stored (and masked on GET — webhook_id is private, so the read shows <hidden>)
+    from arm.api.v1.notifications import _HIDDEN_LITERAL
+    assert cfg["fields"]["webhook_token"] == _HIDDEN_LITERAL

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -644,3 +644,41 @@ def test_apprise_field_private_lookup(app_context):
     assert _apprise_field_is_private("discord", "thread") is False
     assert _apprise_field_is_private("discord", "no_such_field") is None
     assert _apprise_field_is_private("no_such_service", "anything") is None
+
+
+def test_mask_config_apprise_masks_private_fields():
+    """Private apprise field values are replaced with the <hidden>
+    literal on GET; non-private values pass through unchanged."""
+    from arm.api.v1.notifications import _mask_config, _HIDDEN_LITERAL
+    cfg = {
+        "type": "apprise",
+        "url": "discord://1/2",
+        "service_id": "discord",
+        "fields": {"webhook_id": "1", "webhook_token": "2", "thread": "5"},
+    }
+    masked = _mask_config(cfg)
+    assert masked["fields"]["webhook_id"] == _HIDDEN_LITERAL  # private
+    assert masked["fields"]["webhook_token"] == _HIDDEN_LITERAL  # private
+    assert masked["fields"]["thread"] == "5"  # non-private
+    assert masked["url"] == "discord://1/2"  # url not masked in this pass
+    assert masked["service_id"] == "discord"
+
+
+def test_mask_config_apprise_no_fields_passes_through():
+    """Apprise channel with no fields (legacy/raw-URL) unchanged."""
+    from arm.api.v1.notifications import _mask_config
+    cfg = {"type": "apprise", "url": "discord://1/2", "service_id": "discord"}
+    assert _mask_config(cfg) == cfg
+
+
+def test_mask_config_apprise_without_service_id_passes_through():
+    """Without a service_id, _mask_config can't look up which fields are
+    private, so it leaves all fields unmasked (defensive — should never
+    happen for channels created via the API, but covers the guard branch)."""
+    from arm.api.v1.notifications import _mask_config
+    cfg = {
+        "type": "apprise",
+        "url": "discord://1/2",
+        "fields": {"webhook_id": "1", "webhook_token": "2"},
+    }
+    assert _mask_config(cfg) == cfg


### PR DESCRIPTION
## Summary

Persists a flat `fields` map on apprise notification channels alongside the composed `url`, with server-side masking of private fields (`<hidden>` sentinel on GET), per-key merge + URL recomposition on PATCH, and server-side URL composition on CREATE. Extends `POST /notifications/test` to also accept `{channel_id, fields, event_key}` so the upcoming UI editor can test-send with re-entered fields while keeping unchanged secrets.

Cross-repo: depends on contracts `feat: fields` (merged in PR #34). Submodule bumped to `3c732572`. UI side ships in a follow-up PR.

## Changes

- `arm/notifications/catalog.py`: `@lru_cache(maxsize=1)` on `build_catalog()` — was being rebuilt on every GET/PATCH.
- `arm/api/v1/notifications.py`:
  - `_apprise_field_is_private(service_id, key)` helper (catalog lookup).
  - `_compose_apprise_url_from_fields(service_id, fields)` helper (shared by CREATE / PATCH / `/test`).
  - `_mask_config`: masks private apprise field values with `<hidden>`.
  - `_merge_patch_config`: merges apprise `fields` per-key (preserving `<hidden>` secrets) and recomposes `url`.
  - `create_channel`: composes URL server-side when client sends `{service_id, fields}` without `url`.
  - `patch_channel`: skips URL validation when `url` is empty/absent (UI will send fields-only).
  - `test_config`: new `{channel_id, fields, event_key}` body shape for editor test-send (apprise-only).
- `test/notifications/conftest.py`: autouse `_clear_catalog_cache` fixture so mocks don't bleed.
- `test/notifications/test_api.py`: 9 new tests covering mask/merge/create/test endpoint behaviors.

## Why

The editor must let users tweak non-secret apprise fields without re-entering credentials. The previous shape only stored the composed URL, so the editor had no way to prefill fields or distinguish "credential unchanged" from "credential cleared". The flat `fields` map + per-field `<hidden>` sentinel mirrors the proven webhook `shared_secret` round-trip.

Also fixes the partial-credential compose bug on RC: with the new shape, the UI never holds a partial set, so `compose_apprise_url` can't produce broken URLs like `discord://id` (missing token).

## Test Plan

- [x] `python3 -m pytest test/notifications/ -v` → 186 passed
- [ ] CI green (Sonar + CodeQL + lockstep against contracts main)
- [ ] Smoke test on hifi RC after merge: GET masks fields, PATCH preserves secrets, CREATE composes from fields