### PR TITLE
fix(notifications): compose apprise url on unsaved-test (Add-form Send test)

### DIFF
--- a/arm/api/v1/notifications.py
+++ b/arm/api/v1/notifications.py
@@ -455,6 +455,23 @@ def test_config(body: dict):
         raise HTTPException(422, "unsaved test supports only apprise and webhook")
     config = body.get("config") or {}
 
+    # The UI's apprise create path sends {service_id, fields} with url=""
+    # and lets neu compose the url server-side (matches the create_channel
+    # contract). Compose here too so the unsaved-test path works the same
+    # as the create path — otherwise users hit "url is required" after
+    # filling fields on the Add form.
+    if (
+        ch_type == "apprise"
+        and not config.get("url")
+        and isinstance(config.get("fields"), dict)
+        and config.get("service_id")
+    ):
+        composed = _compose_apprise_url_from_fields(
+            config["service_id"], config["fields"]
+        )
+        if composed:
+            config = {**config, "url": composed}
+
     # Friendly (non-raising) validation so the form shows a message.
     url = config.get("url")
     if not url:

--- a/test/notifications/test_api.py
+++ b/test/notifications/test_api.py
@@ -808,3 +808,27 @@ def test_test_endpoint_existing_unsaved_shape_still_works(client):
         })
     assert resp.status_code == 200, resp.text
     assert resp.json() == {"ok": True, "error": None}
+
+
+def test_test_endpoint_unsaved_apprise_composes_url_from_fields(client):
+    """The Add form sends {type:'apprise', url:'', service_id, fields}
+    and expects neu to compose the url (matches the create path). Without
+    this server-side compose the form would error with 'url is required'
+    even after the user fills the catalog fields."""
+    from unittest.mock import patch as mockpatch
+    sent_urls: list[str] = []
+    def fake_send_apprise(*, url, title, body):
+        sent_urls.append(url)
+        return (True, None)
+    with mockpatch("arm.notifications.dispatcher.send_apprise", side_effect=fake_send_apprise):
+        resp = client.post("/api/v1/notifications/test", json={
+            "type": "apprise",
+            "config": {"type": "apprise", "url": "", "service_id": "discord",
+                       "fields": {"webhook_id": "wid", "webhook_token": "wtok"}},
+            "event_key": "job.started",
+        })
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True, "error": None}
+    assert len(sent_urls) == 1
+    assert "wid" in sent_urls[0]
+    assert "wtok" in sent_urls[0]


### PR DESCRIPTION
## Summary

User reported: clicking 'Send test' on the Add Channel form after filling Discord Webhook ID + Token returned 'url is required'. The Add form posts \`{type:'apprise', config:{url:'', service_id, fields}}\` matching the create_channel wire shape — but Branch B of \`test_config\` only inspected \`config.url\` and bailed out for the empty value, never composing from \`fields\` first.

Fix: apply the same \`_compose_apprise_url_from_fields\` helper used by \`create_channel\` and the Branch A editor path. Composes the url before the validation guard so the unsaved-test path matches the create path.

## Test plan

- [x] \`pytest test/notifications/\` — 187 pass including new \`test_test_endpoint_unsaved_apprise_composes_url_from_fields\`
- [ ] CI green
- [ ] Hifi smoke: Add Channel → Discord → fill Webhook ID + Token → Send test → toast reports delivered (not 'url is required')