### PR TITLE
security: confine user-controlled paths to trusted roots (path traversal)

### DIFF
--- a/arm/api/v1/folder.py
+++ b/arm/api/v1/folder.py
@@ -105,7 +105,7 @@ def create_folder_job(req: FolderCreateRequest):
 
     # Validate path is under ingress root
     try:
-        validate_ingress_path(req.source_path, ingress_path)
+        safe_source_path = validate_ingress_path(req.source_path, ingress_path)
     except FileNotFoundError:
         raise HTTPException(status_code=400, detail="Source folder not found")
     except ValueError:
@@ -113,7 +113,7 @@ def create_folder_job(req: FolderCreateRequest):
 
     # Check for duplicate active job with same source_path
     existing = Job.query.filter(
-        Job.source_path == req.source_path,
+        Job.source_path == safe_source_path,
         ~Job.finished,
     ).first()
     if existing:
@@ -123,7 +123,7 @@ def create_folder_job(req: FolderCreateRequest):
         )
 
     # Create job
-    job = Job.from_folder(req.source_path, req.disctype)
+    job = Job.from_folder(safe_source_path, req.disctype)
     apply_request_metadata_to_job(job, req)
     job.status = JobState.IDENTIFYING.value
 
@@ -135,7 +135,7 @@ def create_folder_job(req: FolderCreateRequest):
     db.session.add(config)
     db.session.commit()
 
-    log.info("Created folder import job %s for %s (prescanning)", job.job_id, req.source_path)
+    log.info("Created folder import job %s for %s (prescanning)", job.job_id, safe_source_path)
 
     # Run prescan in background - populates tracks, then moves to MANUAL_PAUSED
     thread = threading.Thread(

--- a/arm/api/v1/iso.py
+++ b/arm/api/v1/iso.py
@@ -70,7 +70,7 @@ def scan_iso_endpoint(req: IsoScanRequest):
             status_code=400,
         )
     try:
-        validate_iso_path(req.path, ingress_path)
+        safe_path = validate_iso_path(req.path, ingress_path)
     except FileNotFoundError:
         return JSONResponse(
             {"success": False, "error": "ISO file not found"},
@@ -82,8 +82,8 @@ def scan_iso_endpoint(req: IsoScanRequest):
             status_code=422,
         )
 
-    meta = extract_metadata(req.path)
-    info = prescan_iso_disc_type(req.path)
+    meta = extract_metadata(safe_path)
+    info = prescan_iso_disc_type(safe_path)
     return {
         "success": True,
         "disc_type": info["disc_type"],
@@ -107,7 +107,7 @@ def create_iso_job(req: IsoCreateRequest):
         )
 
     try:
-        validate_iso_path(req.source_path, ingress_path)
+        safe_source_path = validate_iso_path(req.source_path, ingress_path)
     except FileNotFoundError:
         return JSONResponse(
             {"success": False, "error": "Source ISO not found"},
@@ -120,7 +120,7 @@ def create_iso_job(req: IsoCreateRequest):
         )
 
     existing = Job.query.filter(
-        Job.source_path == req.source_path,
+        Job.source_path == safe_source_path,
         ~Job.finished,
     ).first()
     if existing:
@@ -132,7 +132,7 @@ def create_iso_job(req: IsoCreateRequest):
             status_code=409,
         )
 
-    job = Job.from_iso(req.source_path, req.disctype)
+    job = Job.from_iso(safe_source_path, req.disctype)
     apply_request_metadata_to_job(job, req)
     job.status = JobState.IDENTIFYING.value
 
@@ -143,7 +143,7 @@ def create_iso_job(req: IsoCreateRequest):
     db.session.add(config)
     db.session.commit()
 
-    log.info("Created ISO import job %s for %s (prescanning)", job.job_id, req.source_path)
+    log.info("Created ISO import job %s for %s (prescanning)", job.job_id, safe_source_path)
 
     thread = threading.Thread(
         target=_prescan_and_wait, args=(job.job_id,), daemon=True

--- a/arm/common/__init__.py
+++ b/arm/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared, dependency-light utilities for ARM."""

--- a/arm/common/path_safety.py
+++ b/arm/common/path_safety.py
@@ -1,0 +1,36 @@
+"""Path-confinement helpers to defend against path traversal.
+
+These functions route user-controlled path components through
+``os.path.realpath`` and a strict containment check. This is the
+sanitizer pattern static analysers (e.g. CodeQL ``py/path-injection``)
+recognise: untrusted input is joined onto a *trusted* base directory and
+the resolved result is proven to stay inside that base before it is used
+for any filesystem operation.
+
+Always use the RETURNED value for the actual fs call — never the raw
+user input — otherwise the confinement is bypassed.
+"""
+import os
+
+
+def safe_join(base, *user_parts):
+    """Join user-controlled parts onto a trusted base dir and guarantee the
+    result stays inside base. Raises ValueError on traversal/escape.
+
+    Returns the validated absolute path.
+    """
+    base_real = os.path.realpath(base)
+    target = os.path.realpath(os.path.join(base_real, *[str(p) for p in user_parts]))
+    if target != base_real and not target.startswith(base_real + os.sep):
+        raise ValueError(
+            f"unsafe path: {os.path.join(*[str(p) for p in user_parts])!r} "
+            f"escapes {base_real!r}"
+        )
+    return target
+
+
+def is_within(base, candidate):
+    """True if candidate path is inside base (after realpath)."""
+    base_real = os.path.realpath(base)
+    cand_real = os.path.realpath(candidate)
+    return cand_real == base_real or cand_real.startswith(base_real + os.sep)

--- a/arm/ripper/folder_scan.py
+++ b/arm/ripper/folder_scan.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import xmltodict
 
+from arm.common.path_safety import safe_join
 from arm.ripper.arm_matcher import parse_label
 
 # Non-anchored regex for extracting disc info from folder names with trailing junk
@@ -23,14 +24,22 @@ _FOLDER_SEASON_RE = re.compile(
 logger = logging.getLogger(__name__)
 
 
-def validate_ingress_path(path: str, ingress_root: str) -> None:
-    """Validate that path is under ingress_root after resolving symlinks."""
-    real_path = os.path.realpath(path)
-    real_root = os.path.realpath(ingress_root)
-    if not real_path.startswith(real_root + os.sep) and real_path != real_root:
-        raise ValueError(f"Path {path} resolves outside ingress root")
+def validate_ingress_path(path: str, ingress_root: str) -> str:
+    """Validate that path is under ingress_root after resolving symlinks.
+
+    Confines the user-controlled `path` to `ingress_root` via
+    :func:`arm.common.path_safety.safe_join` and returns the validated
+    absolute path. Callers should use the returned value for filesystem
+    access.
+    """
+    # safe_join resolves symlinks and raises ValueError on any escape.
+    try:
+        real_path = safe_join(ingress_root, path)
+    except ValueError as exc:
+        raise ValueError(f"Path {path} resolves outside ingress root") from exc
     if not os.path.exists(real_path):
         raise FileNotFoundError(f"Path does not exist: {path}")
+    return real_path
 
 
 def detect_disc_type(folder_path: str) -> str:
@@ -95,9 +104,9 @@ def extract_metadata(folder_path: str, disc_type: str) -> dict:
 
 def scan_folder(folder_path: str, ingress_root: str) -> dict:
     """Top-level scan: validate, detect type, extract metadata."""
-    validate_ingress_path(folder_path, ingress_root)
-    disc_type = detect_disc_type(folder_path)
-    metadata = extract_metadata(folder_path, disc_type)
+    safe_path = validate_ingress_path(folder_path, ingress_root)
+    disc_type = detect_disc_type(safe_path)
+    metadata = extract_metadata(safe_path, disc_type)
     return {"disc_type": disc_type, **metadata}
 
 

--- a/arm/ripper/iso_scan.py
+++ b/arm/ripper/iso_scan.py
@@ -11,11 +11,18 @@ import logging
 import os
 import re
 
+from arm.common.path_safety import safe_join
+
 log = logging.getLogger(__name__)
 
 
-def validate_iso_path(path: str, ingress_root: str) -> None:
+def validate_iso_path(path: str, ingress_root: str) -> str:
     """Validate that `path` is an .iso file under `ingress_root`.
+
+    Confines the user-controlled `path` to `ingress_root` via
+    :func:`arm.common.path_safety.safe_join` and returns the validated
+    absolute path. Callers should use the returned value for filesystem
+    access.
 
     Raises:
         ValueError: extension is not .iso, or path resolves outside ingress.
@@ -23,12 +30,12 @@ def validate_iso_path(path: str, ingress_root: str) -> None:
     """
     if not path.lower().endswith(".iso"):
         raise ValueError(f"Not an ISO file (expected .iso extension): {path}")
-    real_path = os.path.realpath(path)
-    real_root = os.path.realpath(ingress_root)
-    if not real_path.startswith(real_root + os.sep) and real_path != real_root:
-        raise ValueError(f"Path {path} resolves outside ingress root")
+    # Route the user input through the confinement helper. safe_join raises
+    # ValueError when `path` resolves outside the trusted ingress root.
+    real_path = safe_join(ingress_root, path)
     if not os.path.isfile(real_path):
         raise FileNotFoundError(f"ISO file does not exist: {path}")
+    return real_path
 
 
 def extract_metadata(iso_path: str) -> dict:

--- a/arm/services/file_browser.py
+++ b/arm/services/file_browser.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import arm.config.config as cfg
+from arm.common.path_safety import is_within, safe_join
 
 log = logging.getLogger(__name__)
 
@@ -151,13 +152,18 @@ def validate_path(path: str) -> Path:
     :raises ValueError: if path escapes allowed roots
     :raises FileNotFoundError: if path does not exist
     """
-    resolved = Path(path).resolve()
     roots = get_allowed_roots()
     for root_path in roots.values():
-        if str(resolved) == root_path or str(resolved).startswith(root_path + os.sep):
-            if not resolved.exists():
-                raise FileNotFoundError(f"Path not found: {path}")
-            return resolved
+        try:
+            # Route the user-controlled path through the confinement helper.
+            # safe_join resolves symlinks and guarantees the result stays
+            # inside this allowed root; it raises ValueError otherwise.
+            confined = Path(safe_join(root_path, path))
+        except ValueError:
+            continue
+        if not confined.exists():
+            raise FileNotFoundError(f"Path not found: {path}")
+        return confined
     raise ValueError("Path is outside allowed media directories")
 
 
@@ -325,16 +331,14 @@ def rename_item(path: str, new_name: str) -> dict:
         raise ValueError("Name cannot be empty")
 
     resolved = validate_path(path)
-    new_path = resolved.parent / new_name
 
-    # Ensure destination is still under an allowed root
-    new_resolved = new_path.resolve()
+    # Confine the new name to the (already validated) parent directory and
+    # re-check that it stays under an allowed root. safe_join rejects any
+    # traversal; the explicit root check guards against the parent itself
+    # sitting on a root boundary.
+    new_path = Path(safe_join(str(resolved.parent), new_name))
     roots = get_allowed_roots()
-    under_root = False
-    for root_path in roots.values():
-        if str(new_resolved).startswith(root_path + os.sep) or str(new_resolved) == root_path:
-            under_root = True
-            break
+    under_root = any(is_within(root_path, new_path) for root_path in roots.values())
     if not under_root:
         raise ValueError("Destination is outside allowed media directories")
 
@@ -360,7 +364,8 @@ def move_item(path: str, destination: str) -> dict:
     if not dest_dir.is_dir():
         raise NotADirectoryError(f"Destination is not a directory: {destination}")
 
-    final_path = dest_dir / source.name
+    # Confine the moved item to the (already validated) destination dir.
+    final_path = Path(safe_join(str(dest_dir), source.name))
     if final_path.exists():
         raise FileExistsError(f"Already exists at destination: {source.name}")
 
@@ -410,7 +415,8 @@ def create_directory(path: str, name: str) -> dict:
     if not parent.is_dir():
         raise NotADirectoryError(f"Parent is not a directory: {path}")
 
-    new_dir = parent / name
+    # Confine the new directory to the (already validated) parent dir.
+    new_dir = Path(safe_join(str(parent), name))
     if new_dir.exists():
         raise FileExistsError(f"Already exists: {name}")
 

--- a/arm/services/jobs.py
+++ b/arm/services/jobs.py
@@ -22,6 +22,7 @@ from arm.models.track import Track
 from arm.models.ui_settings import UISettings
 from arm.database import db
 from arm.services.files import database_updater, job_id_validator
+from arm.common.path_safety import safe_join
 
 log = logging.getLogger(__name__)
 
@@ -380,8 +381,14 @@ def generate_log(logpath, job_id):
     if job is None or job.logfile is None or job.logfile == "":
         log.debug(f"Cant find the job {job_id}")
         return {'success': False, 'job': job_id, 'log': 'Not found'}
-    # Assemble full path
-    fullpath = os.path.join(logpath, job.logfile)
+    # Assemble full path, confining the (DB-stored, user-influenced) logfile
+    # name to the trusted LOGPATH root. safe_join raises ValueError on any
+    # attempt to escape the log directory via traversal or absolute paths.
+    try:
+        fullpath = safe_join(logpath, job.logfile)
+    except ValueError:
+        log.debug("Refusing logfile outside log dir for job %s", job_id)
+        return {'success': False, 'job': job_id, 'log': 'File not found'}
     # Check if the logfile exists
     my_file = Path(fullpath)
     if not my_file.is_file():

--- a/arm/services/log_parser.py
+++ b/arm/services/log_parser.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import arm.config.config as cfg
+from arm.common.path_safety import safe_join
 
 # ARM plain text log format: "{timestamp} {logger}: {LEVEL}: {message}"
 # e.g. "02-28-2026 04:59:16 ARM: INFO: Ripping complete"
@@ -44,14 +45,19 @@ def _log_dir() -> Path:
 
 
 def _resolve_within(name: str, root: Path) -> Path | None:
-    """Resolve a filename safely within root, stripping any directory components."""
+    """Resolve a filename safely within root, stripping any directory components.
+
+    Log files live flat in LOGPATH, so any directory component in *name* is
+    stripped before confinement. The basename is then routed through
+    :func:`arm.common.path_safety.safe_join`, which resolves symlinks and
+    rejects anything that escapes *root*.
+    """
     try:
         safe_name = Path(name).name
         if not safe_name or safe_name in ('.', '..'):
             return None
-        resolved = (root / safe_name).resolve()
-        if resolved.is_relative_to(root.resolve()):
-            return resolved
+        # safe_join raises ValueError on any path that escapes root.
+        return Path(safe_join(str(root), safe_name))
     except (ValueError, OSError):
         pass
     return None

--- a/test/test_logs_api.py
+++ b/test/test_logs_api.py
@@ -244,12 +244,15 @@ class TestLogParserUnit:
         assert "Entering" in result["event"]
 
     def test_resolve_within_oserror_returns_none(self, monkeypatch, tmp_path):
+        import os
         from pathlib import Path
 
-        def boom(self, *a, **kw):
+        def boom(*a, **kw):
             raise OSError("disk gone")
 
-        monkeypatch.setattr(Path, "resolve", boom)
+        # _resolve_within now confines via arm.common.path_safety.safe_join,
+        # which resolves paths with os.path.realpath rather than Path.resolve.
+        monkeypatch.setattr(os.path, "realpath", boom)
         assert log_parser._resolve_within("x.log", Path(tmp_path)) is None
 
     def test_parse_oversized_line_skipped(self):


### PR DESCRIPTION
Phase 2 — clears the CodeQL "uncontrolled data used in path expression" findings.

- New `arm/common/path_safety.py` (`safe_join` / `is_within`) — `os.path.realpath` + strict containment (the CodeQL-recognized sanitizer).
- Confined user-controlled path construction to trusted roots:
  - `file_browser.py` → configured media roots (RAW/COMPLETED/TRANSCODE/MUSIC/INGRESS)
  - `folder_scan.py`, `iso_scan.py`, `api/v1/folder.py`, `api/v1/iso.py` → INGRESS_PATH
  - `log_parser.py`, `services/jobs.py` (logs) → LOGPATH
- **Not changed:** `notifications/channels/bash.py` `script_path` — operator-configured privileged admin path with no base dir to confine to (existing NOSONAR); flagged for a future dedicated config key.

Verified: full suite **2419 passed, 0 failed** (1 skipped, 2 xfailed); 180 targeted tests across file_browser/folder/iso/logs.