### PR TITLE
perf(dispatcher): interruptible tick sleep so test teardown is instant

### DIFF
--- a/arm/notifications/dispatcher.py
+++ b/arm/notifications/dispatcher.py
@@ -280,4 +280,16 @@ async def run_dispatcher_loop(stop_event: Optional[asyncio.Event] = None) -> Non
                 log.exception("notification outbox cleanup failed")
             next_cleanup_at = loop.time() + _CLEANUP_INTERVAL_SECONDS
 
-        await asyncio.sleep(_TICK_INTERVAL_SECONDS)
+        # Interruptible sleep: wake immediately when stop_event is set,
+        # otherwise sleep up to _TICK_INTERVAL_SECONDS. A plain
+        # asyncio.sleep blocks for the full interval and silently swallows
+        # shutdown signals until it returns, which adds ~5s per test that
+        # exits the FastAPI lifespan (test suite was burning ~25 min on
+        # this alone).
+        if stop_event is not None:
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=_TICK_INTERVAL_SECONDS)
+            except asyncio.TimeoutError:
+                pass
+        else:
+            await asyncio.sleep(_TICK_INTERVAL_SECONDS)


### PR DESCRIPTION
## Summary

CI \`test\` job has been taking ~25 minutes for ~2400 tests. Most of that is idle.

**Mechanism (per test):**
1. \`client\` fixture enters \`with TestClient(app, raise_server_exceptions=True)\` → FastAPI lifespan startup → notification dispatcher task spawned → loop enters \`await asyncio.sleep(5.0)\` on its first tick
2. Test body runs (milliseconds)
3. Test ends → \`with\` exits → lifespan shutdown → \`dispatcher_stop.set()\` fires
4. **Loop is mid-\`asyncio.sleep(5.0)\`**. \`stop_event.is_set()\` is only checked at the top of the loop, after the sleep returns
5. Lifespan does \`asyncio.wait_for(dispatcher_task, timeout=10.0)\` — blocks ~5s waiting for the sleep to wake
6. Repeat for the next test using the \`client\` fixture

With hundreds of TestClient-using tests, that's ~25 min in idle teardown waits alone.

## Fix

Replace bare \`asyncio.sleep(timeout)\` in the dispatcher loop with \`asyncio.wait_for(stop_event.wait(), timeout=_TICK_INTERVAL_SECONDS)\`. The moment \`stop_event\` is set the sleep returns immediately. Falls back to the bare sleep when no stop_event is provided (production code always provides one; this preserves the no-event path for completeness).

## Verification

- \`test/test_api.py\` locally: **293 tests in 49s** (was ~25 min in CI)
- Dispatcher tests: 23/23 pass — semantics unchanged when no stop_event or when timeout fires normally
- Production behavior: shutdown still bounded by the 10s \`wait_for\` in \`lifespan\`; tick interval still 5s when idle

## Test plan

- [x] Local pytest: dispatcher 23/23 + test_api.py 293/293
- [ ] CI green and **dramatically faster** (was 27m22s)