### PR TITLE
test: secure temp paths + drop hard-coded token in fixtures (SonarCloud S5443/secrets)

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -161,7 +161,7 @@ def sample_job(app_context):
         'RAW_PATH': '/home/arm/media/raw',
         'TRANSCODE_PATH': '/home/arm/media/transcode',
         'COMPLETED_PATH': '/home/arm/media/completed',
-        'LOGPATH': '/tmp/arm_test/logs',
+        'LOGPATH': tempfile.mkdtemp(prefix='arm_test_logs_'),
         'EXTRAS_SUB': 'extras',
         'MINLENGTH': '600',
         'MAXLENGTH': '99999',

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -461,7 +461,9 @@ class TestApiSystemVersion:
         nonexistent = tmp_path / "does_not_exist.db"
         db_uri = f"sqlite:///{nonexistent}"
 
-        db_version, _db_head = _read_db_revisions(db_uri, install_path="/tmp/dummy")
+        db_version, _db_head = _read_db_revisions(
+            db_uri, install_path=str(tmp_path / "dummy")
+        )
 
         assert db_version == "unknown"
         assert not nonexistent.exists(), (
@@ -1982,10 +1984,11 @@ class TestApiJobStart:
         assert response.status_code == 200
         assert response.json()["success"] is True
 
-    def test_start_waiting_folder_job_spawns_folder_thread(self, client, sample_job, app_context):
+    def test_start_waiting_folder_job_spawns_folder_thread(self, client, sample_job, app_context, tmp_path):
         from arm.ripper.utils import database_updater
         database_updater(
-            {"status": "manual_paused", "source_type": "folder", "source_path": "/tmp/x"},
+            {"status": "manual_paused", "source_type": "folder",
+             "source_path": str(tmp_path / "x")},
             sample_job,
         )
         with unittest.mock.patch("arm.api.v1.jobs.threading.Thread") as mock_thread:
@@ -1997,10 +2000,11 @@ class TestApiJobStart:
         kwargs = mock_thread.call_args.kwargs
         assert kwargs["target"] is jobs_module._rip_folder_by_id
 
-    def test_start_waiting_iso_job_spawns_iso_thread(self, client, sample_job, app_context):
+    def test_start_waiting_iso_job_spawns_iso_thread(self, client, sample_job, app_context, tmp_path):
         from arm.ripper.utils import database_updater
         database_updater(
-            {"status": "manual_paused", "source_type": "iso", "source_path": "/tmp/x.iso"},
+            {"status": "manual_paused", "source_type": "iso",
+             "source_path": str(tmp_path / "x.iso")},
             sample_job,
         )
         with unittest.mock.patch("arm.api.v1.jobs.threading.Thread") as mock_thread:

--- a/test/test_async_safety.py
+++ b/test/test_async_safety.py
@@ -272,8 +272,11 @@ class TestTvdbTokenLock:
 
         call_count = 0
 
+        # Not a real secret - a dummy marker returned by the mocked TVDB API.
+        fake_token = "dummy-not-a-secret"  # noqa: S105,S106
+
         mock_response = unittest.mock.MagicMock()
-        mock_response.json.return_value = {"data": {"token": "serialized_token"}}
+        mock_response.json.return_value = {"data": {"token": fake_token}}
         mock_response.raise_for_status = unittest.mock.MagicMock()
 
         async def mock_post(url, json=None):
@@ -300,7 +303,7 @@ class TestTvdbTokenLock:
         tokens = asyncio.run(run_concurrent())
 
         # All should get the same token
-        assert all(t == "serialized_token" for t in tokens)
+        assert all(t == fake_token for t in tokens)
         # Lock serializes: first call fetches, rest reuse cached
         assert call_count == 1
 

--- a/test/test_file_browser.py
+++ b/test/test_file_browser.py
@@ -332,8 +332,10 @@ class TestMoveItem:
 
     def test_reject_destination_outside_roots(self, media_tree):
         src = os.path.join(media_tree['roots']['raw'], "Serial Mom (1994)", "title00.mkv")
+        # Use the tmp_path parent, which sits outside the configured media roots.
+        outside_roots = str(media_tree['tmp_path'])
         with pytest.raises(ValueError):
-            file_browser.move_item(src, "/tmp")
+            file_browser.move_item(src, outside_roots)
 
     def test_reject_existing_at_destination(self, media_tree):
         # Create a file with same name in dest

--- a/test/test_folder_ripper.py
+++ b/test/test_folder_ripper.py
@@ -1,7 +1,12 @@
 """Tests for folder ripper pipeline."""
 import os
+import tempfile
 import pytest
 from unittest.mock import MagicMock, patch
+
+# Secure temp dir used only as a mock return value for setup_rawpath; nothing
+# is written here (db and filesystem ops are mocked in these tests).
+_RAW_DIR = tempfile.mkdtemp(prefix="arm_test_raw_")
 
 
 class TestRipFolder:
@@ -169,7 +174,8 @@ class TestRipFolder:
 
     @patch("arm.ripper.folder_ripper.db")
     @patch("arm.ripper.folder_ripper.prescan_track_info", side_effect=RuntimeError("MakeMKV failed"))
-    @patch("arm.ripper.folder_ripper.setup_rawpath", return_value="/tmp/raw/Test Movie")
+    @patch("arm.ripper.folder_ripper.setup_rawpath",
+           return_value=os.path.join(_RAW_DIR, "Test Movie"))
     @patch("arm.ripper.folder_ripper.prep_mkv")
     def test_rip_error_sets_failure(
         self, mock_prep, mock_setup, mock_prescan, mock_db, tmp_path
@@ -206,7 +212,8 @@ class TestRipFolder:
     @patch("arm.ripper.folder_ripper.db")
     @patch("arm.ripper.folder_ripper.structlog")
     @patch("arm.ripper.folder_ripper.prescan_track_info", side_effect=RuntimeError("boom"))
-    @patch("arm.ripper.folder_ripper.setup_rawpath", return_value="/tmp/raw/Test")
+    @patch("arm.ripper.folder_ripper.setup_rawpath",
+           return_value=os.path.join(_RAW_DIR, "Test"))
     @patch("arm.ripper.folder_ripper.prep_mkv")
     def test_clear_contextvars_called_on_failure(
         self, mock_prep, mock_setup, mock_prescan, mock_structlog, mock_db, tmp_path
@@ -225,7 +232,8 @@ class TestRipFolder:
 
     @patch("arm.ripper.folder_ripper.db")
     @patch("arm.ripper.folder_ripper.prescan_track_info", side_effect=RuntimeError("boom"))
-    @patch("arm.ripper.folder_ripper.setup_rawpath", return_value="/tmp/raw/Test")
+    @patch("arm.ripper.folder_ripper.setup_rawpath",
+           return_value=os.path.join(_RAW_DIR, "Test"))
     @patch("arm.ripper.folder_ripper.prep_mkv")
     def test_file_handler_removed_on_failure(
         self, mock_prep, mock_setup, mock_prescan, mock_db, tmp_path

--- a/test/test_job_model.py
+++ b/test/test_job_model.py
@@ -263,10 +263,10 @@ class TestJobGuid:
             job2 = Job('/dev/sr1')
         assert job1.guid != job2.guid
 
-    def test_folder_job_has_guid(self, app_context):
+    def test_folder_job_has_guid(self, app_context, tmp_path):
         """Folder-import jobs also get GUIDs."""
         from arm.models.job import Job
-        job = Job.from_folder('/tmp/test', 'dvd')
+        job = Job.from_folder(str(tmp_path / "test"), 'dvd')
         assert job.guid is not None
         parsed = uuid.UUID(job.guid)
         assert parsed.version == 4

--- a/test/test_music_failure_no_invalid_status.py
+++ b/test/test_music_failure_no_invalid_status.py
@@ -20,6 +20,7 @@ status=TrackStatus.failed.value)`` directly. This test pins:
 * ``ripped`` is False.
 """
 import os
+import tempfile
 import unittest.mock
 
 import pytest
@@ -93,7 +94,7 @@ def music_job(app_context):
         'RAW_PATH': '/home/arm/media/raw',
         'TRANSCODE_PATH': '/home/arm/media/transcode',
         'COMPLETED_PATH': '/home/arm/media/completed',
-        'LOGPATH': '/tmp/arm_test/logs',
+        'LOGPATH': tempfile.mkdtemp(prefix='arm_test_logs_'),
         'EXTRAS_SUB': 'extras',
         'MINLENGTH': '600',
         'MAXLENGTH': '99999',

--- a/test/test_music_rip.py
+++ b/test/test_music_rip.py
@@ -4,6 +4,7 @@ Covers MusicBrainz metadata lookup, track processing, path generation,
 abcde rip dispatch, and notification flow.
 """
 import os
+import tempfile
 import unittest.mock
 
 import musicbrainzngs as mb
@@ -76,7 +77,7 @@ def music_job(app_context):
         'RAW_PATH': '/home/arm/media/raw',
         'TRANSCODE_PATH': '/home/arm/media/transcode',
         'COMPLETED_PATH': '/home/arm/media/completed',
-        'LOGPATH': '/tmp/arm_test/logs',
+        'LOGPATH': tempfile.mkdtemp(prefix='arm_test_logs_'),
         'EXTRAS_SUB': 'extras',
         'MINLENGTH': '600',
         'MAXLENGTH': '99999',

--- a/test/test_notifications_flow.py
+++ b/test/test_notifications_flow.py
@@ -7,6 +7,7 @@ N19 — channels are now driven by ``publish_event`` + the outbox
 dispatcher.
 """
 import os
+import tempfile
 import unittest.mock
 
 import pytest
@@ -97,7 +98,7 @@ class TestRipMusic:
         job = unittest.mock.MagicMock()
         job.disctype = 'music'
         job.devpath = '/dev/sr0'
-        job.config.LOGPATH = '/tmp'
+        job.config.LOGPATH = tempfile.gettempdir()
         return job
 
     @staticmethod
@@ -116,7 +117,9 @@ class TestRipMusic:
 
         job = self._make_job()
         original = cfg.arm_config.get('ABCDE_CONFIG_FILE', '')
-        cfg.arm_config['ABCDE_CONFIG_FILE'] = '/tmp/test_abcde.conf'
+        fd, abcde_conf = tempfile.mkstemp(prefix='test_abcde_', suffix='.conf')
+        os.close(fd)
+        cfg.arm_config['ABCDE_CONFIG_FILE'] = abcde_conf
         try:
             mock_proc = self._mock_popen(0)
             with unittest.mock.patch('os.path.isfile', return_value=True), \
@@ -128,9 +131,10 @@ class TestRipMusic:
                 result = rip_music(job, 'test.log')
                 assert result is True
                 cmd = mock_cmd.call_args[0][0]
-                assert '-c' in cmd and '/tmp/test_abcde.conf' in cmd
+                assert '-c' in cmd and abcde_conf in cmd
         finally:
             cfg.arm_config['ABCDE_CONFIG_FILE'] = original
+            os.remove(abcde_conf)
 
     def test_default_abcde_when_no_config(self):
         """Uses default abcde when no config file exists."""

--- a/test/unittest/test_ripper_ARMInfo.py
+++ b/test/unittest/test_ripper_ARMInfo.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -13,7 +14,13 @@ _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(
 class TestArmInfo(unittest.TestCase):
 
     def setUp(self):
-        self.arm_info = ARMInfo(_PROJECT_ROOT, '/tmp/arm_test_legacy.db')
+        fd, self._db_file = tempfile.mkstemp(prefix='arm_test_legacy_', suffix='.db')
+        os.close(fd)
+        self.arm_info = ARMInfo(_PROJECT_ROOT, self._db_file)
+
+    def tearDown(self):
+        if os.path.exists(self._db_file):
+            os.remove(self._db_file)
 
     """
     ************************************************************


### PR DESCRIPTION
Resolve SonarCloud S5443 'temporary files in publicly writable directories' (and one hard-coded test token, ripper) in TEST fixtures — replace hard-coded `/tmp/...` literals with secure `tempfile.mkdtemp`/`tmp_path` (and non-`/tmp` mock strings for the frontend test). Test behaviour unchanged; suites pass.