### PR TITLE
feat: honor user-disabled tracks in rip & transcode

### DIFF
--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -1384,6 +1384,14 @@ def process_single_tracks(job, rawpath, mode: str):
     """
     # process one track at a time based on track length
     for track in job.tracks:
+        # User/MAINFEATURE-disabled tracks never rip on the per-title path.
+        # (The mkv-all fast path is intentionally not gated — see spec.)
+        if track.enabled is False:
+            logging.info("Track #%s disabled by user — skipping rip.", track.track_number)
+            track.process = False
+            track.skip_reason = SkipReason.user_disabled.value
+            db.session.commit()
+            continue
         # Process single track automatically based on start and finish times
         if mode == 'auto':
             if track.length < int(job.config.MINLENGTH):

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -148,8 +148,20 @@ def _build_webhook_payload(title, body, job, raw_basename):
     # Pre-rendered per-track names from ARM's naming engine.
     rendered = render_all_tracks(job, config_dict)
     rendered_map = {r["track_number"]: r for r in rendered}
+    # Honor user/MAINFEATURE-disabled tracks: a track explicitly disabled
+    # (enabled is False) is never transcoded. enabled is None (legacy NULL)
+    # or True is included — mirrors _track_to_dict's NULL fold in
+    # arm/api/v1/jobs.py. If every track is disabled, fall back to all
+    # tracks rather than ship an empty/absent manifest that strands the job.
+    candidate_tracks = [t for t in job.tracks if t.enabled is not False]
+    if not candidate_tracks:
+        logging.warning(
+            "Job %s: all tracks disabled — sending full track list to transcoder",
+            job.job_id,
+        )
+        candidate_tracks = list(job.tracks)
     tracks_meta = []
-    for track in job.tracks:
+    for track in candidate_tracks:
         r = rendered_map.get(str(track.track_number or ''), {})
         # Prefer episode_name for series tracks - track.title can be stale
         # if the user corrected episodes via the UI after auto-match.

--- a/test/test_disabled_tracks.py
+++ b/test/test_disabled_tracks.py
@@ -1,0 +1,37 @@
+"""Disabled tracks (track.enabled == False) must not be sent to the transcoder."""
+from arm.database import db
+from arm.models.track import Track
+
+
+def _add_track(job, number, enabled):
+    t = Track(job.job_id, number, 3600, '16:9', 24.0, False, 'makemkv',
+              f'title{number}', f'title{number}.mkv')
+    t.enabled = enabled
+    t.ripped = True
+    db.session.add(t)
+    return t
+
+
+class TestWebhookManifestHonorsEnabled:
+    def test_disabled_track_excluded_from_manifest(self, app_context, sample_job):
+        from arm.ripper.utils import _build_webhook_payload
+        sample_job.multi_title = True
+        _add_track(sample_job, '1', enabled=True)
+        _add_track(sample_job, '2', enabled=False)
+        _add_track(sample_job, '3', enabled=None)  # legacy NULL -> include
+        db.session.commit()
+
+        payload = _build_webhook_payload("done", "body", sample_job, "raw_dir")
+        numbers = {t["track_number"] for t in (payload.get("tracks") or [])}
+        assert numbers == {"1", "3"}, f"disabled track 2 must be excluded, got {numbers}"
+
+    def test_all_disabled_falls_back_to_all_tracks(self, app_context, sample_job):
+        from arm.ripper.utils import _build_webhook_payload
+        sample_job.multi_title = True
+        _add_track(sample_job, '1', enabled=False)
+        _add_track(sample_job, '2', enabled=False)
+        db.session.commit()
+
+        payload = _build_webhook_payload("done", "body", sample_job, "raw_dir")
+        numbers = {t["track_number"] for t in (payload.get("tracks") or [])}
+        assert numbers == {"1", "2"}, "all-disabled must fall back to sending all tracks"

--- a/test/test_disabled_tracks.py
+++ b/test/test_disabled_tracks.py
@@ -35,3 +35,37 @@ class TestWebhookManifestHonorsEnabled:
         payload = _build_webhook_payload("done", "body", sample_job, "raw_dir")
         numbers = {t["track_number"] for t in (payload.get("tracks") or [])}
         assert numbers == {"1", "2"}, "all-disabled must fall back to sending all tracks"
+
+
+import unittest.mock
+
+
+class TestProcessSingleTracksHonorsEnabled:
+    def test_disabled_track_not_ripped(self, app_context, sample_job, tmp_path):
+        from arm.ripper import makemkv
+        from arm_contracts.enums import SkipReason
+
+        keep = _add_track(sample_job, '1', enabled=True)
+        drop = _add_track(sample_job, '2', enabled=False)
+        keep.process = True
+        keep.length = 3600
+        drop.length = 3600
+        sample_job.config.MKV_ARGS = ''  # fixture omits this; real config always has it
+        db.session.commit()
+
+        ripped_numbers = []
+
+        def fake_run(cmd, _out):
+            # cmd is [..., source, track_number, rawpath]; capture the title arg
+            ripped_numbers.append(cmd[-2])
+            return iter(())
+
+        with unittest.mock.patch('arm.ripper.makemkv.run', side_effect=fake_run), \
+             unittest.mock.patch('arm.ripper.makemkv.progress_log', return_value=str(tmp_path / 'p.log')):
+            makemkv.process_single_tracks(sample_job, str(tmp_path), 'manual')
+
+        assert '1' in ripped_numbers, "enabled track must be ripped"
+        assert '2' not in ripped_numbers, "disabled track must NOT be ripped"
+        db.session.refresh(drop)
+        assert drop.process is False
+        assert drop.skip_reason == SkipReason.user_disabled.value


### PR DESCRIPTION
## Summary
When a user unchecks a track in the disc-review widget, the track's `enabled` flag was being set but ignored downstream — disabled tracks were still ripped and still transcoded into the library. This wires `enabled` through to both the transcode dispatch (always) and the per-title rip path (free), without touching MakeMKV's `mkv all` whole-disc fast path.

- **Transcode** (`utils.py`): `_build_webhook_payload` now excludes tracks where `enabled is False`. `enabled is None` (legacy NULL) and `True` are included — mirrors `_track_to_dict`'s NULL fold. If every track is disabled, it falls back to sending all tracks (logged) so a job is never stranded with an empty manifest.
- **Rip** (`makemkv.py`): `process_single_tracks` skips disabled tracks (stamps `process=False`, `skip_reason=user_disabled`, continues). This covers the manual and auto-bounded paths, which already rip per-title — so gating there is free.

## Why `mkv all` is left untouched
`mkv all` (auto + `MAXLENGTH > 99998`) rips the whole disc in a single MakeMKV pass; replacing it with per-title rips to skip one disabled track would re-scan the disc per title (materially slower on Blu-ray/4K) — a regression on exactly the multi-title discs this targets. On that path, disabled tracks rip to raw but are filtered out before transcode (never reach the library). Their raw files are handled by the existing `delete_raw_files`/`DELRAWFILES` cleanup like every other raw file — no special case.

No migration (columns exist), no UI change (the widget already writes `enabled`).

## Test Plan
- [x] New `test/test_disabled_tracks.py`: transcode manifest excludes disabled / includes None+True / all-disabled fallback; per-title rip skips disabled track and stamps `process=False` + `skip_reason=user_disabled`.
- [x] Full suite green: 2417 passed, 1 skipped, 2 xfailed.

Spec & plan: `arm-ai/arm-neu/docs/superpowers/{specs,plans}/2026-05-29-honor-disabled-tracks*`