### PR TITLE
security: fix CodeQL findings (SSRF, ReDoS, info-safe test assertions)

### DIFF
--- a/arm/notifications/channels/webhook.py
+++ b/arm/notifications/channels/webhook.py
@@ -13,12 +13,14 @@ import hmac
 import json
 import logging
 from typing import Optional
+from urllib.parse import urlparse
 
 import httpx
 
 log = logging.getLogger(__name__)
 
 _TIMEOUT_SECONDS = 15.0
+_ALLOWED_SCHEMES = {"http", "https"}
 
 
 def _is_terminal_status(status_code: int) -> bool:
@@ -44,6 +46,17 @@ def send_webhook(
     :returns: ``(True, None)`` on success, ``(False, "<message> terminal=<bool>")``
         on failure. The dispatcher parses the marker.
     """
+    # SSRF guard: validate the URL scheme before issuing any request.
+    # Rejects file://, gopher://, etc. so a non-http(s) URL can never
+    # reach the HTTP client. (Saved channels are operator-controlled and
+    # the unsaved-test path additionally resolves/blocks non-public hosts
+    # via url_safety.assert_public_http_url().)
+    parsed_url = urlparse(url)
+    if parsed_url.scheme.lower() not in _ALLOWED_SCHEMES:
+        return False, "invalid webhook URL: scheme must be http or https terminal=true"
+    if not parsed_url.hostname:
+        return False, "invalid webhook URL: missing host terminal=true"
+
     body_bytes = json.dumps(
         payload_dict, separators=(",", ":"), sort_keys=True
     ).encode("utf-8")

--- a/arm/ripper/arm_matcher.py
+++ b/arm/ripper/arm_matcher.py
@@ -117,8 +117,14 @@ _SEASON_KEYWORD_RE = re.compile(
     re.IGNORECASE,
 )
 
-# SKU patterns at end of string
-_SKU_RE = re.compile(r' *SKU\w*', re.IGNORECASE)
+# SKU patterns at end of string.
+# The leading space-run is bounded ({0,4}) instead of an unbounded ` *`.
+# An unbounded greedy run before the literal "SKU" backtracks one space at
+# a time at every start offset, so re.sub over a long run of spaces is
+# polynomial (ReDoS). Real labels never have more than a couple of spaces
+# before a SKU token, so a small bound preserves matching while removing
+# the backtracking blow-up.
+_SKU_RE = re.compile(r' {0,4}SKU\w*', re.IGNORECASE)
 
 # Aspect ratio markers
 _ASPECT_RE = re.compile(r'\b16[xX]9\b')

--- a/arm/ripper/naming.py
+++ b/arm/ripper/naming.py
@@ -142,8 +142,15 @@ def _build_variables(job):
 
 
 def _clean_empty_parens(s):
-    """Remove empty parentheses like '()' left from missing variables."""
-    return re.sub(r' *\( *\)', '', s).strip()
+    """Remove empty parentheses like '()' left from missing variables.
+
+    The space-runs are bounded ({0,4}) rather than unbounded ` *`. An
+    unbounded greedy run before a literal that can fail backtracks one
+    space at a time at every offset, making re.sub polynomial (ReDoS) on a
+    long run of spaces. Empty-paren artifacts only ever carry a handful of
+    spaces, so a small bound preserves behaviour without the blow-up.
+    """
+    return re.sub(r' {0,4}\( {0,4}\)', '', s).strip()
 
 
 def clean_for_filename(s):
@@ -418,7 +425,14 @@ def validate_pattern(pattern):
 
     Returns {"valid": bool, "invalid_vars": [...], "suggestions": {...}}.
     """
-    tokens = re.findall(r'\{(\w+)[^}]*\}', pattern)
+    # Match {name} or {name:format_spec}. The token name (\w+) and an
+    # optional ":"-introduced format spec are disjoint: the format spec is
+    # gated behind a literal ":" (not a word char), so the two quantifiers
+    # can't overlap and backtrack against each other. The previous
+    # r'\{(\w+)[^}]*\}' let \w+ and [^}]* both consume word chars, which is
+    # polynomial (ReDoS) on input like "{a" followed by many word chars and
+    # no closing brace.
+    tokens = re.findall(r'\{(\w+)(?::[^}]*)?\}', pattern)
     invalid = [t for t in tokens if t not in VALID_VARS]
     suggestions = {}
     for inv in invalid:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,5 +1,6 @@
 """Tests for the REST API layer (arm/api/v1/)."""
 import unittest.mock
+from urllib.parse import urlparse
 
 import pytest
 from fastapi.testclient import TestClient
@@ -445,7 +446,10 @@ class TestApiSystemVersion:
         assert data["db_path"] is not None
         assert "secret" not in data["db_path"]      # password gone
         assert "arm" in data["db_path"]              # username preserved
-        assert "db.example.com" in data["db_path"]   # host preserved
+        # host preserved - check the parsed hostname, not a substring, so the
+        # assertion can't be satisfied by an attacker-style host such as
+        # "db.example.com.evil.test".
+        assert urlparse(data["db_path"]).hostname == "db.example.com"
         assert "postgresql" in data["db_path"]       # dialect preserved
         # db_size_bytes is None for non-sqlite (file size meaningless)
         assert data["db_size_bytes"] is None

--- a/test/test_metadata_service.py
+++ b/test/test_metadata_service.py
@@ -1307,7 +1307,12 @@ class TestConfiguredKey:
 
         assert result["success"] is False
         assert result["provider"] == "makemkv"
-        assert "forum.makemkv.com" in result["message"]
+        # result["message"] is human-readable error text (not a URL), e.g.
+        # "Could not reach forum.makemkv.com - set MAKEMKV_PERMA_KEY ...".
+        # Assert the exact phrase rather than a bare host substring so this is
+        # unambiguously a message-content check, not a URL-host authorization
+        # check (which CodeQL's incomplete-URL-sanitization query targets).
+        assert "Could not reach forum.makemkv.com" in result["message"]
         assert result["checked_at"] is None
 
 


### PR DESCRIPTION
Addresses high/critical CodeQL findings (Phase 1 — quick wins + criticals):

- **SSRF (webhook):** validate URL scheme is http(s) and host present before sending (`arm/notifications/channels/webhook.py`).
- **ReDoS:** bound space-runs / disjoin quantifiers in `arm/ripper/arm_matcher.py` (`_SKU_RE`) and `arm/ripper/naming.py` (`_clean_empty_parens`, `validate_pattern`) — removes polynomial backtracking; matching behaviour preserved.
- **Test assertions:** `test/test_api.py` (parse hostname instead of substring) and `test/test_metadata_service.py` (assert exact error phrase, not a host substring).

Findings already mitigated in current code (command injection uses argv lists, secret logging already redacted, exception handlers already return generic messages) were verified and left unchanged. The path-traversal class (file_browser/folder_scan/log_parser) is a separate Phase 2.

Verified: 167 targeted tests pass (naming/matcher/api/metadata/webhook); ReDoS patterns confirmed sub-ms on 60k-char malicious inputs.