### PR TITLE
build: consume contracts via BuildKit named context

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -55,6 +55,8 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             IMAGE_TAG=${{ steps.version.outputs.version }}
+          build-contexts: |
+            contracts=components/contracts
           tags: |
             ${{ env.DOCKERHUB_IMAGE }}:latest
             ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -71,6 +71,8 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             IMAGE_TAG=${{ steps.version.outputs.version }}-rc
+          build-contexts: |
+            contracts=components/contracts
           tags: |
             ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.version }}-rc
             ${{ env.GHCR_IMAGE }}:${{ steps.version.outputs.version }}-rc

--- a/.github/workflows/test-pr-image-build.yml
+++ b/.github/workflows/test-pr-image-build.yml
@@ -35,3 +35,5 @@ jobs:
           context: .
           platforms: linux/amd64
           tags: automatic-ripping-machine:pr${{ github.event.number }}
+          build-contexts: |
+            contracts=components/contracts

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=90s --retries=5 CMD /hea
 FROM base AS automatic-ripping-machine
 
 COPY . /opt/arm/
+COPY --from=contracts . /opt/arm/components/contracts
 
 # Ensure Python deps are up-to-date, install rsync for NFS-safe file transfer,
 # create udev symlink, allow git in container

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,10 @@
 
 services:
   arm-rippers:
-    build: .
+    build:
+      context: .
+      additional_contexts:
+        contracts: ./components/contracts
     image: arm:dev
     volumes:
       - ./dev-data/music:/home/arm/music
@@ -28,7 +31,10 @@ services:
       - ./dev-data/makemkv:/home/arm/.MakeMKV
 
   arm-ui:
-    build: ${UI_SRC_PATH:-../automatic-ripping-machine-ui}
+    build:
+      context: ${UI_SRC_PATH:-../automatic-ripping-machine-ui}
+      additional_contexts:
+        contracts: ${UI_SRC_PATH:-../automatic-ripping-machine-ui}/components/contracts
     command:
       - uvicorn
       - backend.main:app
@@ -50,6 +56,8 @@ services:
     build:
       context: ${TRANSCODER_SRC_PATH:-../automatic-ripping-machine-transcoder}
       dockerfile: Dockerfile.dev
+      additional_contexts:
+        contracts: ${TRANSCODER_SRC_PATH:-../automatic-ripping-machine-transcoder}/components/contracts
     command:
       - python
       - -m


### PR DESCRIPTION
## Summary
- Overlay `contracts` from a BuildKit **named build context** in the ripper `Dockerfile`: add `COPY --from=contracts . /opt/arm/components/contracts` immediately after `COPY . /opt/arm/` (the existing `pip3 install -e /opt/arm/components/contracts` is unchanged).
- Repoint `docker-compose.dev.yml` build services (arm-rippers/arm-ui/arm-transcoder) with `additional_contexts.contracts`.
- Add `build-contexts: contracts=components/contracts` to every image-building CI step (publish-image, publish-prerelease, test-pr-image-build). `publish-base-image` is unchanged (the base image does not consume contracts).

**Why:** Makes the ripper image build identically whether standalone (this repo, where the `components/contracts` submodule supplies the context) or inside the `automatic-ripping-machine` v3 monorepo (sibling `contracts` subtree). The submodule stays the content source; submodule-lockstep CI is untouched.

## Test Plan
- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml config -q` parses
- [x] `contracts` named context resolves in a real BuildKit build (verified in the monorepo umbrella)
- [x] All three workflow YAMLs parse; `requirements.txt` unchanged
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)