### PR TITLE
security: clear residual CodeQL findings (secret logging, info exposure, SSRF)

### DIFF
--- a/arm/api/v1/settings.py
+++ b/arm/api/v1/settings.py
@@ -27,20 +27,29 @@ def get_config():
     """Return live arm.yaml config with sensitive fields masked."""
     from arm.ripper.naming import PATTERN_VARIABLES
 
-    raw_config = dict(cfg.arm_config)
-    config = {}
-    for key in raw_config.keys():
-        if key in hidden_attribs and raw_config[key]:
-            config[str(key)] = HIDDEN_VALUE
-        else:
-            config[str(key)] = str(raw_config[key]) if raw_config[key] is not None else None
+    try:
+        raw_config = dict(cfg.arm_config)
+        config = {}
+        for key in raw_config.keys():
+            if key in hidden_attribs and raw_config[key]:
+                config[str(key)] = HIDDEN_VALUE
+            else:
+                config[str(key)] = str(raw_config[key]) if raw_config[key] is not None else None
 
-    comments = generate_comments()
-    return {
-        "config": config,
-        "comments": comments,
-        "naming_variables": PATTERN_VARIABLES,
-    }
+        comments = generate_comments()
+        return {
+            "config": config,
+            "comments": comments,
+            "naming_variables": PATTERN_VARIABLES,
+        }
+    except Exception:
+        # Log the full detail server-side; never return the exception text
+        # (or a stack trace) to the client.
+        log.exception("Failed to build settings config response")
+        return JSONResponse(
+            {"success": False, "error": "Failed to load configuration"},
+            status_code=500,
+        )
 
 
 @router.put('/settings/config')
@@ -117,7 +126,10 @@ def _abcde_path() -> str:
     raw = str(cfg.arm_config.get("ABCDE_CONFIG_FILE", "/etc/abcde.conf"))
     resolved = os.path.realpath(raw)
     if not os.path.isabs(resolved):
-        raise ValueError(f"ABCDE_CONFIG_FILE resolved to a relative path: {resolved}")
+        # Log the resolved value server-side; keep the exception message free
+        # of the (config-derived) path so it cannot reach a client sink.
+        log.error("ABCDE_CONFIG_FILE resolved to a relative path: %s", resolved)
+        raise ValueError("ABCDE_CONFIG_FILE resolved to a relative path")
     return resolved
 
 

--- a/arm/notifications/channels/webhook.py
+++ b/arm/notifications/channels/webhook.py
@@ -13,14 +13,14 @@ import hmac
 import json
 import logging
 from typing import Optional
-from urllib.parse import urlparse
 
 import httpx
+
+from arm.notifications.url_safety import UnsafeUrlError, assert_public_http_url
 
 log = logging.getLogger(__name__)
 
 _TIMEOUT_SECONDS = 15.0
-_ALLOWED_SCHEMES = {"http", "https"}
 
 
 def _is_terminal_status(status_code: int) -> bool:
@@ -46,16 +46,13 @@ def send_webhook(
     :returns: ``(True, None)`` on success, ``(False, "<message> terminal=<bool>")``
         on failure. The dispatcher parses the marker.
     """
-    # SSRF guard: validate the URL scheme before issuing any request.
-    # Rejects file://, gopher://, etc. so a non-http(s) URL can never
-    # reach the HTTP client. (Saved channels are operator-controlled and
-    # the unsaved-test path additionally resolves/blocks non-public hosts
-    # via url_safety.assert_public_http_url().)
-    parsed_url = urlparse(url)
-    if parsed_url.scheme.lower() not in _ALLOWED_SCHEMES:
-        return False, "invalid webhook URL: scheme must be http or https terminal=true"
-    if not parsed_url.hostname:
-        return False, "invalid webhook URL: missing host terminal=true"
+    # SSRF guard: validate the target on every send (not just the unsaved-test
+    # path). assert_public_http_url() requires http(s) and rejects hosts that
+    # resolve to loopback/private/link-local/reserved addresses.
+    try:
+        assert_public_http_url(url)
+    except UnsafeUrlError as exc:
+        return False, f"unsafe webhook URL: {exc} terminal=true"
 
     body_bytes = json.dumps(
         payload_dict, separators=(",", ":"), sort_keys=True
@@ -72,13 +69,6 @@ def send_webhook(
 
     try:
         with httpx.Client(timeout=_TIMEOUT_SECONDS) as client:
-            # SSRF note: for saved channels the URL is operator-controlled
-            # (from the DB). The only request-controlled caller is the
-            # unsaved-config test endpoint, which validates the URL with
-            # url_safety.assert_public_http_url() (rejects loopback/private/
-            # link-local/reserved hosts) before reaching here. CodeQL cannot
-            # model that custom IP allowlist as a sanitizer; py/full-ssrf is
-            # suppressed centrally in .github/codeql/codeql-config.yml.
             resp = client.post(
                 url, content=body_bytes, headers=request_headers
             )

--- a/arm/ripper/rsync_helper.py
+++ b/arm/ripper/rsync_helper.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import subprocess
 import threading
@@ -24,6 +25,17 @@ from arm_contracts import RsyncProgressEvent, RsyncProgressTracker
 import arm.config.config as cfg
 
 logger = logging.getLogger(__name__)
+
+
+def _redact_rsync(target: str) -> str:
+    """Strip embedded credentials from rsync/ssh/url-style targets before
+    logging (e.g. ``user:password@host`` or ``rsync://user:pass@host``).
+
+    Plain local paths contain no ``credential@`` segment and are returned
+    unchanged. This also breaks the secret -> log taint flow that CodeQL
+    reports for logged rsync targets.
+    """
+    return re.sub(r'(\b\w+:)[^@/\s]*(@)', r'\1<redacted>\2', str(target))
 
 
 def run_rsync_sync(
@@ -79,7 +91,10 @@ def run_rsync_sync(
         # of whether the failure happened before rsync was even invoked.
         raise OSError(f"rsync setup failed for {dst}: {exc}") from exc
 
-    logger.info(f"rsync {'(move)' if remove_source else '(copy)'}: {src} -> {dst}")
+    logger.info(
+        f"rsync {'(move)' if remove_source else '(copy)'}: "
+        f"{_redact_rsync(src)} -> {_redact_rsync(dst)}"
+    )
 
     tracker = RsyncProgressTracker()
     proc = subprocess.Popen(
@@ -138,7 +153,7 @@ def run_rsync_sync(
         # rsync --remove-source-files removes files but leaves empty dirs
         shutil.rmtree(src, ignore_errors=True)
 
-    logger.info(f"rsync complete: {src} -> {dst}")
+    logger.info(f"rsync complete: {_redact_rsync(src)} -> {_redact_rsync(dst)}")
 
 
 def _emit(

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -69,7 +69,7 @@ def _move_to_shared_storage(cfg, raw_basename, job=None):
         database_updater({'status': JobState.COPYING.value}, job)
     os.makedirs(dst, exist_ok=True)
 
-    from arm.ripper.rsync_helper import run_rsync_with_side_file
+    from arm.ripper.rsync_helper import run_rsync_with_side_file, _redact_rsync
     try:
         run_rsync_with_side_file(
             src, dst,
@@ -78,7 +78,7 @@ def _move_to_shared_storage(cfg, raw_basename, job=None):
             remove_source=True,
         )
     except OSError as e:
-        logging.error(f"Failed to move {src} -> {dst}: {e}")
+        logging.error(f"Failed to move {_redact_rsync(src)} -> {_redact_rsync(dst)}: {e}")
         raise
 
 

--- a/arm/services/files.py
+++ b/arm/services/files.py
@@ -171,8 +171,12 @@ def send_to_remote_db(job_id):
     url = f"{base_url}/api/v1/?mode=p&api_key={api_key}&crc64={job.crc_id}&t={job.title}" \
           f"&y={job.year}&imdb={job.imdb_id}" \
           f"&hnt={job.hasnicetitle}&l={job.label}&vt={job.video_type}"
-    redacted_url = url.replace(api_key, "<redacted>") if api_key else "<no api key>"
-    log.debug("Remote DB URL: %s", str(redacted_url))
+    # Build the logged string from non-secret parts only; never derive it from
+    # the secret-containing `url` (string .replace() is not a CodeQL sanitizer).
+    display_url = f"{base_url}/api/v1/?mode=p&api_key=<redacted>&crc64={job.crc_id}&t={job.title}" \
+                  f"&y={job.year}&imdb={job.imdb_id}" \
+                  f"&hnt={job.hasnicetitle}&l={job.label}&vt={job.video_type}"
+    log.debug("Remote DB URL: %s", display_url)
     response = requests.get(url, timeout=15)
     req = json.loads(response.text)
     log.debug("Remote DB response success: %s", str(req.get('success', 'unknown')))


### PR DESCRIPTION
Addresses the remaining CodeQL alerts:
- **files.py** clear-text logging: log a redacted URL built without the api_key (no `.replace()` on a secret-bearing string).
- **rsync_helper.py / utils.py** clear-text logging: redact `user:pass@` credentials in logged rsync targets.
- **settings.py** info exposure: log exceptions server-side, return a generic error.
- **webhook.py** SSRF: call `assert_public_http_url()` on every send (rejects non-http(s) + loopback/private/link-local hosts), not just the unsaved-test path.

`bash.py` (operator-set script path) is left as documented accepted risk. 249 webhook/url_safety/notification tests pass; full suite 2419 passed.